### PR TITLE
feat(storage): Added Thread Safety to AdjacencyList Storage Format

### DIFF
--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -2,19 +2,19 @@
 #include "Concepts.hpp"
 #include "StorageEngine/GraphContext.hpp"
 #include "Utils.hpp"
-#include <shared_mutex>
 #include <memory>
+#include <shared_mutex>
 namespace CinderPeak {
 template <typename, typename> class PeakStorageInterface;
 
 namespace PeakStore {
 
 /**
- * @brief Thread safety note: This class uses a single shared mutex for synchronization.
- *        Do not call these methods from within code that already holds locks
- *        on this object, as it may cause deadlocks.
- *        For nested operations, use the provided bulk methods instead.
- *        E.g do not try to call addEdge from addEdges, it will cause a deadlock.
+ * @brief Thread safety note: This class uses a single shared mutex for
+ * synchronization. Do not call these methods from within code that already
+ * holds locks on this object, as it may cause deadlocks. For nested operations,
+ * use the provided bulk methods instead. E.g do not try to call addEdge from
+ * addEdges, it will cause a deadlock.
  */
 template <typename VertexType, typename EdgeType>
 class AdjacencyList
@@ -203,7 +203,7 @@ public:
   impl_getEdge(const VertexType &src, const VertexType &dest) override {
     // For read operation - acquire a shared lock
     std::shared_lock<std::shared_mutex> lock(_mtx);
-    
+
     auto it = _adj_list.find(src);
     if (it == _adj_list.end()) {
       return std::make_pair(EdgeType(), PeakStatus::VertexNotFound());
@@ -220,7 +220,7 @@ public:
   impl_getNeighbors(const VertexType &vertex) const {
     // For read operation - acquire a shared lock
     std::shared_lock<std::shared_mutex> lock(_mtx);
-    
+
     auto it = _adj_list.find(vertex);
     if (it == _adj_list.end()) {
       static const std::vector<std::pair<VertexType, EdgeType>> empty_vec;
@@ -235,7 +235,7 @@ public:
                           const EdgeType &weight) override {
     // For read operation - acquire a shared lock
     std::shared_lock<std::shared_mutex> lock(_mtx);
-    
+
     auto it = _adj_list.find(src);
     if (it == _adj_list.end()) {
       return false;
@@ -255,7 +255,7 @@ public:
   void print_adj_list() {
     // For read operation - acquire a shared lock
     std::shared_lock<std::shared_mutex> lock(_mtx);
-    
+
     for (const auto &[first, second] : _adj_list) {
       std::cout << "Vertex: " << first << "'s adj list:\n";
       for (const auto &pr : second) {

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -8,6 +8,14 @@ namespace CinderPeak {
 template <typename, typename> class PeakStorageInterface;
 
 namespace PeakStore {
+
+/**
+ * @brief Thread safety note: This class uses a single shared mutex for synchronization.
+ *        Do not call these methods from within code that already holds locks
+ *        on this object, as it may cause deadlocks.
+ *        For nested operations, use the provided bulk methods instead.
+ *        E.g do not try to call addEdge from addEdges, it will cause a deadlock.
+ */
 template <typename VertexType, typename EdgeType>
 class AdjacencyList
     : public CinderPeak::PeakStorageInterface<VertexType, EdgeType> {

--- a/tests/AdjacencyShard.cpp
+++ b/tests/AdjacencyShard.cpp
@@ -556,7 +556,6 @@ TEST_F(AdjacencyListThreadTest, ConcurrentReadWriteOperations) {
         thread.join();
     }
     
-    // Verify operations completed without errors
     EXPECT_EQ(readOperations.load(), numReaderThreads * operationsPerThread * 2);
     EXPECT_EQ(writeOperations.load(), numWriterThreads * operationsPerThread);
     EXPECT_EQ(readErrors.load(), 0);
@@ -601,6 +600,5 @@ TEST_F(AdjacencyListThreadTest, ConcurrentBulkOperations) {
         thread.join();
     }
     
-    // Each thread should have 2 successful operations (vertices + edges)
     EXPECT_EQ(successCount.load(), numThreads * 2);
 }


### PR DESCRIPTION
This PR adds thread safety to `PeakStore::AdjacencyList`by introducing coarse-grained synchronization with `std::shared_mutex` (issue #65 ). Write operations such as `impl_addVertex`, `impl_addVertices`,  `impl_addEdge`  and `impl_addEdges` now use `std::unique_lock` for exclusive access, while read operations like `impl_getEdge`, `impl_getNeighbors`, `impl_doesEdgeExist`, and `print_adj_list` use `std::shared_lock` to allow concurrent reads. This ensures data integrity under concurrent workloads, prevents race conditions or memory corruption, and enables safe multi-threaded access to the storage engine.

### Changes made:

-  `AdjacencyList.hpp` -  Modified methods to use appropriate locking for safe concurrent access.
-  `AdjacencyShard.cpp` - Added tests to validate the thread safety implementation.