### PR TITLE
feat(storage): Added Bulk Insertion Support (for Vertices and Edges) in AdjacencyList.hpp and GraphStatistics functionality to the codebase.

### DIFF
--- a/src/GraphMatrix.hpp
+++ b/src/GraphMatrix.hpp
@@ -106,6 +106,11 @@ public:
   }
   void visualize() { LOG_INFO("Called GraphMatrix:visualize"); }
 
+  // Helper method to call getGraphStatistics() from Peakstore
+  std::string getGraphStatistics() {
+    return peak_store->getGraphStatistics();
+  }
+
   EdgeAccessor<VertexType, EdgeType> operator[](const VertexType &src) {
     return EdgeAccessor<VertexType, EdgeType>(*this, src);
   }

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -60,6 +60,8 @@ public:
       return status;
     }
 
+    if (ctx->active_storage->impl_doesEdgeExist(dest, src)) {ctx->metadata->num_parallel_edges++;}
+    if (src == dest) {ctx->metadata->num_self_loops++;}
     ctx->metadata->num_edges++;
     return PeakStatus::OK();
   }
@@ -72,6 +74,9 @@ public:
         !status.isOK()) {
       return status;
     }
+
+    if (ctx->active_storage->impl_doesEdgeExist(dest, src)) {ctx->metadata->num_parallel_edges++;}
+    if (src == dest) {ctx->metadata->num_self_loops++;}
     ctx->metadata->num_edges++;
     return PeakStatus::OK();
   }
@@ -105,6 +110,27 @@ public:
   getContext() const {
     return ctx;
   }
+  
+  // Method to get a summary string of statistics
+  std::string getGraphStatistics() {  
+    std::stringstream ss;
+
+    if (ctx->metadata->num_vertices > 1) {
+      float directed_density = (float)ctx->metadata->num_edges / (ctx->metadata->num_vertices * (ctx->metadata->num_vertices - 1));
+      if (ctx->create_options->hasOption(GraphCreationOptions::Directed))
+        ctx->metadata->density = directed_density;
+      if (ctx->create_options->hasOption(GraphCreationOptions::Undirected))
+        ctx->metadata->density = 2*directed_density;
+    }  
+    ss << "=== Graph Statistics ===" << std::endl;
+    ss << "Vertices: " << ctx->metadata->num_vertices << std::endl;
+    ss << "Edges: " << ctx->metadata->num_edges << std::endl;     
+    ss << "Density: " << std::fixed << std::setprecision(2) << ctx->metadata->density << std::endl;
+    ss << "Self-loops: " << ctx->metadata->num_self_loops << std::endl;
+    ss << "Parallel edges: " << ctx->metadata->num_parallel_edges << std::endl;
+    return ss.str();
+  }
+
   void visualize() { LOG_WARNING("Unimplemented function: visualize"); }
 };
 

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -52,12 +52,12 @@ public:
       }
         
       if (auto it = _adj_list.find(src); it == _adj_list.end()){
-        LOG_WARNING("The vertex " + std::to_string(src) + " does not exist.");
+        LOG_WARNING((std::ostringstream() << "The vertex " << src << " does not exist.").str());
         peak_status = PeakStatus::VertexNotFound();
         continue;
       }
       if (auto it = _adj_list.find(dest); it == _adj_list.end()){
-        LOG_WARNING("The vertex " + std::to_string(dest) + " does not exist.");
+        LOG_WARNING((std::ostringstream() << "The vertex " << src << " does not exist.").str());
         peak_status = PeakStatus::VertexNotFound();
         continue;
       }
@@ -101,7 +101,7 @@ public:
     for (const auto& vertex : vertices) {
       if constexpr (is_primitive_or_string_v<VertexType>) {
         if (auto it =  _adj_list.find(vertex); it != _adj_list.end()) {
-          LOG_WARNING("Vertex " + std::to_string(vertex) + " already exists with primitive type.");
+          LOG_WARNING((std::ostringstream() << "Vertex " << vertex << " already exists with primitive type.").str());
           peak_status = PeakStatus::VertexAlreadyExists();
           continue;
         }
@@ -112,7 +112,8 @@ public:
           const VertexType &existingVertex = it->first;
           if (existingVertex.__id_ == vertex.__id_) {
             LOG_DEBUG("Matching vertex IDs");
-            LOG_WARNING("Non primitive vertex " + std::to_string(vertex) + " already exists.");
+            LOG_WARNING((std::ostringstream() << "Non primitive vertex " << vertex << " already exists.").str());
+
             peak_status = PeakStatus::VertexAlreadyExists();
             continue;
           }
@@ -155,6 +156,7 @@ public:
     }
     return std::make_pair(EdgeType(), PeakStatus::EdgeNotFound());
   }
+
   const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
   impl_getNeighbors(const VertexType &vertex) const {
     auto it = _adj_list.find(vertex);
@@ -164,7 +166,9 @@ public:
     }
     return std::make_pair(it->second, CinderPeak::PeakStatus::OK());
   }
+
   auto getAdjList() { return _adj_list; }
+
   bool impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                           const EdgeType &weight) override {
     auto it = _adj_list.find(src);
@@ -182,6 +186,7 @@ public:
     }
     return false;
   }
+  
   void print_adj_list() {
     for (const auto &[first, second] : _adj_list) {
       std::cout << "Vertex: " << first << "'s adj list:\n";

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -100,7 +100,7 @@ public:
     
     for (const auto& vertex : vertices) {
       if constexpr (is_primitive_or_string_v<VertexType>) {
-        if (auto it = adj_list.find(vertex); it != adj_list.end()) {
+        if (auto it =  _adj_list.find(vertex); it != _adj_list.end()) {
           LOG_WARNING("Vertex " + std::to_string(vertex) + " already exists with primitive type.");
           peak_status = PeakStatus::VertexAlreadyExists();
           continue;
@@ -108,7 +108,7 @@ public:
         LOG_DEBUG("Unmatched vertices");
         LOG_INFO("Inside primitive block");
       } else {
-        if (auto it = adj_list.find(vertex); it != adj_list.end()) {
+        if (auto it = _adj_list.find(vertex); it != _adj_list.end()) {
           const VertexType &existingVertex = it->first;
           if (existingVertex.__id_ == vertex.__id_) {
             LOG_DEBUG("Matching vertex IDs");
@@ -120,7 +120,7 @@ public:
         LOG_INFO("Inside non primitive block");
       }
         
-      adj_list[vertex] = std::vector<std::pair<VertexType, EdgeType>>();
+      _adj_list[vertex] = std::vector<std::pair<VertexType, EdgeType>>();
     }
     
     return peak_status;

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -72,8 +72,7 @@ public:
 >>>>>>> b1fac80 (feature added for bulk edge insertion)
   const PeakStatus impl_addVertex(const VertexType &src) override {
     if constexpr (is_primitive_or_string_v<VertexType>) {
-      auto it = _adj_list.find(src);
-      if (it != _adj_list.end()) {
+      if (auto it = _adj_list.find(src); it != _adj_list.end()) {
         LOG_WARNING("Vertex already exists with primitive type");
         return PeakStatus::VertexAlreadyExists(
             "Primitive Vertex Already Exists");
@@ -81,8 +80,7 @@ public:
       LOG_DEBUG("Unmatched vertices");
       LOG_INFO("Inside primitive block");
     } else {
-      auto it = _adj_list.find(src);
-      if (it != _adj_list.end()) {
+      if (auto it = _adj_list.find(src); it != _adj_list.end()) {
         const VertexType &existingVertex = it->first;
         if (existingVertex.__id_ == src.__id_) {
           LOG_DEBUG("Matching vertex IDs");
@@ -95,6 +93,39 @@ public:
     _adj_list[src] = std::vector<std::pair<VertexType, EdgeType>>();
     return PeakStatus::OK();
   }
+
+  // Added method for bulk vertices insertion
+  const PeakStatus impl_addVerticesBatch(const std::vector<VertexType>& vertices) {
+    PeakStatus peak_status = PeakStatus::OK();
+    
+    for (const auto& vertex : vertices) {
+      if constexpr (is_primitive_or_string_v<VertexType>) {
+        if (auto it = adj_list.find(vertex); it != adj_list.end()) {
+          LOG_WARNING("Vertex " + std::to_string(vertex) + " already exists with primitive type.");
+          peak_status = PeakStatus::VertexAlreadyExists();
+          continue;
+        }
+        LOG_DEBUG("Unmatched vertices");
+        LOG_INFO("Inside primitive block");
+      } else {
+        if (auto it = adj_list.find(vertex); it != adj_list.end()) {
+          const VertexType &existingVertex = it->first;
+          if (existingVertex.__id_ == vertex.__id_) {
+            LOG_DEBUG("Matching vertex IDs");
+            LOG_WARNING("Non primitive vertex " + std::to_string(vertex) + " already exists.");
+            peak_status = PeakStatus::VertexAlreadyExists();
+            continue;
+          }
+        }
+        LOG_INFO("Inside non primitive block");
+      }
+        
+      adj_list[vertex] = std::vector<std::pair<VertexType, EdgeType>>();
+    }
+    
+    return peak_status;
+  }
+
   bool impl_doesEdgeExist(const VertexType &src,
                           const VertexType &dest) override {
     auto it = _adj_list.find(src);

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -27,12 +27,13 @@ public:
     return PeakStatus::OK();
   }
 
-<<<<<<< HEAD
-=======
 
   // Added method for bulk edges insertion
+  // Usage:
+  // For unweighted graph: graph.addEdges({ {1, 2}, {2, 3}, {3, 4} });
+  // For weighted graph: graph.addEdges({ {1, 2, 5}, {2, 3, 7}, {3, 4, 9} });
   template<typename EdgeContainer>
-  const PeakStatus impl_addEdgesBatch(const EdgeContainer& edges) {
+  const PeakStatus impl_addEdges(const EdgeContainer& edges) {
     PeakStatus peak_status = PeakStatus::OK();
 
     for (const auto& edge : edges) {
@@ -68,8 +69,6 @@ public:
     return peak_status;
   }
 
-
->>>>>>> b1fac80 (feature added for bulk edge insertion)
   const PeakStatus impl_addVertex(const VertexType &src) override {
     if constexpr (is_primitive_or_string_v<VertexType>) {
       if (auto it = _adj_list.find(src); it != _adj_list.end()) {
@@ -95,7 +94,8 @@ public:
   }
 
   // Added method for bulk vertices insertion
-  const PeakStatus impl_addVerticesBatch(const std::vector<VertexType>& vertices) {
+  // Usage: graph.addVertices({1, 2, 3, 4, 5});
+  const PeakStatus impl_addVertices(const std::vector<VertexType>& vertices) {
     PeakStatus peak_status = PeakStatus::OK();
     
     for (const auto& vertex : vertices) {

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -27,6 +27,49 @@ public:
     return PeakStatus::OK();
   }
 
+<<<<<<< HEAD
+=======
+
+  // Added method for bulk edges insertion
+  template<typename EdgeContainer>
+  const PeakStatus impl_addEdgesBatch(const EdgeContainer& edges) {
+    PeakStatus peak_status = PeakStatus::OK();
+
+    for (const auto& edge : edges) {
+      VertexType src, dest;
+      EdgeType weight = EdgeType(); // default weight
+      
+        
+      // Extract values based on container type at compile time
+      if constexpr (std::is_same_v<typename EdgeContainer::value_type, std::pair<VertexType, VertexType>>) {
+        src = edge.first;
+        dest = edge.second;
+      }
+      else if constexpr (std::is_same_v<typename EdgeContainer::value_type, std::tuple<VertexType, VertexType, EdgeType>>) {
+        src = std::get<0>(edge);
+        dest = std::get<1>(edge);
+        weight = std::get<2>(edge);
+      }
+        
+      if (auto it = _adj_list.find(src); it == _adj_list.end()){
+        LOG_WARNING("The vertex " + std::to_string(src) + " does not exist.");
+        peak_status = PeakStatus::VertexNotFound();
+        continue;
+      }
+      if (auto it = _adj_list.find(dest); it == _adj_list.end()){
+        LOG_WARNING("The vertex " + std::to_string(dest) + " does not exist.");
+        peak_status = PeakStatus::VertexNotFound();
+        continue;
+      }
+
+      _adj_list[src].emplace_back(dest, weight);
+    }
+        
+    return peak_status;
+  }
+
+
+>>>>>>> b1fac80 (feature added for bulk edge insertion)
   const PeakStatus impl_addVertex(const VertexType &src) override {
     if constexpr (is_primitive_or_string_v<VertexType>) {
       auto it = _adj_list.find(src);

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -150,7 +150,7 @@ size_t CinderPeak::CinderEdge::nextId = 1;
 namespace PeakStore {
 class GraphInternalMetadata {
 public:
-  size_t density;
+  float density; // Updated datatype for density as it ranges from 0 to 1
   size_t num_vertices;
   size_t num_edges;
   size_t num_self_loops;
@@ -164,12 +164,12 @@ public:
         is_edge_type_primitive(edge_tp_p) {
     num_vertices = 0;
     num_edges = 0;
-    density = 0;
+    density = 0.0; // Initialized with float value
     num_self_loops = 0;
     num_parallel_edges = 0;
   }
-  // default ctor for basic testing, this has to be removed later on.
-  GraphInternalMetadata() {}
+  // // default ctor for basic testing, this has to be removed later on.
+  // GraphInternalMetadata() {}
 };
 } // namespace PeakStore
 namespace Exceptions {

--- a/tests/AdjacencyShard.cpp
+++ b/tests/AdjacencyShard.cpp
@@ -43,10 +43,10 @@ TEST_F(AdjacencyListTest, AddVertexString) {
     EXPECT_EQ(status.message(), "Primitive Vertex Already Exists");
 }
 
-TEST_F(AdjacencyListTest, AddVerticesBatch) {
+TEST_F(AdjacencyListTest, AddVertices) {
     std::vector<int> newVertices = {6, 7, 8, 9, 10};
     
-    auto status = intGraph.impl_addVerticesBatch(newVertices);
+    auto status = intGraph.impl_addVertices(newVertices);
     EXPECT_TRUE(status.isOK());
     
     // Verify all vertices were added
@@ -57,10 +57,10 @@ TEST_F(AdjacencyListTest, AddVerticesBatch) {
     }
 }
 
-TEST_F(AdjacencyListTest, AddVerticesBatchDuplicates) {
+TEST_F(AdjacencyListTest, AddVerticesDuplicates) {
     std::vector<int> verticesWithDups = {6, 1, 7, 2, 8}; // 1 and 2 already exist
     
-    auto status = intGraph.impl_addVerticesBatch(verticesWithDups);
+    auto status = intGraph.impl_addVertices(verticesWithDups);
     EXPECT_FALSE(status.isOK());
     EXPECT_EQ(status.code(), StatusCode::VERTEX_ALREADY_EXISTS);
     
@@ -70,17 +70,17 @@ TEST_F(AdjacencyListTest, AddVerticesBatchDuplicates) {
     EXPECT_TRUE(intGraph.impl_getNeighbors(8).second.isOK());
 }
 
-TEST_F(AdjacencyListTest, AddVerticesBatchEmpty) {
+TEST_F(AdjacencyListTest, AddVerticesEmpty) {
     std::vector<int> emptyVertices = {};
     
-    auto status = intGraph.impl_addVerticesBatch(emptyVertices);
+    auto status = intGraph.impl_addVertices(emptyVertices);
     EXPECT_TRUE(status.isOK());
 }
 
-TEST_F(AdjacencyListTest, AddVerticesBatchString) {
+TEST_F(AdjacencyListTest, AddVerticesString) {
     std::vector<std::string> newVertices = {"D", "E", "F"};
     
-    auto status = stringGraph.impl_addVerticesBatch(newVertices);
+    auto status = stringGraph.impl_addVertices(newVertices);
     EXPECT_TRUE(status.isOK());
     
     // Verify vertices were added
@@ -125,12 +125,12 @@ TEST_F(AdjacencyListTest, AddEdgeInvalidVertices) {
     EXPECT_EQ(status2.code(), StatusCode::VERTEX_NOT_FOUND);
 }
 
-TEST_F(AdjacencyListTest, AddEdgesBatchPairs) {
+TEST_F(AdjacencyListTest, AddEdgesPairs) {
     std::vector<std::pair<int, int>> edges = {
         {1, 2}, {2, 3}, {3, 4}, {4, 5}, {1, 5}
     };
     
-    auto status = intGraph.impl_addEdgesBatch(edges);
+    auto status = intGraph.impl_addEdges(edges);
     EXPECT_TRUE(status.isOK());
     
     // Verify all edges were added
@@ -141,12 +141,12 @@ TEST_F(AdjacencyListTest, AddEdgesBatchPairs) {
     }
 }
 
-TEST_F(AdjacencyListTest, AddEdgesBatchTuples) {
+TEST_F(AdjacencyListTest, AddEdgesTuples) {
     std::vector<std::tuple<int, int, int>> edges = {
         {1, 2, 10}, {2, 3, 20}, {3, 4, 30}, {4, 5, 40}
     };
     
-    auto status = intGraph.impl_addEdgesBatch(edges);
+    auto status = intGraph.impl_addEdges(edges);
     EXPECT_TRUE(status.isOK());
     
     // Verify all edges with correct weights
@@ -156,12 +156,12 @@ TEST_F(AdjacencyListTest, AddEdgesBatchTuples) {
     EXPECT_EQ(intGraph.impl_getEdge(4, 5).first, 40);
 }
 
-TEST_F(AdjacencyListTest, AddEdgesBatchInvalidVertices) {
+TEST_F(AdjacencyListTest, AddEdgesInvalidVertices) {
     std::vector<std::pair<int, int>> edgesWithInvalid = {
         {1, 2}, {99, 3}, {4, 5}, {1, 100} // 99 and 100 don't exist
     };
     
-    auto status = intGraph.impl_addEdgesBatch(edgesWithInvalid);
+    auto status = intGraph.impl_addEdges(edgesWithInvalid);
     EXPECT_FALSE(status.isOK());
     EXPECT_EQ(status.code(), StatusCode::VERTEX_NOT_FOUND);
     
@@ -174,20 +174,20 @@ TEST_F(AdjacencyListTest, AddEdgesBatchInvalidVertices) {
     EXPECT_FALSE(intGraph.impl_getEdge(1, 100).second.isOK());
 }
 
-TEST_F(AdjacencyListTest, AddEdgesBatchEmpty) {
+TEST_F(AdjacencyListTest, AddEdgesEmpty) {
     std::vector<std::pair<int, int>> emptyEdges = {};
     
-    auto status = intGraph.impl_addEdgesBatch(emptyEdges);
+    auto status = intGraph.impl_addEdges(emptyEdges);
     EXPECT_TRUE(status.isOK());
 }
 
-TEST_F(AdjacencyListTest, AddEdgesBatchMixedTypes) {
+TEST_F(AdjacencyListTest, AddEdgesMixedTypes) {
     // Test with string graph
     std::vector<std::tuple<std::string, std::string, float>> edges = {
         {"A", "B", 1.5f}, {"B", "C", 2.7f}, {"A", "C", 3.14f}
     };
     
-    auto status = stringGraph.impl_addEdgesBatch(edges);
+    auto status = stringGraph.impl_addEdges(edges);
     EXPECT_TRUE(status.isOK());
     
     EXPECT_FLOAT_EQ(stringGraph.impl_getEdge("A", "B").first, 1.5f);

--- a/tests/Statistics.cpp
+++ b/tests/Statistics.cpp
@@ -1,0 +1,226 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <random>
+#include <vector>
+#include <algorithm>
+#include "CinderPeak.hpp"
+
+using namespace CinderPeak::PeakStore;
+using namespace CinderPeak;
+
+class GraphStatisticsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        original_cout = std::cout.rdbuf();
+        original_cerr = std::cerr.rdbuf();
+        std::cout.rdbuf(null_stream.rdbuf());
+        std::cerr.rdbuf(null_stream.rdbuf());
+    }
+
+    void TearDown() override {
+        std::cout.rdbuf(original_cout);
+        std::cerr.rdbuf(original_cerr);
+    }
+
+    void displayStats(const std::string& title, const std::string& stats) {
+        std::cout.rdbuf(original_cout);
+        std::cout << "\n" << title << "\n" << std::string(40, '=') << "\n" << stats << std::endl;
+        std::cout.rdbuf(null_stream.rdbuf());
+    }
+
+    int extractValue(const std::string& stats, const std::string& label) {
+        size_t pos = stats.find(label);
+        if (pos == std::string::npos) return -1;
+        pos += label.length();
+        size_t end = stats.find('\n', pos);
+        if (end == std::string::npos) end = stats.length();
+        try {
+            return std::stoi(stats.substr(pos, end - pos));
+        } catch (...) {
+            return -1;
+        }
+    }
+
+    std::stringstream null_stream;
+    std::streambuf* original_cout;
+    std::streambuf* original_cerr;
+};
+
+// Simple large dense graph test - 1000 vertices, lots of edges
+TEST_F(GraphStatisticsTest, LargeDenseGraph) {
+    GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+    GraphMatrix<int, int> graph(opts);
+    
+    const int num_vertices = 1000;
+    const int target_edges = 50000; // 50k edges - dense but reasonable
+    
+    std::cout.rdbuf(original_cout);
+    std::cout << "Creating large graph: " << num_vertices << " vertices, " << target_edges << " edges" << std::endl;
+    std::cout.rdbuf(null_stream.rdbuf());
+    
+    // Add all vertices
+    for (int i = 1; i <= num_vertices; ++i) {
+        graph.addVertex(i);
+    }
+    
+    std::mt19937 gen(12345);
+    std::uniform_int_distribution<> vertex_dist(1, num_vertices);
+    std::uniform_int_distribution<> weight_dist(1, 1000);
+    
+    // Make it connected first (spanning tree)
+    for (int i = 2; i <= num_vertices; ++i) {
+        graph.addEdge(i-1, i, weight_dist(gen));
+    }
+    
+    // Add self-loops
+    for (int i = 1; i <= 50; ++i) {
+        graph.addEdge(i, i, weight_dist(gen));
+    }
+    
+    // Add random edges until we hit target
+    int edges_added = num_vertices - 1 + 50; // spanning tree + self-loops
+    for (int attempt = 0; attempt < target_edges * 3 && edges_added < target_edges; ++attempt) {
+        int v1 = vertex_dist(gen);
+        int v2 = vertex_dist(gen);
+        try {
+            graph.addEdge(v1, v2, weight_dist(gen));
+            edges_added++;
+        } catch (...) {
+            // Skip duplicates/failures
+        }
+        
+        if (attempt % 10000 == 0) {
+            std::cout.rdbuf(original_cout);
+            std::cout << "Progress: " << edges_added << " edges added..." << std::endl;
+            std::cout.rdbuf(null_stream.rdbuf());
+        }
+    }
+    
+    // Get statistics
+    std::cout.rdbuf(original_cout);
+    std::cout << "Getting statistics..." << std::endl;
+    std::cout.rdbuf(null_stream.rdbuf());
+    
+    std::string stats = graph.getGraphStatistics();
+    displayStats("Large Dense Graph Statistics", stats);
+    
+    // Basic verifications
+    EXPECT_FALSE(stats.empty());
+    EXPECT_NE(stats.find("=== Graph Statistics ==="), std::string::npos);
+    
+    int vertices = extractValue(stats, "Vertices: ");
+    int edges = extractValue(stats, "Edges: ");
+    int self_loops = extractValue(stats, "Self-loops: ");
+    int parallel_edges = extractValue(stats, "Parallel edges: ");
+    
+    EXPECT_EQ(vertices, num_vertices);
+    EXPECT_GT(edges, 1000); // Should have many edges
+    EXPECT_GE(self_loops, 0);
+    EXPECT_GE(parallel_edges, 0);
+}
+
+// Medium size tests for comparison
+TEST_F(GraphStatisticsTest, MediumGraphs) {
+    std::vector<std::pair<int, int>> configs = {
+        {100, 500},   // 100 vertices, 500 edges
+        {200, 1000},  // 200 vertices, 1000 edges
+        {500, 2500}   // 500 vertices, 2500 edges
+    };
+    
+    for (auto config : configs) {
+        GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+        GraphMatrix<int, int> graph(opts);
+        
+        int vertices = config.first;
+        int target_edges = config.second;
+        
+        // Add vertices
+        for (int i = 1; i <= vertices; ++i) {
+            graph.addVertex(i);
+        }
+        
+        std::mt19937 gen(vertices); // Different seed per test
+        std::uniform_int_distribution<> vertex_dist(1, vertices);
+        std::uniform_int_distribution<> weight_dist(1, 100);
+        
+        // Add edges
+        for (int i = 0; i < target_edges; ++i) {
+            int v1 = vertex_dist(gen);
+            int v2 = vertex_dist(gen);
+            try {
+                graph.addEdge(v1, v2, weight_dist(gen));
+            } catch (...) {
+                // Continue on failure
+            }
+        }
+        
+        std::string stats = graph.getGraphStatistics();
+        std::string title = "Graph " + std::to_string(vertices) + " vertices";
+        displayStats(title, stats);
+        
+        EXPECT_FALSE(stats.empty());
+        EXPECT_EQ(extractValue(stats, "Vertices: "), vertices);
+    }
+}
+
+// Original test case (kept for regression)
+TEST_F(GraphStatisticsTest, OriginalTest) {
+    GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+    GraphMatrix<int, int> graph(opts);
+    
+    for (int i = 1; i <= 8; ++i) {
+        graph.addVertex(i);
+    }
+    
+    graph.addEdge(1, 2, 50);
+    graph.addEdge(2, 3, 60);
+    graph.addEdge(3, 4, 70);
+    graph.addEdge(4, 5, 80);
+    graph.addEdge(5, 6, 90);
+    graph.addEdge(5, 5, 90); // Self-loop
+    graph.addEdge(6, 5, 90); // Parallel edge
+    graph.addEdge(6, 7, 100);
+    graph.addEdge(7, 8, 110);
+    graph.addEdge(8, 1, 120);
+    graph.addEdge(1, 5, 150);
+    graph.addEdge(6, 2, 850);
+    
+    std::string stats = graph.getGraphStatistics();
+    displayStats("Original Test Case", stats);
+    
+    EXPECT_NE(stats.find("=== Graph Statistics ==="), std::string::npos);
+    EXPECT_EQ(extractValue(stats, "Vertices: "), 8);
+    EXPECT_GT(extractValue(stats, "Edges: "), 0);
+    EXPECT_GE(extractValue(stats, "Self-loops: "), 1);
+}
+
+// Edge cases
+TEST_F(GraphStatisticsTest, EdgeCases) {
+    // Empty graph
+    {
+        GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+        GraphMatrix<int, int> empty_graph(opts);
+        
+        std::string stats = empty_graph.getGraphStatistics();
+        EXPECT_EQ(extractValue(stats, "Vertices: "), 0);
+        EXPECT_EQ(extractValue(stats, "Edges: "), 0);
+    }
+    
+    // Single vertex with self-loop
+    {
+        GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+        GraphMatrix<int, int> single_graph(opts);
+        
+        single_graph.addVertex(1);
+        single_graph.addEdge(1, 1, 100);
+        
+        std::string stats = single_graph.getGraphStatistics();
+        displayStats("Single Vertex Test", stats);
+        
+        EXPECT_EQ(extractValue(stats, "Vertices: "), 1);
+        EXPECT_EQ(extractValue(stats, "Edges: "), 1);
+        EXPECT_EQ(extractValue(stats, "Self-loops: "), 1);
+    }
+}


### PR DESCRIPTION
This PR introduces **bulk insertion support** for vertices and edges in the adjacency list, addressing (issue #45) The new functions streamline graph construction by reducing repetitive single-insert calls.

### Changes Made

* **`AdjacencyList.hpp`**
  - Added `impl_addEdgesBatch` for inserting multiple edges in one call.
  - Added `impl_addVerticesBatch` for inserting multiple vertices in one call.

* **`AdjacencyShard.cpp`**
  - Added and refined unit tests to validate bulk insertion behavior.
  - Extended coverage for edge cases such as duplicate entries and empty input.

### Benefits

* Improves efficiency when adding large sets of edges or vertices.
* Reduces boilerplate in client code.
* Ensures consistent handling of duplicates and invalid inputs.

### Test Results
<img width="722" height="1004" alt="bulk_insertion" src="https://github.com/user-attachments/assets/230029f7-87bc-48e1-a1b1-612bceb74601" />
