### PR TITLE
feat(API): Added Compile time safety and automatic infer of GraphInternalMetadata.

### DIFF
--- a/examples/ListExample1.cpp
+++ b/examples/ListExample1.cpp
@@ -2,21 +2,24 @@
 using namespace CinderPeak;
 int main() {
   GraphCreationOptions opts(
-      {GraphCreationOptions::Directed, GraphCreationOptions::Weighted});
+      {GraphCreationOptions::Directed});
 
-  GraphList<int, int> graph(opts);
-  graph.addVertex(1);
-  graph.addVertex(2);
-  graph.addVertex(3);
-  graph.addVertex(4);
-  graph.addVertex(5);
+  // GraphList<int, int> graph(opts);
+  // graph.addVertex(1);
+  // graph.addVertex(2);
+  // graph.addVertex(3);
+  // graph.addVertex(4);
+  // graph.addVertex(5);
 
-  graph.addEdge(1, 3, 10);
-  graph.addEdge(1, 4, 9);
-  graph.addEdge(4, 5, 7);
-  graph.addEdge(1, 2, 6);
+  // graph.addEdge(1, 3, 10);
+  // graph.addEdge(1, 4, 9);
+  // graph.addEdge(4, 5, 7);
+  // graph.addEdge(1, 2, 6);
 
-  GraphList<int, Unweighted> unweighted_graph(opts);
+  GraphCreationOptions opts1(
+  {GraphCreationOptions::Directed});
+  GraphList<int, Unweighted> unweighted_graph(opts1);
+
   unweighted_graph.addVertex(1);
   unweighted_graph.addVertex(2);
   unweighted_graph.addVertex(3);

--- a/examples/ListExample1.cpp
+++ b/examples/ListExample1.cpp
@@ -16,9 +16,13 @@ int main() {
   graph.addEdge(4, 5, 7);
   graph.addEdge(1, 2, 6);
 
-  //For testing unusual behaviour (inserting unweighted edge to weighted graph)
-  graph.addEdge(1, 5);
-  graph.addEdge(6, 2);
+  GraphList<int, Unweighted> unweighted_graph(opts);
+  unweighted_graph.addVertex(1);
+  unweighted_graph.addVertex(2);
+  unweighted_graph.addVertex(3);
+  unweighted_graph.addVertex(4);
+  unweighted_graph.addEdge(1, 2);
+  Unweighted l = unweighted_graph.getEdge(1, 2);
 
   return 0;
 }

--- a/examples/MatrixExample.cpp
+++ b/examples/MatrixExample.cpp
@@ -21,7 +21,6 @@ public:
 };
 int main() {
   GraphCreationOptions options({GraphCreationOptions::Undirected,
-                                GraphCreationOptions::Weighted,
                                 GraphCreationOptions::SelfLoops});
 
   GraphMatrix<CustomVertex, CustomEdge> myGraph(options);

--- a/examples/PrimitiveGraph.cpp
+++ b/examples/PrimitiveGraph.cpp
@@ -6,12 +6,14 @@
 using namespace CinderPeak::PeakStore;
 using namespace CinderPeak;
 
-int main() {
+int main()
+{
   GraphCreationOptions opts(
-      {GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+      {GraphCreationOptions::Undirected});
   GraphMatrix<int, int> graph(opts);
 
-  for (int i = 1; i <= 8; ++i) {
+  for (int i = 1; i <= 8; ++i)
+  {
     graph.addVertex(i);
   }
 
@@ -34,5 +36,4 @@ int main() {
   // graph.addEdge(4, 8, 180);
 
   graph.visualize();
-
 }

--- a/examples/PrimitiveGraph.cpp
+++ b/examples/PrimitiveGraph.cpp
@@ -35,7 +35,4 @@ int main() {
 
   graph.visualize();
 
-  //For testing unusual behaviour (inserting unweighted edge to weighted graph)
-  graph.addEdge(1, 5);
-  graph.addEdge(6, 2);
 }

--- a/examples/extras/PeakExample.cpp
+++ b/examples/extras/PeakExample.cpp
@@ -4,10 +4,9 @@ using namespace CinderPeak::PeakStore;
 using namespace CinderPeak;
 int main() {
   GraphCreationOptions options({GraphCreationOptions::Directed,
-                                GraphCreationOptions::Weighted,
                                 GraphCreationOptions::SelfLoops});
   GraphInternalMetadata metadata("graph_matrix", Traits::isTypePrimitive<int>(),
-                                 Traits::isTypePrimitive<int>());
+                                 Traits::isTypePrimitive<int>(), Traits::isGraphWeighted<int>(), !Traits::isGraphWeighted<int>());
   // metadata.num_edges = 4;s
   // metadata.num_vertices = 2;
 

--- a/examples/extras/PeakExample.cpp
+++ b/examples/extras/PeakExample.cpp
@@ -1,12 +1,13 @@
 #include "PeakStore.hpp"
+#include "Concepts.hpp"
 using namespace CinderPeak::PeakStore;
 using namespace CinderPeak;
 int main() {
   GraphCreationOptions options({GraphCreationOptions::Directed,
                                 GraphCreationOptions::Weighted,
                                 GraphCreationOptions::SelfLoops});
-  GraphInternalMetadata metadata("graph_matrix", isTypePrimitive<int>(),
-                                 isTypePrimitive<int>());
+  GraphInternalMetadata metadata("graph_matrix", Traits::isTypePrimitive<int>(),
+                                 Traits::isTypePrimitive<int>());
   // metadata.num_edges = 4;s
   // metadata.num_vertices = 2;
 

--- a/src/Concepts.hpp
+++ b/src/Concepts.hpp
@@ -1,0 +1,129 @@
+#pragma once
+#include <functional>
+#include <optional>
+#include <string>
+#include <type_traits>
+
+#include "StorageEngine/Utils.hpp" // for Unweighted
+
+namespace CinderPeak::Traits {
+
+// True if EdgeType is Unweighted
+template <typename T> struct is_unweighted : std::is_same<T, Unweighted> {};
+
+template <typename T> constexpr bool is_unweighted_v = is_unweighted<T>::value;
+
+// True if EdgeType is not Unweighted (i.e., weighted)
+template <typename T>
+struct is_weighted : std::integral_constant<bool, !is_unweighted_v<T>> {};
+
+template <typename T> constexpr bool is_weighted_v = is_weighted<T>::value;
+
+// True if EdgeType is numeric
+template <typename T> struct is_numeric_edge : std::is_arithmetic<T> {};
+
+template <typename T>
+constexpr bool is_numeric_edge_v = is_numeric_edge<T>::value;
+
+// True if EdgeType is a pointer
+template <typename T> struct is_pointer_edge : std::is_pointer<T> {};
+
+template <typename T>
+constexpr bool is_pointer_edge_v = is_pointer_edge<T>::value;
+
+// True if EdgeType is optional
+template <typename T> struct is_optional_edge : std::false_type {};
+
+template <typename T>
+struct is_optional_edge<std::optional<T>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_optional_edge_v = is_optional_edge<T>::value;
+
+// True if VertexType is primitive or string
+template <typename T>
+struct is_primitive_or_string
+    : std::disjunction<std::is_arithmetic<T>, std::is_same<T, std::string>> {};
+
+template <typename T>
+constexpr bool is_primitive_or_string_v = is_primitive_or_string<T>::value;
+
+// True if VertexType is enum
+template <typename T> struct is_enum_vertex : std::is_enum<T> {};
+
+template <typename T>
+constexpr bool is_enum_vertex_v = is_enum_vertex<T>::value;
+
+// True if VertexType is comparable (supports <)
+template <typename T, typename = void>
+struct is_comparable_vertex : std::false_type {};
+
+template <typename T>
+struct is_comparable_vertex<
+    T, std::void_t<decltype(std::declval<T>() < std::declval<T>())>>
+    : std::true_type {};
+
+template <typename T>
+constexpr bool is_comparable_vertex_v = is_comparable_vertex<T>::value;
+
+// True if VertexType is hashable (usable in unordered_map/set)
+template <typename T, typename = void> struct is_hashable : std::false_type {};
+
+template <typename T>
+struct is_hashable<T, std::void_t<decltype(std::hash<T>{}(std::declval<T>()))>>
+    : std::true_type {};
+
+template <typename T> constexpr bool is_hashable_v = is_hashable<T>::value;
+
+// Primitive, enum, or string
+template <typename T>
+struct is_primitive_enum_or_string
+    : std::disjunction<is_primitive_or_string<T>, is_enum_vertex<T>> {};
+
+template <typename T>
+constexpr bool is_primitive_enum_or_string_v =
+    is_primitive_enum_or_string<T>::value;
+
+// Weighted numeric edge
+template <typename T>
+struct is_weighted_numeric_edge
+    : std::integral_constant<bool, is_weighted_v<T> && is_numeric_edge_v<T>> {};
+
+template <typename T>
+constexpr bool is_weighted_numeric_edge_v = is_weighted_numeric_edge<T>::value;
+
+// Unweighted + integral vertex
+template <typename V, typename E>
+struct is_unweighted_integral_vertex
+    : std::integral_constant<bool, is_unweighted_v<E> &&
+                                       std::is_integral<V>::value> {};
+
+template <typename V, typename E>
+constexpr bool is_unweighted_integral_vertex_v =
+    is_unweighted_integral_vertex<V, E>::value;
+
+// Runtime helper
+template <typename T> constexpr bool isTypePrimitive() {
+  if constexpr (is_primitive_or_string_v<T>) {
+    return true;
+  }
+  return false;
+}
+
+#define STATIC_ASSERT_WEIGHTED(E)                                              \
+  static_assert(CinderPeak::Traits::is_weighted_v<E>,                          \
+                "EdgeType must be weighted (not Unweighted).")
+
+#define STATIC_ASSERT_UNWEIGHTED(E)                                            \
+  static_assert(CinderPeak::Traits::is_unweighted_v<E>,                        \
+                "EdgeType must be Unweighted.")
+
+#define STATIC_ASSERT_NUMERIC_EDGE(E)                                          \
+  static_assert(CinderPeak::Traits::is_numeric_edge_v<E>,                      \
+                "EdgeType must be numeric for this algorithm.")
+
+#define STATIC_ASSERT_COMPARABLE_VERTEX(V)                                     \
+  static_assert(CinderPeak::Traits::is_comparable_vertex_v<V>,                 \
+                "VertexType must support operator< for this algorithm.")
+
+} // namespace CinderPeak::Traits

--- a/src/Concepts.hpp
+++ b/src/Concepts.hpp
@@ -109,6 +109,12 @@ template <typename T> constexpr bool isTypePrimitive() {
   }
   return false;
 }
+template <typename T> constexpr bool isGraphWeighted() {
+  if constexpr (is_weighted_v<T>) {
+    return true;
+  }
+  return false;
+}
 
 #define STATIC_ASSERT_WEIGHTED(E)                                              \
   static_assert(CinderPeak::Traits::is_weighted_v<E>,                          \

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -17,7 +17,9 @@ public:
                 CinderPeak::GraphCreationOptions::getDefaultCreateOptions()) {
     CinderPeak::PeakStore::GraphInternalMetadata metadata(
         "graph_list", CinderPeak::Traits::isTypePrimitive<VertexType>(),
-        CinderPeak::Traits::isTypePrimitive<EdgeType>());
+        CinderPeak::Traits::isTypePrimitive<EdgeType>(),
+        CinderPeak::Traits::isGraphWeighted<EdgeType>(),
+        !CinderPeak::Traits::isGraphWeighted<EdgeType>());
     peak_store = std::make_unique<
         CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>>(metadata,
                                                                 options);

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Concepts.hpp"
 #include "StorageEngine/Utils.hpp"
 #include <iostream>
 namespace CinderPeak {
@@ -15,8 +16,8 @@ public:
   GraphList(const GraphCreationOptions &options =
                 CinderPeak::GraphCreationOptions::getDefaultCreateOptions()) {
     CinderPeak::PeakStore::GraphInternalMetadata metadata(
-        "graph_list", isTypePrimitive<VertexType>(),
-        isTypePrimitive<EdgeType>());
+        "graph_list", CinderPeak::Traits::isTypePrimitive<VertexType>(),
+        CinderPeak::Traits::isTypePrimitive<EdgeType>());
     peak_store = std::make_unique<
         CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>>(metadata,
                                                                 options);
@@ -30,33 +31,21 @@ public:
     }
   }
 
-  // Combined addEdge() overloads into one
-  void addEdge(const VertexType &src, const VertexType &dest,
-               const EdgeType &weight = EdgeType()) {
-    auto ctx = peak_store->getContext(); PeakStatus resp = PeakStatus::OK();
-    
-    bool isWeighted = ctx->create_options->hasOption(GraphCreationOptions::Weighted);
-    if (isWeighted && weight == EdgeType()) {
-      LOG_CRITICAL(
-        "Cannot call unweighted addEdge on a weighted graph, missing weight");
-      return;
-    } 
-    if (!(isWeighted || weight == EdgeType())) {
-      LOG_CRITICAL(
-        "Cannot call weighted addEdge on a unweighted graph, extra weight");
-      return;
-    } 
-
-    if (isWeighted) {
-      resp = peak_store->addEdge(src, dest, weight);
-    } else {
-      resp = peak_store->addEdge(src, dest);
-    }
-
-    if (!resp.isOK()) {
+  template <typename E = EdgeType>
+  auto addEdge(const VertexType &src, const VertexType &dest)
+      -> std::enable_if_t<CinderPeak::Traits::is_unweighted_v<E>, void> {
+    auto resp = peak_store->addEdge(src, dest);
+    if (!resp.isOK())
       Exceptions::handle_exception_map(resp);
-      return;
-    }
+  }
+
+  template <typename E = EdgeType>
+  auto addEdge(const VertexType &src, const VertexType &dest,
+               const EdgeType &weight)
+      -> std::enable_if_t<!CinderPeak::Traits::is_unweighted_v<E>, void> {
+    auto resp = peak_store->addEdge(src, dest, weight);
+    if (!resp.isOK())
+      Exceptions::handle_exception_map(resp);
   }
 
   EdgeType getEdge(const VertexType &src, const VertexType &dest) {

--- a/src/GraphMatrix.hpp
+++ b/src/GraphMatrix.hpp
@@ -55,7 +55,9 @@ public:
                   CinderPeak::GraphCreationOptions::getDefaultCreateOptions()) {
     CinderPeak::PeakStore::GraphInternalMetadata metadata(
         "graph_matrix", CinderPeak::Traits::isTypePrimitive<VertexType>(),
-        CinderPeak::Traits::isTypePrimitive<EdgeType>());
+        CinderPeak::Traits::isTypePrimitive<EdgeType>(),
+        CinderPeak::Traits::isGraphWeighted<EdgeType>(),
+        !CinderPeak::Traits::isGraphWeighted<EdgeType>());
     peak_store = std::make_unique<
         CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>>(metadata,
                                                                 options);

--- a/src/GraphMatrix.hpp
+++ b/src/GraphMatrix.hpp
@@ -1,7 +1,9 @@
 #pragma once
+#include "Concepts.hpp"
 #include "StorageEngine/Utils.hpp"
 #include <iostream>
 #include <memory>
+#include <type_traits>
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class PeakStore;
@@ -52,8 +54,8 @@ public:
   GraphMatrix(const GraphCreationOptions &options =
                   CinderPeak::GraphCreationOptions::getDefaultCreateOptions()) {
     CinderPeak::PeakStore::GraphInternalMetadata metadata(
-        "graph_matrix", isTypePrimitive<VertexType>(),
-        isTypePrimitive<EdgeType>());
+        "graph_matrix", CinderPeak::Traits::isTypePrimitive<VertexType>(),
+        CinderPeak::Traits::isTypePrimitive<EdgeType>());
     peak_store = std::make_unique<
         CinderPeak::PeakStore::PeakStore<VertexType, EdgeType>>(metadata,
                                                                 options);
@@ -66,34 +68,20 @@ public:
       return;
     }
   }
-
-  // Combined addEdge() overloads into one
-  void addEdge(const VertexType &src, const VertexType &dest,
-               const EdgeType &weight = EdgeType()) {
-    auto ctx = peak_store->getContext(); PeakStatus resp = PeakStatus::OK();
-
-    bool isWeighted = ctx->create_options->hasOption(GraphCreationOptions::Weighted);
-    if (isWeighted && weight == EdgeType()) {
-      LOG_CRITICAL(
-        "Cannot call unweighted addEdge on a weighted graph, missing weight");
-      return;
-    } 
-    if (!(isWeighted || weight == EdgeType())) {
-      LOG_CRITICAL(
-        "Cannot call weighted addEdge on a unweighted graph, extra weight");
-      return;
-    } 
-
-    if (isWeighted) {
-      resp = peak_store->addEdge(src, dest, weight);
-    } else {
-      resp = peak_store->addEdge(src, dest);
-    }
-
-    if (!resp.isOK()) {
+  template <typename E = EdgeType>
+  auto addEdge(const VertexType &src, const VertexType &dest)
+      -> std::enable_if_t<CinderPeak::Traits::is_unweighted_v<E>, void> {
+    auto resp = peak_store->addEdge(src, dest);
+    if (!resp.isOK())
       Exceptions::handle_exception_map(resp);
-      return;
-    }
+  }
+  template <typename E = EdgeType>
+  auto addEdge(const VertexType &src, const VertexType &dest,
+               const EdgeType &weight)
+      -> std::enable_if_t<CinderPeak::Traits::is_weighted_v<E>, void> {
+    auto resp = peak_store->addEdge(src, dest, weight);
+    if (!resp.isOK())
+      Exceptions::handle_exception_map(resp);
   }
 
   EdgeType getEdge(const VertexType &src, const VertexType &dest) const {
@@ -107,9 +95,7 @@ public:
   void visualize() { LOG_INFO("Called GraphMatrix:visualize"); }
 
   // Helper method to call getGraphStatistics() from Peakstore
-  std::string getGraphStatistics() {
-    return peak_store->getGraphStatistics();
-  }
+  std::string getGraphStatistics() { return peak_store->getGraphStatistics(); }
 
   EdgeAccessor<VertexType, EdgeType> operator[](const VertexType &src) {
     return EdgeAccessor<VertexType, EdgeType>(*this, src);

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -47,48 +47,50 @@ public:
     LOG_INFO("Successfully initialized context object.");
   }
 
-PeakStatus addEdge(const VertexType &src, const VertexType &dest,
-                   const EdgeType &weight = EdgeType()) {
-    bool isWeighted = ctx->create_options->hasOption(GraphCreationOptions::Weighted);
+  PeakStatus addEdge(const VertexType &src, const VertexType &dest,
+                     const EdgeType &weight = EdgeType()) {
+    bool isWeighted =
+        ctx->create_options->hasOption(GraphCreationOptions::Weighted);
     bool edgeExists;
     PeakStatus status = PeakStatus::OK();
 
     if (isWeighted) {
-        edgeExists = ctx->active_storage->impl_doesEdgeExist(src, dest, weight);
+      edgeExists = ctx->active_storage->impl_doesEdgeExist(src, dest, weight);
     } else {
-        edgeExists = ctx->active_storage->impl_doesEdgeExist(src, dest);
+      edgeExists = ctx->active_storage->impl_doesEdgeExist(src, dest);
     }
 
     if (edgeExists) {
-        if ((isWeighted && !ctx->create_options->hasOption(GraphCreationOptions::ParallelEdges)) || !isWeighted) {
-            LOG_DEBUG("Edge already exists");
-            return PeakStatus::EdgeAlreadyExists();
-        }
+      if ((isWeighted && !ctx->create_options->hasOption(
+                             GraphCreationOptions::ParallelEdges)) ||
+          !isWeighted) {
+        LOG_DEBUG("Edge already exists");
+        return PeakStatus::EdgeAlreadyExists();
+      }
     }
 
     if (isWeighted) {
-        LOG_INFO("Called weighted PeakStore::addEdge");
-        status = ctx->active_storage->impl_addEdge(src, dest, weight);
+      LOG_INFO("Called weighted PeakStore::addEdge");
+      status = ctx->active_storage->impl_addEdge(src, dest, weight);
     } else {
-        LOG_INFO("Called unweighted PeakStore::addEdge");
-        status = ctx->active_storage->impl_addEdge(src, dest);
+      LOG_INFO("Called unweighted PeakStore::addEdge");
+      status = ctx->active_storage->impl_addEdge(src, dest);
     }
 
     if (!status.isOK()) {
-        return status;
+      return status;
     }
 
     if (ctx->active_storage->impl_doesEdgeExist(dest, src)) {
-        ctx->metadata->num_parallel_edges++;
+      ctx->metadata->num_parallel_edges++;
     }
     if (src == dest) {
-        ctx->metadata->num_self_loops++;
+      ctx->metadata->num_self_loops++;
     }
     ctx->metadata->num_edges++;
 
     return status;
-}
-
+  }
 
   std::pair<EdgeType, PeakStatus> getEdge(const VertexType &src,
                                           const VertexType &dest) {
@@ -120,22 +122,25 @@ PeakStatus addEdge(const VertexType &src, const VertexType &dest,
   getContext() const {
     return ctx;
   }
-  
+
   // Method to get a summary string of statistics
-  std::string getGraphStatistics() {  
+  std::string getGraphStatistics() {
     std::stringstream ss;
 
     if (ctx->metadata->num_vertices > 1) {
-      float directed_density = (float)ctx->metadata->num_edges / (ctx->metadata->num_vertices * (ctx->metadata->num_vertices - 1));
+      float directed_density =
+          (float)ctx->metadata->num_edges /
+          (ctx->metadata->num_vertices * (ctx->metadata->num_vertices - 1));
       if (ctx->create_options->hasOption(GraphCreationOptions::Directed))
         ctx->metadata->density = directed_density;
       if (ctx->create_options->hasOption(GraphCreationOptions::Undirected))
-        ctx->metadata->density = 2*directed_density;
-    }  
+        ctx->metadata->density = 2 * directed_density;
+    }
     ss << "=== Graph Statistics ===" << std::endl;
     ss << "Vertices: " << ctx->metadata->num_vertices << std::endl;
-    ss << "Edges: " << ctx->metadata->num_edges << std::endl;     
-    ss << "Density: " << std::fixed << std::setprecision(2) << ctx->metadata->density << std::endl;
+    ss << "Edges: " << ctx->metadata->num_edges << std::endl;
+    ss << "Density: " << std::fixed << std::setprecision(2)
+       << ctx->metadata->density << std::endl;
     ss << "Self-loops: " << ctx->metadata->num_self_loops << std::endl;
     ss << "Parallel edges: " << ctx->metadata->num_parallel_edges << std::endl;
     return ss.str();

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -49,8 +49,7 @@ public:
 
   PeakStatus addEdge(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight = EdgeType()) {
-    bool isWeighted =
-        ctx->create_options->hasOption(GraphCreationOptions::Weighted);
+    bool isWeighted = ctx->metadata->isGraphWeighted();
     bool edgeExists;
     PeakStatus status = PeakStatus::OK();
 
@@ -59,7 +58,6 @@ public:
     } else {
       edgeExists = ctx->active_storage->impl_doesEdgeExist(src, dest);
     }
-
     if (edgeExists) {
       if ((isWeighted && !ctx->create_options->hasOption(
                              GraphCreationOptions::ParallelEdges)) ||

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -18,11 +18,9 @@ class GraphCreationOptions {
 public:
   enum GraphType {
     Directed = 0,
-    Weighted,
     SelfLoops,
     ParallelEdges,
     Undirected,
-    Unweighted,
   };
   GraphCreationOptions(std::initializer_list<GraphType> graph_types) {
     for (auto type : graph_types) {
@@ -159,8 +157,10 @@ public:
   const std::string graph_type;
   bool is_vertex_type_primitive;
   bool is_edge_type_primitive;
+  bool is_graph_weighted;
+  bool is_graph_unweighted;
   GraphInternalMetadata(const std::string &graph_type, bool vertex_tp_p,
-                        bool edge_tp_p)
+                        bool edge_tp_p, bool weighted, bool unweighted)
       : graph_type(graph_type), is_vertex_type_primitive(vertex_tp_p),
         is_edge_type_primitive(edge_tp_p) {
     num_vertices = 0;
@@ -168,7 +168,11 @@ public:
     density = 0.0; // Initialized with float value
     num_self_loops = 0;
     num_parallel_edges = 0;
+    is_graph_weighted = weighted;
+    is_graph_unweighted = unweighted;
   }
+  const bool isGraphWeighted() { return is_graph_weighted; }
+  const bool isGraphUnweighted() { return is_graph_unweighted; }
   // // default ctor for basic testing, this has to be removed later on.
   // GraphInternalMetadata() {}
 };

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -75,12 +75,13 @@ template <typename VertexType, typename EdgeType> struct PairHasher {
            (EdgeHasher<EdgeType>{}(p.second) << 1);
   }
 };
-template <typename T>
-struct is_primitive_or_string
-    : std::disjunction<std::is_arithmetic<T>, std::is_same<T, std::string>> {};
-template <typename T>
-inline constexpr bool is_primitive_or_string_v =
-    is_primitive_or_string<T>::value;
+// template <typename T>
+// struct is_primitive_or_string
+//     : std::disjunction<std::is_arithmetic<T>, std::is_same<T, std::string>>
+//     {};
+// template <typename T>
+// inline constexpr bool is_primitive_or_string_v =
+//     is_primitive_or_string<T>::value;
 
 std::string __generate_vertex_name() {
   std::random_device rd;
@@ -100,12 +101,12 @@ std::string __generate_vertex_name() {
   ss << "_" << duration;
   return ss.str();
 }
-template <typename T> bool isTypePrimitive() {
-  if constexpr (is_primitive_or_string_v<T>) {
-    return true;
-  }
-  return false;
-}
+// template <typename T> bool isTypePrimitive() {
+//   if constexpr (is_primitive_or_string_v<T>) {
+//     return true;
+//   }
+//   return false;
+// }
 class CinderVertex {
 public:
   size_t __id_;
@@ -203,5 +204,11 @@ inline void handle_exception_map(const PeakStatus &status) {
   }
 }
 } // namespace Exceptions
+struct Unweighted {};
+
+// Always equal, since weights don’t matter
+inline bool operator==(const Unweighted &, const Unweighted &) noexcept {
+  return true;
+}
 
 } // namespace CinderPeak

--- a/src/StorageInterface.hpp
+++ b/src/StorageInterface.hpp
@@ -9,7 +9,7 @@ public:
   virtual const PeakStatus impl_addVertex(const VertexType &src) = 0;
 
   // No longer needed as the weighted overload handles unweighted edges via
-  // default EdgeType(). 
+  // default EdgeType().
   // virtual const PeakStatus impl_addEdge(const VertexType &src,
   //                                       const VertexType &dest) = 0;
 

--- a/tests/Statistics.cpp
+++ b/tests/Statistics.cpp
@@ -50,7 +50,7 @@ protected:
 
 // Simple large dense graph test - 1000 vertices, lots of edges
 TEST_F(GraphStatisticsTest, LargeDenseGraph) {
-    GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+    GraphCreationOptions opts({GraphCreationOptions::Undirected});
     GraphMatrix<int, int> graph(opts);
     
     const int num_vertices = 1000;
@@ -130,7 +130,7 @@ TEST_F(GraphStatisticsTest, MediumGraphs) {
     };
     
     for (auto config : configs) {
-        GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+        GraphCreationOptions opts({GraphCreationOptions::Undirected});
         GraphMatrix<int, int> graph(opts);
         
         int vertices = config.first;
@@ -167,7 +167,7 @@ TEST_F(GraphStatisticsTest, MediumGraphs) {
 
 // Original test case (kept for regression)
 TEST_F(GraphStatisticsTest, OriginalTest) {
-    GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+    GraphCreationOptions opts({GraphCreationOptions::Undirected});
     GraphMatrix<int, int> graph(opts);
     
     for (int i = 1; i <= 8; ++i) {
@@ -200,7 +200,7 @@ TEST_F(GraphStatisticsTest, OriginalTest) {
 TEST_F(GraphStatisticsTest, EdgeCases) {
     // Empty graph
     {
-        GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+        GraphCreationOptions opts({GraphCreationOptions::Undirected});
         GraphMatrix<int, int> empty_graph(opts);
         
         std::string stats = empty_graph.getGraphStatistics();
@@ -210,7 +210,7 @@ TEST_F(GraphStatisticsTest, EdgeCases) {
     
     // Single vertex with self-loop
     {
-        GraphCreationOptions opts({GraphCreationOptions::Weighted, GraphCreationOptions::Undirected});
+        GraphCreationOptions opts({GraphCreationOptions::Undirected});
         GraphMatrix<int, int> single_graph(opts);
         
         single_graph.addVertex(1);


### PR DESCRIPTION
## Which issue does this PR close?
Closes #69 

This PR adds compile time safety checks to both ``GraphList`` and ``GraphMatrix`` API classes by using the newly added type traits in ``Concepts.hpp`` using SFINAE (substitution failure is not an error).

This PR also adds the support for proper building of ``GraphInternalMetadata`` which acts as a snapshot of the graph and contains important details about the graph properties, these properties can be checked at any time before performing any action. The ``Weighted`` and ``Unweighted`` graph creation options are also removed as they can be inferred by the template specializations at the compile time, and the corresponding boolean flags are set in the ``GraphInternalMetadata``.

