### PR TITLE
feat(hybrid): Add examples for CSR-COO storage format

### DIFF
--- a/examples/extras/HybridExample.cpp
+++ b/examples/extras/HybridExample.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include "CinderPeak.hpp"
+using namespace CinderPeak::PeakStore;
+using namespace CinderPeak;
+
+void Example1(){
+    std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>> adjList = {
+        {1, {{2, 10}, {3, 20}}},
+        {2, {{3, 30}}},
+        {3, {{1, 40}}}
+    };
+
+    HybridCSR_COO<int, int> graph;
+    graph.populateFromAdjList(adjList);
+
+    std::cout << "Example1 Graph:\n";
+    graph.exc();  
+}
+
+void Example2(){
+    std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>> adjList2 = {
+        {1, {{2,10}, {3,20}}},
+        {2, {{1,10}}},
+        {3, {{1,20}, {4,50}, {5,40}}},
+        {4, {{3,50}}},
+        {5, {{3,40}}}
+    };
+
+    HybridCSR_COO<int, int> graph;
+    graph.populateFromAdjList(adjList2);
+
+    std::cout << "Example2 Graph:\n";
+    graph.exc();
+}
+
+void Example3(){
+    std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>> adjList3 = {
+        {1, {{2,10}, {3,30}}},
+        {2, {{1,10}, {4,20}}},
+        {3, {{1,20}, {4,10}}},
+        {4, {{2,20}, {3,10}}}
+    };
+
+    HybridCSR_COO<int, int> graph;
+    graph.populateFromAdjList(adjList3);
+
+    std::cout << "Example3 Graph:\n";
+    graph.exc();
+}
+
+int main() {
+    Example1();
+    Example2();
+    Example3();
+    return 0;
+}


### PR DESCRIPTION
### Summary
This PR adds three examples  graphs demonstrating how to use the `HybridCSR_COO` storage format.

### Changes
- Added `HybridExample.cpp` file  under `examples/extras/`.
- Implemented three different examples for graphs (`Example1`, `Example2`, `Example3`) showing different graph structures.
- Verified that graphs are created successfully using `populateFromAdjList()`.

### Related Issue
Closes #21
