### PR TITLE
 refactor(adjlist): unify impl_addEdge overloads into a single function

### DIFF
--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -15,10 +15,12 @@ private:
       _adj_list;
 
 public:
-  // TODO: combine two impl_addEdge overloads into one.
+  
   AdjacencyList() { LOG_INFO("Initialized Adjacency List object"); }
+
+  // Combined two impl_addEdge overloads into one.
   const PeakStatus impl_addEdge(const VertexType &src, const VertexType &dest,
-                                const EdgeType &weight) {
+                                const EdgeType &weight = EdgeType()) {
     if (auto it = _adj_list.find(src); it == _adj_list.end())
       return PeakStatus::VertexNotFound();
     if (auto it = _adj_list.find(dest); it == _adj_list.end())
@@ -26,15 +28,8 @@ public:
     _adj_list[src].emplace_back(dest, weight);
     return PeakStatus::OK();
   }
-  const PeakStatus impl_addEdge(const VertexType &src,
-                                const VertexType &dest) override {
-    if (auto it = _adj_list.find(src); it == _adj_list.end())
-      return PeakStatus::VertexNotFound();
-    if (auto it = _adj_list.find(dest); it == _adj_list.end())
-      return PeakStatus::VertexNotFound();
-    _adj_list[src].emplace_back(dest, EdgeType());
-    return PeakStatus::OK();
-  }
+
+
   const PeakStatus impl_addVertex(const VertexType &src) override {
     if constexpr (is_primitive_or_string_v<VertexType>) {
       auto it = _adj_list.find(src);

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -210,7 +210,7 @@ public:
   }
 
   const PeakStatus impl_addEdge(const VertexType &src, const VertexType &dest,
-                                const EdgeType &weight) override {
+                                const EdgeType &weight = EdgeType()) override {
     if (!vertex_to_index.count(src) || !vertex_to_index.count(dest)) {
       return PeakStatus::VertexNotFound();
     }
@@ -225,10 +225,11 @@ public:
     return PeakStatus::OK();
   }
 
-  const PeakStatus impl_addEdge(const VertexType &src,
-                                const VertexType &dest) override {
-    return impl_addEdge(src, dest, EdgeType{});
-  }
+  // No longer needed as the weighted overload handles unweighted edges via default EdgeType().
+  // const PeakStatus impl_addEdge(const VertexType &src,
+  //                               const VertexType &dest) override {
+  //   return impl_addEdge(src, dest, EdgeType{});
+  // }
 
   bool impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                           const EdgeType &weight) override {

--- a/src/StorageInterface.hpp
+++ b/src/StorageInterface.hpp
@@ -8,11 +8,14 @@ template <typename VertexType, typename EdgeType> class PeakStorageInterface {
 public:
   // virtual void exc() const = 0;
   virtual const PeakStatus impl_addVertex(const VertexType &src) = 0;
-  virtual const PeakStatus impl_addEdge(const VertexType &src,
-                                        const VertexType &dest) = 0;
+
+  // No longer needed as the weighted overload handles unweighted edges via default EdgeType().
+  // virtual const PeakStatus impl_addEdge(const VertexType &src,
+  //                                       const VertexType &dest) = 0;
+
   virtual const PeakStatus impl_addEdge(const VertexType &src,
                                         const VertexType &dest,
-                                        const EdgeType &weight) = 0;
+                                        const EdgeType &weight = EdgeType()) = 0;
   virtual bool impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                                   const EdgeType &weight) = 0;
   virtual bool impl_doesEdgeExist(const VertexType &src,

--- a/tests/AdjacencyShard.cpp
+++ b/tests/AdjacencyShard.cpp
@@ -129,13 +129,19 @@ TEST_F(AdjacencyListTest, GetNeighborsNonExistentVertex) {
 
 TEST_F(AdjacencyListTest, EdgeExistence) {
     intGraph.impl_addEdge(1, 2, 5);
-    //bad practice, need to be changed later on
-    EXPECT_FALSE(intGraph.impl_doesEdgeExist(1, 2));
-    EXPECT_FALSE(intGraph.impl_doesEdgeExist(1, 2));
+    
+    // Test edge existence through public interface instead of impl_doesEdgeExist
+    auto edge1_2 = intGraph.impl_getEdge(1, 2);
+    EXPECT_TRUE(edge1_2.second.isOK());
 
-    EXPECT_FALSE(intGraph.impl_doesEdgeExist(1, 3));
-    EXPECT_FALSE(intGraph.impl_doesEdgeExist(2, 1));
-    EXPECT_FALSE(intGraph.impl_doesEdgeExist(99, 1));
+    auto edge1_3 = intGraph.impl_getEdge(1, 3);
+    EXPECT_FALSE(edge1_3.second.isOK());
+
+    auto edge2_1 = intGraph.impl_getEdge(2, 1);
+    EXPECT_FALSE(edge2_1.second.isOK());
+
+    auto edge99_1 = intGraph.impl_getEdge(99, 1);
+    EXPECT_FALSE(edge99_1.second.isOK());
 }
 
 //


### PR DESCRIPTION
This PR refactors the `impl_addEdge` implementation to remove redundancy by unifying the weighted and unweighted overloads into a single function (issue #44 ). The unweighted variant is no longer needed because the weighted version now accepts a default-constructed EdgeType when no explicit weight is provided. This change simplifies the codebase, reduces maintenance overhead, and ensures consistent behavior across all storage backends.

**Changes Made:**

* **AdjacencyList.hpp** – Refactored to use a single impl_addEdge function with a default weight.
* **HybridCSR_COO.hpp** – Removed unweighted impl_addEdge function (redundant after refactor).
* **StorageInterface.hpp** – Removed unweighted impl_addEdge pure virtual declaration.
* **AdjacencyShard.cpp** – Updated/improved test cases.


**Test Results:**
<img width="824" height="862" alt="Screenshot from 2025-08-20 16-26-22" src="https://github.com/user-attachments/assets/c11d4d98-5a05-40e1-bede-4afc0c61c140" />


