### PR TITLE
feat(vis): Improve visualization engine and interactive node dragging in SFML

### DIFF
--- a/src/Visualizer.hpp
+++ b/src/Visualizer.hpp
@@ -1,256 +1,144 @@
-// // Temporarily Depreciated. Unused.
+#pragma once
+#include "ArialFontDataEmbed.hpp"
+#include <type_traits>
+#include <SFML/Graphics.hpp>
+#include <cmath>
+#include <iostream>
+#include <optional>
+#include <unordered_map>
+#include <vector>
 
-// #pragma once
-// #include "ArialFontDataEmbed.hpp"
-// #include <SFML/Graphics.hpp>
-// #include <cmath> // for std::cos, std::sin
-// #include <iostream>
-// #include <optional>
-// #include <sstream>
-// #include <type_traits>
-// #include <unordered_map>
-// #include <vector>
-// namespace CinderPeak {
-// template <typename VertexType, typename EdgeType> class GraphVisualizer {
-// public:
-//   using AdjListType =
-//       std::unordered_map<VertexType,
-//                          std::vector<std::pair<VertexType, EdgeType>>,
-//                          VertexHasher<VertexType>>;
+namespace CinderPeak {
 
-//   explicit GraphVisualizer(AdjListType adj_list) : _adj_list(adj_list) {
-//     LOG_DEBUG("GOT ADJACENCY LIST WITH SIZE: ");
-//     LOG_DEBUG(std::to_string(_adj_list.size()));
-//   }
+template <typename VertexType, typename EdgeType>
+class InteractiveVisualizer {
+public:
+    using AdjListType =
+        std::unordered_map<VertexType,
+                        std::vector<std::pair<VertexType, EdgeType>>>;
 
-//   void visualize_primitives_graph() {
-//     sf::RenderWindow window(sf::VideoMode({800, 600}), "Graph Visualization");
-//     window.setFramerateLimit(60);
+    explicit InteractiveVisualizer(AdjListType adj_list)
+        : _adj_list(adj_list) {}
 
-//     std::unordered_map<VertexType, sf::Vector2f> vertex_positions;
-//     const float center_x = 400.f;
-//     const float center_y = 300.f;
-//     const float radius = 200.f;
+    void visualize() {
+        sf::RenderWindow window(sf::VideoMode({800, 600}), "Interactive Graph");
+        window.setFramerateLimit(60);
 
-//     std::cout << "Adjacency list size: " << _adj_list.size() << std::endl;
+        if (_adj_list.empty()) {
+            std::cerr << "Empty adjacency list!" << std::endl;
+            return;
+        }
 
-//     if (_adj_list.size() == 0) {
-//       std::cerr << "Empty adjacency list!" << std::endl;
-//       return;
-//     }
+        std::unordered_map<VertexType, sf::Vector2f> vertex_positions;
+        const float center_x = 400.f;
+        const float center_y = 300.f;
+        const float radius = 200.f;
+        float angle_step = 2 * 3.14159265f / _adj_list.size();
+        float current_angle = 0.f;
 
-//     float angle_step = 2 * 3.14159265f / _adj_list.size();
-//     float current_angle = 0.f;
+        for (const auto& [vertex, _] : _adj_list) {
+            float x = center_x + radius * std::cos(current_angle);
+            float y = center_y + radius * std::sin(current_angle);
+            vertex_positions[vertex] = sf::Vector2f(x, y);
+            current_angle += angle_step;
+        }
 
-//     int vertex_count = 0;
-//     for (const auto &[vertex, _] : _adj_list) {
-//       float x = center_x + radius * std::cos(current_angle);
-//       float y = center_y + radius * std::sin(current_angle);
-//       vertex_positions[vertex] = sf::Vector2f(x, y);
+        std::unordered_map<VertexType, sf::Color> vertex_colors;
+        const std::vector<sf::Color> palette = {
+            sf::Color(102, 197, 204), sf::Color(246, 207, 113),
+            sf::Color(248, 156, 116), sf::Color(220, 176, 242),
+            sf::Color(135, 197, 125), sf::Color(158, 185, 243),
+            sf::Color(254, 136, 177)};
 
-//       std::cout << "Vertex " << vertex << " positioned at (" << x << ", " << y
-//                 << ")" << std::endl;
+        int colorIndex = 0;
+        for (const auto& [vertex, _] : _adj_list) {
+            vertex_colors[vertex] = palette[colorIndex % palette.size()];
+            colorIndex++;
+        }
 
-//       current_angle += angle_step;
-//       vertex_count++;
-//     }
+        sf::Font font;
+        if (!font.loadFromMemory(Arial_ttf, Arial_ttf_len)) {
+            std::cerr << "Failed to load font from memory" << std::endl;
+            return;
+        }
 
-//     std::cout << "Total vertices positioned: " << vertex_count << std::endl;
+        std::optional<VertexType> selected_vertex = std::nullopt;
+        sf::Vector2f mouse_offset;
 
-//     sf::Font font;
-//     if (!font.openFromMemory(Arial_ttf, Arial_ttf_len)) {
-//       std::cerr << "Failed to load font from memory" << std::endl;
-//       return;
-//     }
+        while (window.isOpen()) {
+            sf::Event event;
+            while (window.pollEvent(event)) {
+                if (event.type == sf::Event::Closed)
+                    window.close();
 
-//     std::unordered_map<VertexType, sf::Color> vertex_colors;
-//     const std::vector<sf::Color> color_palette = {
-//         sf::Color(102, 197, 204), sf::Color(246, 207, 113),
-//         sf::Color(248, 156, 116), sf::Color(220, 176, 242),
-//         sf::Color(135, 197, 125), sf::Color(158, 185, 243),
-//         sf::Color(254, 136, 177)};
-//     int color_index = 0;
-//     for (const auto &[vertex, _] : _adj_list) {
-//       vertex_colors[vertex] = color_palette[color_index % color_palette.size()];
-//       color_index++;
-//     }
+                if (event.type == sf::Event::MouseButtonPressed &&
+                    event.mouseButton.button == sf::Mouse::Left) {
+                    sf::Vector2f mouse_pos(event.mouseButton.x, event.mouseButton.y);
+                    for (auto& [vertex, pos] : vertex_positions) {
+                        float dist = std::hypot(pos.x - mouse_pos.x, pos.y - mouse_pos.y);
+                        if (dist <= 22.f) {
+                            selected_vertex = vertex;
+                            mouse_offset = pos - mouse_pos;
+                            break;
+                        }
+                    }
+                }
 
-//     while (window.isOpen()) {
-//       while (std::optional<sf::Event> event = window.pollEvent()) {
-//         if (event->is<sf::Event::Closed>()) {
-//           window.close();
-//         }
-//       }
+                if (event.type == sf::Event::MouseButtonReleased &&
+                    event.mouseButton.button == sf::Mouse::Left) {
+                    selected_vertex = std::nullopt;
+                }
+            }
 
-//       window.clear(sf::Color(240, 240, 240));
+            if (selected_vertex.has_value()) {
+                sf::Vector2i mpos = sf::Mouse::getPosition(window);
+                vertex_positions[*selected_vertex] = sf::Vector2f(mpos.x, mpos.y) + mouse_offset;
+            }
 
-//       for (const auto &[src_vertex, edges] : _adj_list) {
-//         sf::Vector2f src_pos = vertex_positions[src_vertex];
-//         for (const auto &[dest_vertex, edge_weight] : edges) {
-//           if (vertex_positions.find(dest_vertex) == vertex_positions.end()) {
-//             std::cerr << "Warning: Destination vertex " << dest_vertex
-//                       << " not found in positions!" << std::endl;
-//             continue;
-//           }
+            window.clear(sf::Color(240, 240, 240));
 
-//           sf::Vector2f dest_pos = vertex_positions[dest_vertex];
-//           sf::Vector2f direction = dest_pos - src_pos;
-//           float length =
-//               std::sqrt(direction.x * direction.x + direction.y * direction.y);
-//           sf::Vector2f unit_direction = direction / length;
+            for (const auto& [src, edges] : _adj_list) {
+                sf::Vector2f src_pos = vertex_positions[src];
+                for (const auto& [dest, edge_weight] : edges) {
+                    if (vertex_positions.find(dest) == vertex_positions.end()) continue;
+                    sf::Vector2f dest_pos = vertex_positions[dest];
+                    sf::Vertex line[] = {
+                        sf::Vertex(src_pos, sf::Color(100, 100, 100, 180)),
+                        sf::Vertex(dest_pos, sf::Color(100, 100, 100, 180))
+                    };
+                    window.draw(line, 2, sf::Lines);
+                }
+            }
 
-//           sf::Vector2f adjusted_src = src_pos + unit_direction * 20.f;
-//           sf::Vector2f adjusted_dest = dest_pos - unit_direction * 20.f;
+            for (const auto& [vertex, pos] : vertex_positions) {
+                sf::CircleShape circle(22.f);
+                circle.setFillColor(vertex_colors[vertex]);
+                circle.setOutlineThickness(2.f);
+                circle.setOutlineColor(sf::Color(80, 80, 80));
+                circle.setOrigin(22.f, 22.f);
+                circle.setPosition(pos);
+                window.draw(circle);
 
-//           const float control_offset = length * 0.2f;
-//           sf::Vector2f control_point1 =
-//               src_pos + sf::Vector2f(-unit_direction.y, unit_direction.x) *
-//                             control_offset;
-//           sf::Vector2f control_point2 =
-//               dest_pos + sf::Vector2f(-unit_direction.y, unit_direction.x) *
-//                              control_offset;
+                sf::Text label;
+                label.setFont(font);
+                label.setCharacterSize(20);
+                label.setFillColor(sf::Color(30, 30, 30));
+                if constexpr (std::is_same_v<VertexType, char>)
+                    label.setString(std::string(1, vertex));
+                else
+                    label.setString(std::to_string(vertex));
 
-//           sf::VertexArray curve(sf::PrimitiveType::LineStrip);
-//           const int segments = 20;
-//           for (int i = 0; i <= segments; ++i) {
-//             float t = static_cast<float>(i) / segments;
-//             float u = 1.f - t;
-//             float w1 = u * u * u;
-//             float w2 = 3.f * u * u * t;
-//             float w3 = 3.f * u * t * t;
-//             float w4 = t * t * t;
+                sf::FloatRect text_bounds = label.getLocalBounds();
+                label.setOrigin(text_bounds.width / 2.f, text_bounds.height / 2.f);
+                label.setPosition(pos);
+                window.draw(label);
+            }
 
-//             sf::Vector2f point = w1 * adjusted_src + w2 * control_point1 +
-//                                  w3 * control_point2 + w4 * adjusted_dest;
-//             curve.append(sf::Vertex{
-//                 point, sf::Color(100, 100, 100, 180)}); // Semi-transparent gray
-//           }
-//           window.draw(curve);
+            window.display();
+        }
+    }
 
-//           // // Draw arrow head
-//           // if (length > 40.f)
-//           // {
-//           //   sf::Vector2f arrow_head = adjusted_dest;
-//           //   sf::Vector2f arrow_left = arrow_head - unit_direction * 10.f +
-//           //   sf::Vector2f(-unit_direction.y, unit_direction.x) * 5.f;
-//           //   sf::Vector2f arrow_right = arrow_head - unit_direction * 10.f +
-//           //   sf::Vector2f(unit_direction.y, -unit_direction.x) * 5.f;
-
-//           //   sf::VertexArray arrow(sf::PrimitiveType::Triangles, 3);
-//           //   arrow[0].position = arrow_head;
-//           //   arrow[1].position = arrow_left;
-//           //   arrow[2].position = arrow_right;
-//           //   arrow[0].color = arrow[1].color = arrow[2].color = sf::Color(100,
-//           //   100, 100, 180); window.draw(arrow);
-//           // }
-
-//           sf::Vector2f mid_point =
-//               (adjusted_src + adjusted_dest) / 2.f +
-//               sf::Vector2f(-unit_direction.y, unit_direction.x) *
-//                   (control_offset * 0.7f);
-//           sf::Text weight_text{font, "", 16};
-//           weight_text.setFillColor(sf::Color(70, 70, 70));
-
-//           if constexpr (std::is_same_v<EdgeType, char>) {
-//             weight_text.setString(std::string(1, edge_weight));
-//           } else {
-//             weight_text.setString(std::to_string(edge_weight));
-//           }
-
-//           sf::FloatRect text_bounds = weight_text.getLocalBounds();
-//           weight_text.setOrigin(
-//               sf::Vector2f{text_bounds.position.x + text_bounds.size.x / 2.f,
-//                            text_bounds.position.y + text_bounds.size.y / 2.f});
-
-//           weight_text.setPosition(mid_point);
-
-//           sf::RectangleShape text_bg(
-//               sf::Vector2f(text_bounds.size.x + 8.f, text_bounds.size.y + 4.f));
-//           // sf::RectangleShape text_bg(sf::Vector2f(text_bounds.size.x + 8.f,
-//           // text_bounds.size.y + 4.f));
-//           text_bg.setFillColor(sf::Color(240, 240, 240, 220));
-//           text_bg.setOrigin(sf::Vector2f(text_bg.getSize().x / 2.f,
-//                                          text_bg.getSize().y / 2.f));
-//           text_bg.setPosition(mid_point);
-//           window.draw(text_bg);
-
-//           window.draw(weight_text);
-//         }
-//       }
-
-//       int drawn_vertices = 0;
-//       for (const auto &[vertex, pos] : vertex_positions) {
-//         const float radius = 22.f;
-//         sf::CircleShape vertex_circle(radius);
-//         vertex_circle.setFillColor(vertex_colors[vertex]);
-//         vertex_circle.setOutlineThickness(2.f);
-//         vertex_circle.setOutlineColor(sf::Color(80, 80, 80));
-//         vertex_circle.setOrigin(sf::Vector2f(radius, radius));
-//         vertex_circle.setPosition(pos);
-
-//         sf::CircleShape highlight(radius * 0.7f);
-//         highlight.setFillColor(sf::Color(255, 255, 255, 60));
-//         highlight.setOrigin(
-//             sf::Vector2f(highlight.getRadius(), highlight.getRadius()));
-//         highlight.setPosition(
-//             sf::Vector2f{pos.x - radius * 0.15f, pos.y - radius * 0.15f});
-
-//         window.draw(vertex_circle);
-//         window.draw(highlight);
-
-//         sf::Text vertex_text{font, "", 20};
-//         vertex_text.setFillColor(sf::Color(30, 30, 30));
-//         if constexpr (std::is_same_v<VertexType, char>) {
-//           vertex_text.setString(std::string(1, vertex));
-//         } else {
-//           vertex_text.setString(std::to_string(vertex));
-//         }
-
-//         sf::FloatRect text_bounds = vertex_text.getLocalBounds();
-//         vertex_text.setOrigin(
-//             sf::Vector2f{text_bounds.position.x + text_bounds.size.x / 2.f,
-//                          text_bounds.position.y + text_bounds.size.y / 2.f});
-//         vertex_text.setPosition(pos);
-//         window.draw(vertex_text);
-
-//         drawn_vertices++;
-//       }
-
-//       static bool first_frame = true;
-//       if (first_frame) {
-//         std::cout << "Drew " << drawn_vertices << " vertices on screen"
-//                   << std::endl;
-//         first_frame = false;
-//       }
-
-//       window.display();
-//     }
-//   }
-//   void visualize() {
-//     sf::RenderWindow window(sf::VideoMode({1200, 800}), "Graph Visualization");
-
-//     while (window.isOpen()) {
-//       while (auto event = window.pollEvent()) {
-//         if (event->is<sf::Event::Closed>())
-//           window.close();
-//       }
-
-//       window.clear(sf::Color::White);
-//       window.display();
-//     }
-//   }
-//   void print_adj_list() {
-//     for (const auto &[first, second] : _adj_list) {
-//       std::cout << "Vertex: " << first << "'s adj list:\n";
-//       for (const auto &pr : second) {
-//         std::cout << "  Neighbor: " << pr.first << " Weight: " << pr.second
-//                   << "\n";
-//       }
-//     }
-//   }
-
-// private:
-//   AdjListType _adj_list;
-// };
-
-// } // namespace CinderPeak
+  private:
+      AdjListType _adj_list;
+  };
+} 

--- a/src/Visualizer.hpp
+++ b/src/Visualizer.hpp
@@ -1,144 +1,256 @@
-#pragma once
-#include "ArialFontDataEmbed.hpp"
-#include <type_traits>
-#include <SFML/Graphics.hpp>
-#include <cmath>
-#include <iostream>
-#include <optional>
-#include <unordered_map>
-#include <vector>
+// // Temporarily Depreciated. Unused.
 
-namespace CinderPeak {
+// #pragma once
+// #include "ArialFontDataEmbed.hpp"
+// #include <SFML/Graphics.hpp>
+// #include <cmath> // for std::cos, std::sin
+// #include <iostream>
+// #include <optional>
+// #include <sstream>
+// #include <type_traits>
+// #include <unordered_map>
+// #include <vector>
+// namespace CinderPeak {
+// template <typename VertexType, typename EdgeType> class GraphVisualizer {
+// public:
+//   using AdjListType =
+//       std::unordered_map<VertexType,
+//                          std::vector<std::pair<VertexType, EdgeType>>,
+//                          VertexHasher<VertexType>>;
 
-template <typename VertexType, typename EdgeType>
-class InteractiveVisualizer {
-public:
-    using AdjListType =
-        std::unordered_map<VertexType,
-                        std::vector<std::pair<VertexType, EdgeType>>>;
+//   explicit GraphVisualizer(AdjListType adj_list) : _adj_list(adj_list) {
+//     LOG_DEBUG("GOT ADJACENCY LIST WITH SIZE: ");
+//     LOG_DEBUG(std::to_string(_adj_list.size()));
+//   }
 
-    explicit InteractiveVisualizer(AdjListType adj_list)
-        : _adj_list(adj_list) {}
+//   void visualize_primitives_graph() {
+//     sf::RenderWindow window(sf::VideoMode({800, 600}), "Graph Visualization");
+//     window.setFramerateLimit(60);
 
-    void visualize() {
-        sf::RenderWindow window(sf::VideoMode({800, 600}), "Interactive Graph");
-        window.setFramerateLimit(60);
+//     std::unordered_map<VertexType, sf::Vector2f> vertex_positions;
+//     const float center_x = 400.f;
+//     const float center_y = 300.f;
+//     const float radius = 200.f;
 
-        if (_adj_list.empty()) {
-            std::cerr << "Empty adjacency list!" << std::endl;
-            return;
-        }
+//     std::cout << "Adjacency list size: " << _adj_list.size() << std::endl;
 
-        std::unordered_map<VertexType, sf::Vector2f> vertex_positions;
-        const float center_x = 400.f;
-        const float center_y = 300.f;
-        const float radius = 200.f;
-        float angle_step = 2 * 3.14159265f / _adj_list.size();
-        float current_angle = 0.f;
+//     if (_adj_list.size() == 0) {
+//       std::cerr << "Empty adjacency list!" << std::endl;
+//       return;
+//     }
 
-        for (const auto& [vertex, _] : _adj_list) {
-            float x = center_x + radius * std::cos(current_angle);
-            float y = center_y + radius * std::sin(current_angle);
-            vertex_positions[vertex] = sf::Vector2f(x, y);
-            current_angle += angle_step;
-        }
+//     float angle_step = 2 * 3.14159265f / _adj_list.size();
+//     float current_angle = 0.f;
 
-        std::unordered_map<VertexType, sf::Color> vertex_colors;
-        const std::vector<sf::Color> palette = {
-            sf::Color(102, 197, 204), sf::Color(246, 207, 113),
-            sf::Color(248, 156, 116), sf::Color(220, 176, 242),
-            sf::Color(135, 197, 125), sf::Color(158, 185, 243),
-            sf::Color(254, 136, 177)};
+//     int vertex_count = 0;
+//     for (const auto &[vertex, _] : _adj_list) {
+//       float x = center_x + radius * std::cos(current_angle);
+//       float y = center_y + radius * std::sin(current_angle);
+//       vertex_positions[vertex] = sf::Vector2f(x, y);
 
-        int colorIndex = 0;
-        for (const auto& [vertex, _] : _adj_list) {
-            vertex_colors[vertex] = palette[colorIndex % palette.size()];
-            colorIndex++;
-        }
+//       std::cout << "Vertex " << vertex << " positioned at (" << x << ", " << y
+//                 << ")" << std::endl;
 
-        sf::Font font;
-        if (!font.loadFromMemory(Arial_ttf, Arial_ttf_len)) {
-            std::cerr << "Failed to load font from memory" << std::endl;
-            return;
-        }
+//       current_angle += angle_step;
+//       vertex_count++;
+//     }
 
-        std::optional<VertexType> selected_vertex = std::nullopt;
-        sf::Vector2f mouse_offset;
+//     std::cout << "Total vertices positioned: " << vertex_count << std::endl;
 
-        while (window.isOpen()) {
-            sf::Event event;
-            while (window.pollEvent(event)) {
-                if (event.type == sf::Event::Closed)
-                    window.close();
+//     sf::Font font;
+//     if (!font.openFromMemory(Arial_ttf, Arial_ttf_len)) {
+//       std::cerr << "Failed to load font from memory" << std::endl;
+//       return;
+//     }
 
-                if (event.type == sf::Event::MouseButtonPressed &&
-                    event.mouseButton.button == sf::Mouse::Left) {
-                    sf::Vector2f mouse_pos(event.mouseButton.x, event.mouseButton.y);
-                    for (auto& [vertex, pos] : vertex_positions) {
-                        float dist = std::hypot(pos.x - mouse_pos.x, pos.y - mouse_pos.y);
-                        if (dist <= 22.f) {
-                            selected_vertex = vertex;
-                            mouse_offset = pos - mouse_pos;
-                            break;
-                        }
-                    }
-                }
+//     std::unordered_map<VertexType, sf::Color> vertex_colors;
+//     const std::vector<sf::Color> color_palette = {
+//         sf::Color(102, 197, 204), sf::Color(246, 207, 113),
+//         sf::Color(248, 156, 116), sf::Color(220, 176, 242),
+//         sf::Color(135, 197, 125), sf::Color(158, 185, 243),
+//         sf::Color(254, 136, 177)};
+//     int color_index = 0;
+//     for (const auto &[vertex, _] : _adj_list) {
+//       vertex_colors[vertex] = color_palette[color_index % color_palette.size()];
+//       color_index++;
+//     }
 
-                if (event.type == sf::Event::MouseButtonReleased &&
-                    event.mouseButton.button == sf::Mouse::Left) {
-                    selected_vertex = std::nullopt;
-                }
-            }
+//     while (window.isOpen()) {
+//       while (std::optional<sf::Event> event = window.pollEvent()) {
+//         if (event->is<sf::Event::Closed>()) {
+//           window.close();
+//         }
+//       }
 
-            if (selected_vertex.has_value()) {
-                sf::Vector2i mpos = sf::Mouse::getPosition(window);
-                vertex_positions[*selected_vertex] = sf::Vector2f(mpos.x, mpos.y) + mouse_offset;
-            }
+//       window.clear(sf::Color(240, 240, 240));
 
-            window.clear(sf::Color(240, 240, 240));
+//       for (const auto &[src_vertex, edges] : _adj_list) {
+//         sf::Vector2f src_pos = vertex_positions[src_vertex];
+//         for (const auto &[dest_vertex, edge_weight] : edges) {
+//           if (vertex_positions.find(dest_vertex) == vertex_positions.end()) {
+//             std::cerr << "Warning: Destination vertex " << dest_vertex
+//                       << " not found in positions!" << std::endl;
+//             continue;
+//           }
 
-            for (const auto& [src, edges] : _adj_list) {
-                sf::Vector2f src_pos = vertex_positions[src];
-                for (const auto& [dest, edge_weight] : edges) {
-                    if (vertex_positions.find(dest) == vertex_positions.end()) continue;
-                    sf::Vector2f dest_pos = vertex_positions[dest];
-                    sf::Vertex line[] = {
-                        sf::Vertex(src_pos, sf::Color(100, 100, 100, 180)),
-                        sf::Vertex(dest_pos, sf::Color(100, 100, 100, 180))
-                    };
-                    window.draw(line, 2, sf::Lines);
-                }
-            }
+//           sf::Vector2f dest_pos = vertex_positions[dest_vertex];
+//           sf::Vector2f direction = dest_pos - src_pos;
+//           float length =
+//               std::sqrt(direction.x * direction.x + direction.y * direction.y);
+//           sf::Vector2f unit_direction = direction / length;
 
-            for (const auto& [vertex, pos] : vertex_positions) {
-                sf::CircleShape circle(22.f);
-                circle.setFillColor(vertex_colors[vertex]);
-                circle.setOutlineThickness(2.f);
-                circle.setOutlineColor(sf::Color(80, 80, 80));
-                circle.setOrigin(22.f, 22.f);
-                circle.setPosition(pos);
-                window.draw(circle);
+//           sf::Vector2f adjusted_src = src_pos + unit_direction * 20.f;
+//           sf::Vector2f adjusted_dest = dest_pos - unit_direction * 20.f;
 
-                sf::Text label;
-                label.setFont(font);
-                label.setCharacterSize(20);
-                label.setFillColor(sf::Color(30, 30, 30));
-                if constexpr (std::is_same_v<VertexType, char>)
-                    label.setString(std::string(1, vertex));
-                else
-                    label.setString(std::to_string(vertex));
+//           const float control_offset = length * 0.2f;
+//           sf::Vector2f control_point1 =
+//               src_pos + sf::Vector2f(-unit_direction.y, unit_direction.x) *
+//                             control_offset;
+//           sf::Vector2f control_point2 =
+//               dest_pos + sf::Vector2f(-unit_direction.y, unit_direction.x) *
+//                              control_offset;
 
-                sf::FloatRect text_bounds = label.getLocalBounds();
-                label.setOrigin(text_bounds.width / 2.f, text_bounds.height / 2.f);
-                label.setPosition(pos);
-                window.draw(label);
-            }
+//           sf::VertexArray curve(sf::PrimitiveType::LineStrip);
+//           const int segments = 20;
+//           for (int i = 0; i <= segments; ++i) {
+//             float t = static_cast<float>(i) / segments;
+//             float u = 1.f - t;
+//             float w1 = u * u * u;
+//             float w2 = 3.f * u * u * t;
+//             float w3 = 3.f * u * t * t;
+//             float w4 = t * t * t;
 
-            window.display();
-        }
-    }
+//             sf::Vector2f point = w1 * adjusted_src + w2 * control_point1 +
+//                                  w3 * control_point2 + w4 * adjusted_dest;
+//             curve.append(sf::Vertex{
+//                 point, sf::Color(100, 100, 100, 180)}); // Semi-transparent gray
+//           }
+//           window.draw(curve);
 
-  private:
-      AdjListType _adj_list;
-  };
-} 
+//           // // Draw arrow head
+//           // if (length > 40.f)
+//           // {
+//           //   sf::Vector2f arrow_head = adjusted_dest;
+//           //   sf::Vector2f arrow_left = arrow_head - unit_direction * 10.f +
+//           //   sf::Vector2f(-unit_direction.y, unit_direction.x) * 5.f;
+//           //   sf::Vector2f arrow_right = arrow_head - unit_direction * 10.f +
+//           //   sf::Vector2f(unit_direction.y, -unit_direction.x) * 5.f;
+
+//           //   sf::VertexArray arrow(sf::PrimitiveType::Triangles, 3);
+//           //   arrow[0].position = arrow_head;
+//           //   arrow[1].position = arrow_left;
+//           //   arrow[2].position = arrow_right;
+//           //   arrow[0].color = arrow[1].color = arrow[2].color = sf::Color(100,
+//           //   100, 100, 180); window.draw(arrow);
+//           // }
+
+//           sf::Vector2f mid_point =
+//               (adjusted_src + adjusted_dest) / 2.f +
+//               sf::Vector2f(-unit_direction.y, unit_direction.x) *
+//                   (control_offset * 0.7f);
+//           sf::Text weight_text{font, "", 16};
+//           weight_text.setFillColor(sf::Color(70, 70, 70));
+
+//           if constexpr (std::is_same_v<EdgeType, char>) {
+//             weight_text.setString(std::string(1, edge_weight));
+//           } else {
+//             weight_text.setString(std::to_string(edge_weight));
+//           }
+
+//           sf::FloatRect text_bounds = weight_text.getLocalBounds();
+//           weight_text.setOrigin(
+//               sf::Vector2f{text_bounds.position.x + text_bounds.size.x / 2.f,
+//                            text_bounds.position.y + text_bounds.size.y / 2.f});
+
+//           weight_text.setPosition(mid_point);
+
+//           sf::RectangleShape text_bg(
+//               sf::Vector2f(text_bounds.size.x + 8.f, text_bounds.size.y + 4.f));
+//           // sf::RectangleShape text_bg(sf::Vector2f(text_bounds.size.x + 8.f,
+//           // text_bounds.size.y + 4.f));
+//           text_bg.setFillColor(sf::Color(240, 240, 240, 220));
+//           text_bg.setOrigin(sf::Vector2f(text_bg.getSize().x / 2.f,
+//                                          text_bg.getSize().y / 2.f));
+//           text_bg.setPosition(mid_point);
+//           window.draw(text_bg);
+
+//           window.draw(weight_text);
+//         }
+//       }
+
+//       int drawn_vertices = 0;
+//       for (const auto &[vertex, pos] : vertex_positions) {
+//         const float radius = 22.f;
+//         sf::CircleShape vertex_circle(radius);
+//         vertex_circle.setFillColor(vertex_colors[vertex]);
+//         vertex_circle.setOutlineThickness(2.f);
+//         vertex_circle.setOutlineColor(sf::Color(80, 80, 80));
+//         vertex_circle.setOrigin(sf::Vector2f(radius, radius));
+//         vertex_circle.setPosition(pos);
+
+//         sf::CircleShape highlight(radius * 0.7f);
+//         highlight.setFillColor(sf::Color(255, 255, 255, 60));
+//         highlight.setOrigin(
+//             sf::Vector2f(highlight.getRadius(), highlight.getRadius()));
+//         highlight.setPosition(
+//             sf::Vector2f{pos.x - radius * 0.15f, pos.y - radius * 0.15f});
+
+//         window.draw(vertex_circle);
+//         window.draw(highlight);
+
+//         sf::Text vertex_text{font, "", 20};
+//         vertex_text.setFillColor(sf::Color(30, 30, 30));
+//         if constexpr (std::is_same_v<VertexType, char>) {
+//           vertex_text.setString(std::string(1, vertex));
+//         } else {
+//           vertex_text.setString(std::to_string(vertex));
+//         }
+
+//         sf::FloatRect text_bounds = vertex_text.getLocalBounds();
+//         vertex_text.setOrigin(
+//             sf::Vector2f{text_bounds.position.x + text_bounds.size.x / 2.f,
+//                          text_bounds.position.y + text_bounds.size.y / 2.f});
+//         vertex_text.setPosition(pos);
+//         window.draw(vertex_text);
+
+//         drawn_vertices++;
+//       }
+
+//       static bool first_frame = true;
+//       if (first_frame) {
+//         std::cout << "Drew " << drawn_vertices << " vertices on screen"
+//                   << std::endl;
+//         first_frame = false;
+//       }
+
+//       window.display();
+//     }
+//   }
+//   void visualize() {
+//     sf::RenderWindow window(sf::VideoMode({1200, 800}), "Graph Visualization");
+
+//     while (window.isOpen()) {
+//       while (auto event = window.pollEvent()) {
+//         if (event->is<sf::Event::Closed>())
+//           window.close();
+//       }
+
+//       window.clear(sf::Color::White);
+//       window.display();
+//     }
+//   }
+//   void print_adj_list() {
+//     for (const auto &[first, second] : _adj_list) {
+//       std::cout << "Vertex: " << first << "'s adj list:\n";
+//       for (const auto &pr : second) {
+//         std::cout << "  Neighbor: " << pr.first << " Weight: " << pr.second
+//                   << "\n";
+//       }
+//     }
+//   }
+
+// private:
+//   AdjListType _adj_list;
+// };
+
+// } // namespace CinderPeak

--- a/src/Visualizer.hpp
+++ b/src/Visualizer.hpp
@@ -1,256 +1,145 @@
-// // Temporarily Depreciated. Unused.
+#pragma once
+#include "ArialFontDataEmbed.hpp"
+#include <type_traits>
+#include <SFML/Graphics.hpp>
+#include <cmath>
+#include <iostream>
+#include <optional>
+#include <unordered_map>
+#include <vector>
 
-// #pragma once
-// #include "ArialFontDataEmbed.hpp"
-// #include <SFML/Graphics.hpp>
-// #include <cmath> // for std::cos, std::sin
-// #include <iostream>
-// #include <optional>
-// #include <sstream>
-// #include <type_traits>
-// #include <unordered_map>
-// #include <vector>
-// namespace CinderPeak {
-// template <typename VertexType, typename EdgeType> class GraphVisualizer {
-// public:
-//   using AdjListType =
-//       std::unordered_map<VertexType,
-//                          std::vector<std::pair<VertexType, EdgeType>>,
-//                          VertexHasher<VertexType>>;
+namespace CinderPeak {
 
-//   explicit GraphVisualizer(AdjListType adj_list) : _adj_list(adj_list) {
-//     LOG_DEBUG("GOT ADJACENCY LIST WITH SIZE: ");
-//     LOG_DEBUG(std::to_string(_adj_list.size()));
-//   }
+template <typename VertexType, typename EdgeType>
+class InteractiveVisualizer {
+public:
+    using AdjListType =
+        std::unordered_map<VertexType,
+                        std::vector<std::pair<VertexType, EdgeType>>>;
 
-//   void visualize_primitives_graph() {
-//     sf::RenderWindow window(sf::VideoMode({800, 600}), "Graph Visualization");
-//     window.setFramerateLimit(60);
+    explicit InteractiveVisualizer(AdjListType adj_list)
+        : _adj_list(adj_list) {}
 
-//     std::unordered_map<VertexType, sf::Vector2f> vertex_positions;
-//     const float center_x = 400.f;
-//     const float center_y = 300.f;
-//     const float radius = 200.f;
+    void visualize() {
+        sf::RenderWindow window(sf::VideoMode({800, 600}), "Interactive Graph");
+        window.setFramerateLimit(60);
 
-//     std::cout << "Adjacency list size: " << _adj_list.size() << std::endl;
+        if (_adj_list.empty()) {
+            std::cerr << "Empty adjacency list!" << std::endl;
+            return;
+        }
 
-//     if (_adj_list.size() == 0) {
-//       std::cerr << "Empty adjacency list!" << std::endl;
-//       return;
-//     }
+        std::unordered_map<VertexType, sf::Vector2f> vertex_positions;
+        const float center_x = 400.f;
+        const float center_y = 300.f;
+        const float radius = 200.f;
+        float angle_step = 2 * 3.14159265f / _adj_list.size();
+        float current_angle = 0.f;
 
-//     float angle_step = 2 * 3.14159265f / _adj_list.size();
-//     float current_angle = 0.f;
+        for (const auto& [vertex, _] : _adj_list) {
+            float x = center_x + radius * std::cos(current_angle);
+            float y = center_y + radius * std::sin(current_angle);
+            vertex_positions[vertex] = sf::Vector2f(x, y);
+            current_angle += angle_step;
+        }
 
-//     int vertex_count = 0;
-//     for (const auto &[vertex, _] : _adj_list) {
-//       float x = center_x + radius * std::cos(current_angle);
-//       float y = center_y + radius * std::sin(current_angle);
-//       vertex_positions[vertex] = sf::Vector2f(x, y);
+        std::unordered_map<VertexType, sf::Color> vertex_colors;
+        const std::vector<sf::Color> palette = {
+            sf::Color(102, 197, 204), sf::Color(246, 207, 113),
+            sf::Color(248, 156, 116), sf::Color(220, 176, 242),
+            sf::Color(135, 197, 125), sf::Color(158, 185, 243),
+            sf::Color(254, 136, 177)};
 
-//       std::cout << "Vertex " << vertex << " positioned at (" << x << ", " << y
-//                 << ")" << std::endl;
+        int colorIndex = 0;
+        for (const auto& [vertex, _] : _adj_list) {
+            vertex_colors[vertex] = palette[colorIndex % palette.size()];
+            colorIndex++;
+        }
 
-//       current_angle += angle_step;
-//       vertex_count++;
-//     }
+        sf::Font font;
+        if (!font.loadFromMemory(Arial_ttf, Arial_ttf_len)) {
+            std::cerr << "Failed to load font from memory" << std::endl;
+            return;
+        }
 
-//     std::cout << "Total vertices positioned: " << vertex_count << std::endl;
+        std::optional<VertexType> selected_vertex = std::nullopt;
+        sf::Vector2f mouse_offset;
 
-//     sf::Font font;
-//     if (!font.openFromMemory(Arial_ttf, Arial_ttf_len)) {
-//       std::cerr << "Failed to load font from memory" << std::endl;
-//       return;
-//     }
+        while (window.isOpen()) {
+            sf::Event event;
+            while (window.pollEvent(event)) {
+                if (event.type == sf::Event::Closed)
+                    window.close();
 
-//     std::unordered_map<VertexType, sf::Color> vertex_colors;
-//     const std::vector<sf::Color> color_palette = {
-//         sf::Color(102, 197, 204), sf::Color(246, 207, 113),
-//         sf::Color(248, 156, 116), sf::Color(220, 176, 242),
-//         sf::Color(135, 197, 125), sf::Color(158, 185, 243),
-//         sf::Color(254, 136, 177)};
-//     int color_index = 0;
-//     for (const auto &[vertex, _] : _adj_list) {
-//       vertex_colors[vertex] = color_palette[color_index % color_palette.size()];
-//       color_index++;
-//     }
+                if (event.type == sf::Event::MouseButtonPressed &&
+                    event.mouseButton.button == sf::Mouse::Left) {
+                    sf::Vector2f mouse_pos(event.mouseButton.x, event.mouseButton.y);
+                    for (auto& [vertex, pos] : vertex_positions) {
+                        float dist = std::hypot(pos.x - mouse_pos.x, pos.y - mouse_pos.y);
+                        if (dist <= 22.f) {
+                            selected_vertex = vertex;
+                            mouse_offset = pos - mouse_pos;
+                            break;
+                        }
+                    }
+                }
 
-//     while (window.isOpen()) {
-//       while (std::optional<sf::Event> event = window.pollEvent()) {
-//         if (event->is<sf::Event::Closed>()) {
-//           window.close();
-//         }
-//       }
+                if (event.type == sf::Event::MouseButtonReleased &&
+                    event.mouseButton.button == sf::Mouse::Left) {
+                    selected_vertex = std::nullopt;
+                }
+            }
 
-//       window.clear(sf::Color(240, 240, 240));
+            if (selected_vertex.has_value()) {
+                sf::Vector2i mpos = sf::Mouse::getPosition(window);
+                vertex_positions[*selected_vertex] = sf::Vector2f(mpos.x, mpos.y) + mouse_offset;
+            }
 
-//       for (const auto &[src_vertex, edges] : _adj_list) {
-//         sf::Vector2f src_pos = vertex_positions[src_vertex];
-//         for (const auto &[dest_vertex, edge_weight] : edges) {
-//           if (vertex_positions.find(dest_vertex) == vertex_positions.end()) {
-//             std::cerr << "Warning: Destination vertex " << dest_vertex
-//                       << " not found in positions!" << std::endl;
-//             continue;
-//           }
+            window.clear(sf::Color(240, 240, 240));
 
-//           sf::Vector2f dest_pos = vertex_positions[dest_vertex];
-//           sf::Vector2f direction = dest_pos - src_pos;
-//           float length =
-//               std::sqrt(direction.x * direction.x + direction.y * direction.y);
-//           sf::Vector2f unit_direction = direction / length;
+            for (const auto& [src, edges] : _adj_list) {
+                sf::Vector2f src_pos = vertex_positions[src];
+                for (const auto& [dest, edge_weight] : edges) {
+                    if (vertex_positions.find(dest) == vertex_positions.end()) continue;
+                    sf::Vector2f dest_pos = vertex_positions[dest];
+                    sf::Vertex line[] = {
+                        sf::Vertex(src_pos, sf::Color(100, 100, 100, 180)),
+                        sf::Vertex(dest_pos, sf::Color(100, 100, 100, 180))
+                    };
+                    window.draw(line, 2, sf::Lines);
+                }
+            }
 
-//           sf::Vector2f adjusted_src = src_pos + unit_direction * 20.f;
-//           sf::Vector2f adjusted_dest = dest_pos - unit_direction * 20.f;
+            for (const auto& [vertex, pos] : vertex_positions) {
+                sf::CircleShape circle(22.f);
+                circle.setFillColor(vertex_colors[vertex]);
+                circle.setOutlineThickness(2.f);
+                circle.setOutlineColor(sf::Color(80, 80, 80));
+                circle.setOrigin(22.f, 22.f);
+                circle.setPosition(pos);
+                window.draw(circle);
 
-//           const float control_offset = length * 0.2f;
-//           sf::Vector2f control_point1 =
-//               src_pos + sf::Vector2f(-unit_direction.y, unit_direction.x) *
-//                             control_offset;
-//           sf::Vector2f control_point2 =
-//               dest_pos + sf::Vector2f(-unit_direction.y, unit_direction.x) *
-//                              control_offset;
+                sf::Text label;
+                label.setFont(font);
+                label.setCharacterSize(20);
+                label.setFillColor(sf::Color(30, 30, 30));
+                if constexpr (std::is_same_v<VertexType, char>)
+                    label.setString(std::string(1, vertex));
+                else
+                    label.setString(std::to_string(vertex));
 
-//           sf::VertexArray curve(sf::PrimitiveType::LineStrip);
-//           const int segments = 20;
-//           for (int i = 0; i <= segments; ++i) {
-//             float t = static_cast<float>(i) / segments;
-//             float u = 1.f - t;
-//             float w1 = u * u * u;
-//             float w2 = 3.f * u * u * t;
-//             float w3 = 3.f * u * t * t;
-//             float w4 = t * t * t;
+                sf::FloatRect text_bounds = label.getLocalBounds();
+                label.setOrigin(text_bounds.width / 2.f, text_bounds.height / 2.f);
+                label.setPosition(pos);
+                window.draw(label);
+            }
 
-//             sf::Vector2f point = w1 * adjusted_src + w2 * control_point1 +
-//                                  w3 * control_point2 + w4 * adjusted_dest;
-//             curve.append(sf::Vertex{
-//                 point, sf::Color(100, 100, 100, 180)}); // Semi-transparent gray
-//           }
-//           window.draw(curve);
+            window.display();
+        }
+    }
 
-//           // // Draw arrow head
-//           // if (length > 40.f)
-//           // {
-//           //   sf::Vector2f arrow_head = adjusted_dest;
-//           //   sf::Vector2f arrow_left = arrow_head - unit_direction * 10.f +
-//           //   sf::Vector2f(-unit_direction.y, unit_direction.x) * 5.f;
-//           //   sf::Vector2f arrow_right = arrow_head - unit_direction * 10.f +
-//           //   sf::Vector2f(unit_direction.y, -unit_direction.x) * 5.f;
+  private:
+      AdjListType _adj_list;
+  };
 
-//           //   sf::VertexArray arrow(sf::PrimitiveType::Triangles, 3);
-//           //   arrow[0].position = arrow_head;
-//           //   arrow[1].position = arrow_left;
-//           //   arrow[2].position = arrow_right;
-//           //   arrow[0].color = arrow[1].color = arrow[2].color = sf::Color(100,
-//           //   100, 100, 180); window.draw(arrow);
-//           // }
-
-//           sf::Vector2f mid_point =
-//               (adjusted_src + adjusted_dest) / 2.f +
-//               sf::Vector2f(-unit_direction.y, unit_direction.x) *
-//                   (control_offset * 0.7f);
-//           sf::Text weight_text{font, "", 16};
-//           weight_text.setFillColor(sf::Color(70, 70, 70));
-
-//           if constexpr (std::is_same_v<EdgeType, char>) {
-//             weight_text.setString(std::string(1, edge_weight));
-//           } else {
-//             weight_text.setString(std::to_string(edge_weight));
-//           }
-
-//           sf::FloatRect text_bounds = weight_text.getLocalBounds();
-//           weight_text.setOrigin(
-//               sf::Vector2f{text_bounds.position.x + text_bounds.size.x / 2.f,
-//                            text_bounds.position.y + text_bounds.size.y / 2.f});
-
-//           weight_text.setPosition(mid_point);
-
-//           sf::RectangleShape text_bg(
-//               sf::Vector2f(text_bounds.size.x + 8.f, text_bounds.size.y + 4.f));
-//           // sf::RectangleShape text_bg(sf::Vector2f(text_bounds.size.x + 8.f,
-//           // text_bounds.size.y + 4.f));
-//           text_bg.setFillColor(sf::Color(240, 240, 240, 220));
-//           text_bg.setOrigin(sf::Vector2f(text_bg.getSize().x / 2.f,
-//                                          text_bg.getSize().y / 2.f));
-//           text_bg.setPosition(mid_point);
-//           window.draw(text_bg);
-
-//           window.draw(weight_text);
-//         }
-//       }
-
-//       int drawn_vertices = 0;
-//       for (const auto &[vertex, pos] : vertex_positions) {
-//         const float radius = 22.f;
-//         sf::CircleShape vertex_circle(radius);
-//         vertex_circle.setFillColor(vertex_colors[vertex]);
-//         vertex_circle.setOutlineThickness(2.f);
-//         vertex_circle.setOutlineColor(sf::Color(80, 80, 80));
-//         vertex_circle.setOrigin(sf::Vector2f(radius, radius));
-//         vertex_circle.setPosition(pos);
-
-//         sf::CircleShape highlight(radius * 0.7f);
-//         highlight.setFillColor(sf::Color(255, 255, 255, 60));
-//         highlight.setOrigin(
-//             sf::Vector2f(highlight.getRadius(), highlight.getRadius()));
-//         highlight.setPosition(
-//             sf::Vector2f{pos.x - radius * 0.15f, pos.y - radius * 0.15f});
-
-//         window.draw(vertex_circle);
-//         window.draw(highlight);
-
-//         sf::Text vertex_text{font, "", 20};
-//         vertex_text.setFillColor(sf::Color(30, 30, 30));
-//         if constexpr (std::is_same_v<VertexType, char>) {
-//           vertex_text.setString(std::string(1, vertex));
-//         } else {
-//           vertex_text.setString(std::to_string(vertex));
-//         }
-
-//         sf::FloatRect text_bounds = vertex_text.getLocalBounds();
-//         vertex_text.setOrigin(
-//             sf::Vector2f{text_bounds.position.x + text_bounds.size.x / 2.f,
-//                          text_bounds.position.y + text_bounds.size.y / 2.f});
-//         vertex_text.setPosition(pos);
-//         window.draw(vertex_text);
-
-//         drawn_vertices++;
-//       }
-
-//       static bool first_frame = true;
-//       if (first_frame) {
-//         std::cout << "Drew " << drawn_vertices << " vertices on screen"
-//                   << std::endl;
-//         first_frame = false;
-//       }
-
-//       window.display();
-//     }
-//   }
-//   void visualize() {
-//     sf::RenderWindow window(sf::VideoMode({1200, 800}), "Graph Visualization");
-
-//     while (window.isOpen()) {
-//       while (auto event = window.pollEvent()) {
-//         if (event->is<sf::Event::Closed>())
-//           window.close();
-//       }
-
-//       window.clear(sf::Color::White);
-//       window.display();
-//     }
-//   }
-//   void print_adj_list() {
-//     for (const auto &[first, second] : _adj_list) {
-//       std::cout << "Vertex: " << first << "'s adj list:\n";
-//       for (const auto &pr : second) {
-//         std::cout << "  Neighbor: " << pr.first << " Weight: " << pr.second
-//                   << "\n";
-//       }
-//     }
-//   }
-
-// private:
-//   AdjListType _adj_list;
-// };
-
-// } // namespace CinderPeak
+} 


### PR DESCRIPTION
This PR enhances the graph visualization engine by adding interactive node dragging using SFML.

Changes:
- Users can now click and drag nodes to reposition them.
- Connected edges update dynamically as nodes are moved.
- Visual improvements for vertex coloring and labeling.

Note: The code logic was implemented, but it has not been tested locally as SFML is not installed.
