### PR TITLE
bug(license): The link in the mit license is not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ We welcome contributions! See the [CONTRIBUTING.md](CONTRIBUTING.md) file for gu
 ---
 
 ## 📄 License
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [MIT License](./License).


### PR DESCRIPTION
Which issue does this PR close?
Closes #32 

Rationale for this change
The license link in the project was outdated or incorrect, making it harder for users to navigate to the LICENSE file. This update ensures accurate navigation and improves accessibility of licensing information.

What changes are included in this PR?
🔗 Updated the license link in the README to correctly point to the LICENSE file.

Are these changes tested?
Yes, verified that the updated link now correctly redirects to the LICENSE file in the repository.

Are there any user-facing changes?
Yes. Users clicking on the license link in the README will now be directed to the correct file without encountering broken links.

👤 Username: @vinitjain2005

Screenshot
<img width="733" height="140" alt="Screenshot 2025-08-08 105214" src="https://github.com/user-attachments/assets/6a50f4c1-4d95-4ace-ab28-df4056a242e2" />
