### PR TITLE
feat(logging): Added setConsoleLogging method to enable or disable logs in terminal.

### DIFF
--- a/examples/ListExample1.cpp
+++ b/examples/ListExample1.cpp
@@ -6,7 +6,7 @@ int main() {
 
   GraphList<int, int> graph(opts);
 
-  graph.togglePLogging(true); // Enabling log display
+  GraphList<int, int>::setConsoleLogging(true); // Enabling log display
 
   graph.addVertex(1);
   graph.addVertex(2);

--- a/examples/ListExample1.cpp
+++ b/examples/ListExample1.cpp
@@ -5,6 +5,9 @@ int main() {
       {GraphCreationOptions::Directed, GraphCreationOptions::Weighted});
 
   GraphList<int, int> graph(opts);
+
+  graph.togglePLogging(true); // Enabling log display
+
   graph.addVertex(1);
   graph.addVertex(2);
   graph.addVertex(3);

--- a/examples/MatrixExample.cpp
+++ b/examples/MatrixExample.cpp
@@ -26,7 +26,7 @@ int main() {
 
   GraphMatrix<CustomVertex, CustomEdge> myGraph(options);
 
-  myGraph.togglePLogging(false); // Disabling log display
+  myGraph.setConsoleLogging(false); // Disabling log display
 
   CustomVertex v1;
   CustomVertex v2;

--- a/examples/MatrixExample.cpp
+++ b/examples/MatrixExample.cpp
@@ -26,6 +26,8 @@ int main() {
 
   GraphMatrix<CustomVertex, CustomEdge> myGraph(options);
 
+  myGraph.togglePLogging(false); // Disabling log display
+
   CustomVertex v1;
   CustomVertex v2;
   CustomEdge e;

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -69,6 +69,12 @@ public:
     return data;
   }
 
+
+  // Helper method to call togglePLogging function from Peakstore
+  static void togglePLogging(const bool toggle) {
+    CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>::togglePLogging(toggle);
+  }
+
   void visualize() {
     LOG_INFO("Called GraphList:visualize");
     peak_store->visualize();

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -69,9 +69,9 @@ public:
     return data;
   }
 
-  // Helper method to call togglePLogging function from Peakstore
-  static void togglePLogging(const bool toggle) {
-    CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>::togglePLogging(toggle);
+  // Helper method to call setConsoleLogging function from Peakstore
+  static void setConsoleLogging(const bool toggle) {
+    CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>::setConsoleLogging(toggle);
   }
 
   void visualize() {

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -69,7 +69,6 @@ public:
     return data;
   }
 
-
   // Helper method to call togglePLogging function from Peakstore
   static void togglePLogging(const bool toggle) {
     CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>::togglePLogging(toggle);

--- a/src/GraphMatrix.hpp
+++ b/src/GraphMatrix.hpp
@@ -111,9 +111,9 @@ public:
     return peak_store->getGraphStatistics();
   }
 
-  // Helper method to call togglePLogging function from Peakstore
-  static void togglePLogging(const bool toggle) {
-    CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>::togglePLogging(toggle);
+  // Helper method to call setConsoleLogging function from Peakstore
+  static void setConsoleLogging(const bool toggle) {
+    CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>::setConsoleLogging(toggle);
   }
 
   EdgeAccessor<VertexType, EdgeType> operator[](const VertexType &src) {

--- a/src/GraphMatrix.hpp
+++ b/src/GraphMatrix.hpp
@@ -111,6 +111,11 @@ public:
     return peak_store->getGraphStatistics();
   }
 
+  // Helper method to call togglePLogging function from Peakstore
+  static void togglePLogging(const bool toggle) {
+    CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>::togglePLogging(toggle);
+  }
+
   EdgeAccessor<VertexType, EdgeType> operator[](const VertexType &src) {
     return EdgeAccessor<VertexType, EdgeType>(*this, src);
   }

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -121,7 +121,7 @@ PeakStatus addEdge(const VertexType &src, const VertexType &dest,
   }
 
   // Method to enable and disable logs in terminal
-  static void togglePLogging(const bool toggle) {
+  static void setConsoleLogging(const bool toggle) {
     Logger::enableConsoleLogging = toggle;
   }
   

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -42,7 +42,6 @@ public:
             const GraphCreationOptions &options =
                 CinderPeak::GraphCreationOptions::getDefaultCreateOptions())
       : ctx(std::make_shared<GraphContext<VertexType, EdgeType>>()) {
-    Logger::enableConsoleLogging = true;
     initializeContext(metadata, options);
     LOG_INFO("Successfully initialized context object.");
   }
@@ -119,6 +118,11 @@ PeakStatus addEdge(const VertexType &src, const VertexType &dest,
   const std::shared_ptr<GraphContext<VertexType, EdgeType>> &
   getContext() const {
     return ctx;
+  }
+
+  // Method to enable and disable logs in terminal
+  static void togglePLogging(const bool toggle) {
+    Logger::enableConsoleLogging = toggle;
   }
   
   // Method to get a summary string of statistics


### PR DESCRIPTION
This PR implements the `setConsoleLogging()` method to allow users and developers to enable or disable terminal log display at runtime (issue #51), providing better control over debugging output. By default, terminal log display is turned off to keep the terminal clean, and can be easily enabled when needed.

### Changes made:

- `PeakStore.hpp` - Added  `setConsoleLogging()` method to enable/disable log display.
- `GraphList.hpp`, `GraphMatrix.hpp` - Added helper methods to call the `setConsoleLoggingtogglePLogging()` method from PeakStore.
- `ListExample1.cpp`, `PrimitiveGraph.cpp` - Modified to check log toggling functionality.


### Test results:
<img width="1920" height="1080" alt="toggleTest" src="https://github.com/user-attachments/assets/2c1cceca-2f1d-4ec0-a509-519cccf9133d" />
