### PR TITLE
feat(GraphList): added ``clearEdges()`` method to remove all the edges

### DIFF
--- a/examples/ListExample1.cpp
+++ b/examples/ListExample1.cpp
@@ -25,15 +25,25 @@ int main() {
   graph.addVertex(1);
   graph.addVertex(2);
   graph.addVertex(3);
-  std::cout << "Number of vertices: " << graph.numVertices()
-            << "\n"; // Testing numVertices implementation
-
   graph.addVertex(4);
   graph.addVertex(5);
   graph.addEdge(1, 3, 5);
   graph.updateEdge(1, 3, 10);
+  graph.addEdge(2, 3, 15);
+  graph.addEdge(4, 2, 52);
+  graph.addEdge(5, 3, 53);
+
   std::cout << "Number of vertices: " << graph.numVertices()
-            << "\n"; // Testing numVertices implementation
+            << "\n"; // Number of vertices before clearing
+  std::cout << "Number of edges: " << graph.numEdges()
+            << "\n"; // Number of edges before clearing
+
+  graph.clearEdges();
+
+  std::cout << "Number of vertices: " << graph.numVertices()
+            << "\n"; // Number of vertices after clearing
+  std::cout << "Number of edges: " << graph.numEdges()
+            << "\n"; // Number of edges after clearing
 
   // Graph 2
   GraphCreationOptions opts1({GraphCreationOptions::Directed});

--- a/examples/ListExample1.cpp
+++ b/examples/ListExample1.cpp
@@ -30,8 +30,7 @@ int main() {
   auto [v1, i1] = graph.addVertex(1);
   auto [v2, i2] = graph.addVertex(2);
   auto [v3, i3] = graph.addVertex(3);
-  std::cout << "Number of vertices: " << graph.numVertices()
-            << "\n";
+  std::cout << "Number of vertices: " << graph.numVertices() << "\n";
   auto [v4, i4] = graph.addVertex(4);
   auto [v5, i5] = graph.addVertex(5);
 

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -41,6 +41,15 @@ public:
     }
   }
 
+  // Helper method to call clearEdges from PeakStore
+  void clearEdges() {
+    auto resp = peak_store->clearEdges();
+    if (!resp.isOK()) {
+      Exceptions::handle_exception_map(resp);
+      return;
+    }
+  }
+
   template <typename E = EdgeType>
   auto addEdge(const VertexType &src, const VertexType &dest)
       -> std::enable_if_t<CinderPeak::Traits::is_unweighted_v<E>, void> {

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -138,6 +138,16 @@ public:
     return status;
   }
 
+  // Helper method to call impl_clearEdges from AdjacencyList
+  PeakStatus clearEdges() {
+    LOG_INFO("Called peakStore:clearEdges");
+    auto status = ctx->active_storage->impl_clearEdges();
+    if (status.isOK()) {
+      ctx->metadata->num_edges = 0;
+    }
+    return status;
+  }
+
   static void setConsoleLogging(const bool toggle) {
     Logger::enableConsoleLogging = toggle;
   }

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -148,6 +148,16 @@ public:
     return peak_status;
   }
 
+  const PeakStatus impl_clearEdges() {
+    auto it = _adj_list.begin();
+
+    while (it != _adj_list.end()) {
+      it->second = std::vector<std::pair<VertexType, EdgeType>>();
+      it++;
+    }
+    return PeakStatus::OK();
+  }
+
   const PeakStatus impl_updateEdge(const VertexType &src,
                                    const VertexType &dest,
                                    const EdgeType &newWeight) {

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -149,11 +149,8 @@ public:
   }
 
   const PeakStatus impl_clearEdges() {
-    auto it = _adj_list.begin();
-
-    while (it != _adj_list.end()) {
-      it->second = std::vector<std::pair<VertexType, EdgeType>>();
-      it++;
+    for (auto &edge : _adj_list) {
+      edge.second.clear();
     }
     return PeakStatus::OK();
   }

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -208,8 +208,6 @@ public:
     return PeakStatus::OK();
   }
 
-  const PeakStatus impl_clearEdges() { return PeakStatus::OK(); }
-
   const PeakStatus impl_addEdge(const VertexType &src, const VertexType &dest,
                                 const EdgeType &weight = EdgeType()) override {
     if (!vertex_to_index.count(src) || !vertex_to_index.count(dest)) {
@@ -255,6 +253,20 @@ public:
 
     size_t idx = std::distance(csr_col_vals.begin(), it);
     csr_weights[idx] = newWeight;
+    return PeakStatus::OK();
+  }
+
+  const PeakStatus impl_clearEdges() override {
+    clearCOOArrays();
+
+    if (is_built) {
+      std::fill(csr_row_offsets.begin(), csr_row_offsets.end(), 0);
+      csr_col_vals.clear();
+      csr_weights.clear();
+      csr_col_vals.shrink_to_fit();
+      csr_weights.shrink_to_fit();
+    }
+
     return PeakStatus::OK();
   }
 

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -208,6 +208,8 @@ public:
     return PeakStatus::OK();
   }
 
+  const PeakStatus impl_clearEdges() { return PeakStatus::OK(); }
+
   const PeakStatus impl_addEdge(const VertexType &src, const VertexType &dest,
                                 const EdgeType &weight = EdgeType()) override {
     if (!vertex_to_index.count(src) || !vertex_to_index.count(dest)) {

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -269,6 +269,7 @@ public:
     }
 
     return PeakStatus::OK();
+  }
 
   // Method to check whether a vertex exists or not
   bool impl_hasVertex(const VertexType &v) override {

--- a/src/StorageInterface.hpp
+++ b/src/StorageInterface.hpp
@@ -9,6 +9,9 @@ public:
   virtual const PeakStatus impl_addVertex(const VertexType &src) = 0;
   virtual const PeakStatus impl_removeVertex(const VertexType &vtx) = 0;
 
+  // Method to remove all Edges
+  virtual const PeakStatus impl_clearEdges() = 0;
+
   virtual const PeakStatus
   impl_addEdge(const VertexType &src, const VertexType &dest,
                const EdgeType &weight = EdgeType()) = 0;

--- a/tests/AdjacencyShard.cpp
+++ b/tests/AdjacencyShard.cpp
@@ -251,6 +251,28 @@ TEST_F(AdjacencyListTest, AddEdgesMixedTypes) {
   EXPECT_FLOAT_EQ(stringGraph.impl_getEdge("A", "C").first, 3.14f);
 }
 
+// Test to validate clearEdges functionality
+TEST_F(AdjacencyListTest, ClearEdges) {
+  EXPECT_TRUE(intGraph.impl_addEdge(1, 2).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(2, 3).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(3, 4).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(4, 5).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(5, 3).isOK());
+
+  EXPECT_TRUE(intGraph.impl_clearEdges().isOK());
+
+  EXPECT_FALSE(intGraph.impl_getEdge(1, 2).second.isOK());
+  EXPECT_FALSE(intGraph.impl_getEdge(2, 3).second.isOK());
+  EXPECT_FALSE(intGraph.impl_getEdge(4, 5).second.isOK());
+  EXPECT_FALSE(intGraph.impl_getEdge(3, 4).second.isOK());
+  EXPECT_FALSE(intGraph.impl_getEdge(5, 3).second.isOK());
+
+  // Following can be replaced
+  EXPECT_FALSE(intGraph.impl_addVertex(1).isOK());
+  EXPECT_FALSE(intGraph.impl_addVertex(2).isOK());
+  EXPECT_FALSE(intGraph.impl_addVertex(3).isOK());
+}
+
 //
 // 3. Edge Retrieval
 //

--- a/tests/HybridCSRCOO.cpp
+++ b/tests/HybridCSRCOO.cpp
@@ -123,6 +123,33 @@ TEST_F(HybridCSRCOOTest, EdgeAdditionWithNonExistentVertices) {
   EXPECT_FALSE(status3.isOK());
 }
 
+// Added test to validate clearEdges functionality
+TEST_F(HybridCSRCOOTest, ClearEdges) {
+  std::vector<int> vertices = {1, 2, 3, 4, 5};
+  for (int v : vertices) {
+    graph->impl_addVertex(v);
+  }
+
+  EXPECT_TRUE(graph->impl_addEdge(1, 2).isOK());
+  EXPECT_TRUE(graph->impl_addEdge(2, 3).isOK());
+  EXPECT_TRUE(graph->impl_addEdge(1, 3).isOK());
+  EXPECT_TRUE(graph->impl_addEdge(4, 5).isOK());
+  EXPECT_TRUE(graph->impl_addEdge(1, 5).isOK());
+
+  EXPECT_TRUE(graph->impl_getEdge(1, 2).second.isOK());
+  EXPECT_TRUE(graph->impl_getEdge(4, 5).second.isOK());
+
+  EXPECT_TRUE(graph->impl_clearEdges().isOK());
+
+  EXPECT_FALSE(graph->impl_getEdge(1, 2).second.isOK());
+  EXPECT_FALSE(graph->impl_getEdge(4, 5).second.isOK());
+
+  // Following can be modified using hasVertex method
+  EXPECT_FALSE(graph->impl_addVertex(1).isOK());
+  EXPECT_FALSE(graph->impl_addVertex(2).isOK());
+  EXPECT_FALSE(graph->impl_addVertex(4).isOK());
+}
+
 TEST_F(HybridCSRCOOTest, EdgeRetrievalAdvanced) {
   for (int i = 1; i <= 5; ++i) {
     graph->impl_addVertex(i);


### PR DESCRIPTION
This PR implements the `impl_clearEdges()` method (issue #78 ) in both `AdjacencyList.hpp` and `HybridCSR_COO.hpp` to remove all the edge while keeping all vertices intact.

### Changes made:

- `AdjacencyList.hpp`, `HybridCSR_COO.hpp`  - Added `impl_clearEdges()` method to remove all edges.
- `PeakStore.hpp` - Added helper method to call `impl_clearEdges()` method from AdjacencyList.
- `GraphList.hpp` - Added helper method to call `clearEdges()` method from PeakStore.
- `StorageInterface.hpp`  - Added declaration for `impl_clearEdges()` method.
- `AdjacencyShard.cpp`, `HybridCSRCOO.cpp`, `ListExample1.cpp` - Modified to add new tests to validate clearEdges functionality.