### PR TITLE
feat(GraphList): added ``removeEdge()`` method to remove an edge

### DIFF
--- a/examples/ListExample1.cpp
+++ b/examples/ListExample1.cpp
@@ -45,6 +45,12 @@ int main() {
   if (graph.hasVertex(6))
     std::cout << "Vertex 6 exists.\n";
 
+  std::cout << "Does edge (5,3) exists: " << graph.getEdge(5, 3).second
+            << "\n"; // Check edge existence
+  graph.removeEdge(5, 3);
+  std::cout << "Does edge (5,3) exists: " << graph.getEdge(5, 3).second
+            << "\n"; // Check edge existence after removal
+
   std::cout << "Number of vertices: " << graph.numVertices()
             << "\n"; // Number of vertices before clearing
   std::cout << "Number of edges: " << graph.numEdges()

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -70,6 +70,15 @@ public:
     return true;
   }
 
+  bool removeEdge(const VertexType &src, const VertexType &dest) {
+    auto resp = peak_store->removeEdge(src, dest);
+    if (!resp.isOK()) {
+      Exceptions::handle_exception_map(resp);
+      return false;
+    }
+    return true;
+  }
+
   // Helper method to call clearEdges from PeakStore
   void clearEdges() {
     auto resp = peak_store->clearEdges();

--- a/src/GraphList.hpp
+++ b/src/GraphList.hpp
@@ -38,6 +38,8 @@ private:
   // per typedef.
   using GetEdgeResult = std::pair<std::optional<Edge_t>, bool>;
 
+  using RemoveEdgeResult = std::pair<std::optional<Edge_t>, bool>;
+
 public:
   GraphList(const GraphCreationOptions &options =
                 GraphCreationOptions::getDefaultCreateOptions(),
@@ -70,13 +72,13 @@ public:
     return true;
   }
 
-  bool removeEdge(const VertexType &src, const VertexType &dest) {
-    auto resp = peak_store->removeEdge(src, dest);
-    if (!resp.isOK()) {
-      Exceptions::handle_exception_map(resp);
-      return false;
+  RemoveEdgeResult removeEdge(const VertexType &src, const VertexType &dest) {
+    auto [data, status] = peak_store->removeEdge(src, dest);
+    if (!status.isOK()) {
+      Exceptions::handle_exception_map(status);
+      return {std::nullopt, false};
     }
-    return true;
+    return {std::make_optional(data), true};
   }
 
   // Helper method to call clearEdges from PeakStore

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -92,13 +92,13 @@ public:
     return status;
   }
 
-  PeakStatus removeEdge(const VertexType &src, const VertexType &dest) {
+  std::pair<EdgeType, PeakStatus> removeEdge(const VertexType &src,
+                                             const VertexType &dest) {
     LOG_INFO("Called adjacency:removeEdge()");
-    if (PeakStatus resp = ctx->active_storage->impl_removeEdge(src, dest);
-        !resp.isOK())
-      return resp;
-    ctx->metadata->updateEdgeCount(UpdateOp::Remove);
-    return PeakStatus::OK();
+    auto result = ctx->active_storage->impl_removeEdge(src, dest);
+    if (result.second.isOK())
+      ctx->metadata->updateEdgeCount(UpdateOp::Remove);
+    return result;
   }
 
   std::pair<PeakStatus, EdgeType> updateEdge(const VertexType &src,

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -97,7 +97,7 @@ public:
     if (PeakStatus resp = ctx->active_storage->impl_removeEdge(src, dest);
         !resp.isOK())
       return resp;
-    ctx->metadata->num_edges--;
+    ctx->metadata->updateEdgeCount(UpdateOp::Remove);
     return PeakStatus::OK();
   }
 

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -92,6 +92,15 @@ public:
     return status;
   }
 
+  PeakStatus removeEdge(const VertexType &src, const VertexType &dest) {
+    LOG_INFO("Called adjacency:removeEdge()");
+    if (PeakStatus resp = ctx->active_storage->impl_removeEdge(src, dest);
+        !resp.isOK())
+      return resp;
+    ctx->metadata->num_edges--;
+    return PeakStatus::OK();
+  }
+
   std::pair<PeakStatus, EdgeType> updateEdge(const VertexType &src,
                                              const VertexType &dest,
                                              const EdgeType &newWeight) {

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -150,6 +150,12 @@ public:
     return peak_status;
   }
 
+  // Method to remove an edge
+  const PeakStatus impl_removeEdge(const VertexType &src,
+                                   const VertexType &dest) override {
+    return PeakStatus::OK();
+  }
+
   const PeakStatus impl_clearEdges() override {
     for (auto &edge : _adj_list) {
       edge.second.clear();

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -153,7 +153,18 @@ public:
   // Method to remove an edge
   const PeakStatus impl_removeEdge(const VertexType &src,
                                    const VertexType &dest) override {
-    return PeakStatus::OK();
+    if (auto it = _adj_list.find(src); it == _adj_list.end())
+      return PeakStatus::VertexNotFound();
+
+    auto &edges = _adj_list.find(src)->second;
+    auto it = std::find_if(edges.begin(), edges.end(), [&](const auto &edge) {
+      return edge.first == dest;
+    });
+    if (it != edges.end()) {
+      edges.erase(it);
+      return PeakStatus::OK();
+    }
+    return PeakStatus::EdgeNotFound();
   }
 
   const PeakStatus impl_clearEdges() override {

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -151,20 +151,25 @@ public:
   }
 
   // Method to remove an edge
-  const PeakStatus impl_removeEdge(const VertexType &src,
-                                   const VertexType &dest) override {
+  const std::pair<EdgeType, PeakStatus>
+  impl_removeEdge(const VertexType &src, const VertexType &dest) override {
+    auto weight = EdgeType();
     if (auto it = _adj_list.find(src); it == _adj_list.end())
-      return PeakStatus::VertexNotFound();
+      return std::make_pair(weight, PeakStatus::VertexNotFound());
 
     auto &edges = _adj_list.find(src)->second;
     auto it = std::find_if(edges.begin(), edges.end(), [&](const auto &edge) {
       return edge.first == dest;
     });
-    if (it != edges.end()) {
-      edges.erase(it);
-      return PeakStatus::OK();
+
+    if (it == edges.end()) {
+      return std::make_pair(weight, PeakStatus::EdgeNotFound());
     }
-    return PeakStatus::EdgeNotFound();
+
+    weight = it->second;
+
+    edges.erase(it);
+    return std::make_pair(weight, PeakStatus::OK());
   }
 
   const PeakStatus impl_clearEdges() override {

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -245,27 +245,30 @@ public:
   }
 
   // Method to remove an edge
-  const PeakStatus impl_removeEdge(const VertexType &src,
-                                   const VertexType &dest) override {
+  const std::pair<EdgeType, PeakStatus>
+  impl_removeEdge(const VertexType &src, const VertexType &dest) override {
+    auto weight = EdgeType();
+
     if (!vertex_to_index.count(src) || !vertex_to_index.count(dest)) {
-      return PeakStatus::VertexNotFound();
+      return std::make_pair(weight, PeakStatus::VertexNotFound());
     }
 
     if (!impl_doesEdgeExist(src, dest)) {
-      return PeakStatus::EdgeNotFound();
+      return std::make_pair(weight, PeakStatus::EdgeNotFound());
     }
 
     for (size_t i = coo_src.size(); i > 0; --i) {
       if (coo_src[i - 1] == src && coo_dest[i - 1] == dest) {
         coo_src.erase(coo_src.begin() + (i - 1));
         coo_dest.erase(coo_dest.begin() + (i - 1));
+        weight = coo_weights[i - 1];
         coo_weights.erase(coo_weights.begin() + (i - 1));
-        return PeakStatus::OK();
+        return std::make_pair(weight, PeakStatus::OK());
       }
     }
 
     if (!is_built_) {
-      return PeakStatus::EdgeNotFound();
+      return std::make_pair(weight, PeakStatus::EdgeNotFound());
     }
 
     size_t row = vertex_to_index.at(src);
@@ -278,6 +281,8 @@ public:
     if (it != csr_col_vals.begin() + end && *it == dest) {
       size_t edge_idx = std::distance(csr_col_vals.begin(), it);
 
+      weight = csr_weights[edge_idx];
+
       csr_col_vals.erase(csr_col_vals.begin() + edge_idx);
       csr_weights.erase(csr_weights.begin() + edge_idx);
 
@@ -285,7 +290,7 @@ public:
         csr_row_offsets[i]--;
       }
     }
-    return PeakStatus::OK();
+    return std::make_pair(weight, PeakStatus::OK());
   }
 
   const PeakStatus impl_updateEdge(const VertexType &src,

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -264,7 +264,7 @@ public:
       }
     }
 
-    if (!is_built) {
+    if (!is_built_) {
       return PeakStatus::EdgeNotFound();
     }
 

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -244,6 +244,50 @@ public:
     return PeakStatus::OK();
   }
 
+  // Method to remove an edge
+  const PeakStatus impl_removeEdge(const VertexType &src,
+                                   const VertexType &dest) override {
+    if (!vertex_to_index.count(src) || !vertex_to_index.count(dest)) {
+      return PeakStatus::VertexNotFound();
+    }
+
+    if (!impl_doesEdgeExist(src, dest)) {
+      return PeakStatus::EdgeNotFound();
+    }
+
+    for (size_t i = coo_src.size(); i > 0; --i) {
+      if (coo_src[i - 1] == src && coo_dest[i - 1] == dest) {
+        coo_src.erase(coo_src.begin() + (i - 1));
+        coo_dest.erase(coo_dest.begin() + (i - 1));
+        coo_weights.erase(coo_weights.begin() + (i - 1));
+        return PeakStatus::OK();
+      }
+    }
+
+    if (!is_built) {
+      return PeakStatus::EdgeNotFound();
+    }
+
+    size_t row = vertex_to_index.at(src);
+    size_t start = csr_row_offsets[row];
+    size_t end = csr_row_offsets[row + 1];
+
+    auto it = std::lower_bound(csr_col_vals.begin() + start,
+                               csr_col_vals.begin() + end, dest);
+
+    if (it != csr_col_vals.begin() + end && *it == dest) {
+      size_t edge_idx = std::distance(csr_col_vals.begin(), it);
+
+      csr_col_vals.erase(csr_col_vals.begin() + edge_idx);
+      csr_weights.erase(csr_weights.begin() + edge_idx);
+
+      for (size_t i = row + 1; i < csr_row_offsets.size(); ++i) {
+        csr_row_offsets[i]--;
+      }
+    }
+    return PeakStatus::OK();
+  }
+
   const PeakStatus impl_updateEdge(const VertexType &src,
                                    const VertexType &dest,
                                    const EdgeType &newWeight) override {
@@ -278,12 +322,6 @@ public:
 
     size_t idx = std::distance(csr_col_vals.begin(), it);
     csr_weights[idx] = newWeight;
-    return PeakStatus::OK();
-  }
-
-  // Method to remove an edge
-  const PeakStatus impl_removeEdge(const VertexType &src,
-                                   const VertexType &dest) override {
     return PeakStatus::OK();
   }
 

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -281,6 +281,12 @@ public:
     return PeakStatus::OK();
   }
 
+  // Method to remove an edge
+  const PeakStatus impl_removeEdge(const VertexType &src,
+                                   const VertexType &dest) override {
+    return PeakStatus::OK();
+  }
+
   // Method to remove all edges
   const PeakStatus impl_clearEdges() override {
     std::unique_lock<std::shared_mutex> lock(_mtx);

--- a/src/StorageInterface.hpp
+++ b/src/StorageInterface.hpp
@@ -12,6 +12,10 @@ public:
   // Method to remove all Edges
   virtual const PeakStatus impl_clearEdges() = 0;
 
+  // Method to remove an Edge
+  virtual const PeakStatus impl_removeEdge(const VertexType &src,
+                                           const VertexType &dest) = 0;
+
   virtual const PeakStatus
   impl_addEdge(const VertexType &src, const VertexType &dest,
                const EdgeType &weight = EdgeType()) = 0;

--- a/src/StorageInterface.hpp
+++ b/src/StorageInterface.hpp
@@ -13,8 +13,8 @@ public:
   virtual const PeakStatus impl_clearEdges() = 0;
 
   // Method to remove an Edge
-  virtual const PeakStatus impl_removeEdge(const VertexType &src,
-                                           const VertexType &dest) = 0;
+  virtual const std::pair<EdgeType, PeakStatus>
+  impl_removeEdge(const VertexType &src, const VertexType &dest) = 0;
 
   virtual const PeakStatus
   impl_addEdge(const VertexType &src, const VertexType &dest,

--- a/tests/unit/AdjacencyList/AdjacencyShard.cpp
+++ b/tests/unit/AdjacencyList/AdjacencyShard.cpp
@@ -150,6 +150,28 @@ TEST_F(AdjacencyStorageShardTest, AddEdgeWithWeight) {
   EXPECT_EQ(edge2.first, 10);
 }
 
+// Added test to validate removeEdge functionality
+TEST_F(AdjacencyStorageShardTest, RemoveEdge) {
+  EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 5).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(2, 3, 10).isOK());
+
+  auto edge1 = intGraph.impl_getEdge(1, 2);
+  EXPECT_TRUE(edge1.second.isOK());
+
+  EXPECT_TRUE(intGraph.impl_removeEdge(1, 2).isOK());
+  edge1 = intGraph.impl_getEdge(1, 2);
+  EXPECT_FALSE(edge1.second.isOK());
+
+  auto edge2 = intGraph.impl_getEdge(2, 3);
+  EXPECT_TRUE(edge2.second.isOK());
+
+  EXPECT_TRUE(intGraph.impl_removeEdge(2, 3).isOK());
+  edge2 = intGraph.impl_getEdge(2, 3);
+  EXPECT_FALSE(edge2.second.isOK());
+
+  EXPECT_FALSE(intGraph.impl_removeEdge(5, 6).isOK());
+}
+
 TEST_F(AdjacencyStorageShardTest, UpdateEdgeWithWeight) {
   EXPECT_TRUE(intGraph.impl_addEdge(101, 102, 7).isOK());
   EXPECT_TRUE(intGraph.impl_addEdge(103, 102, 5).isOK());

--- a/tests/unit/AdjacencyList/AdjacencyShard.cpp
+++ b/tests/unit/AdjacencyList/AdjacencyShard.cpp
@@ -150,26 +150,52 @@ TEST_F(AdjacencyStorageShardTest, AddEdgeWithWeight) {
   EXPECT_EQ(edge2.first, 10);
 }
 
-// Added test to validate removeEdge functionality
-TEST_F(AdjacencyStorageShardTest, RemoveEdge) {
+// Added test to validate removeEdge functionality in a weighted graph
+TEST_F(AdjacencyStorageShardTest, RemoveEdgeWithWeight) {
   EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 5).isOK());
   EXPECT_TRUE(intGraph.impl_addEdge(2, 3, 10).isOK());
 
   auto edge1 = intGraph.impl_getEdge(1, 2);
   EXPECT_TRUE(edge1.second.isOK());
 
-  EXPECT_TRUE(intGraph.impl_removeEdge(1, 2).isOK());
+  auto result1 = intGraph.impl_removeEdge(1, 2);
+  EXPECT_TRUE(result1.second.isOK());
+  EXPECT_EQ(result1.first, edge1.first);
   edge1 = intGraph.impl_getEdge(1, 2);
   EXPECT_FALSE(edge1.second.isOK());
 
   auto edge2 = intGraph.impl_getEdge(2, 3);
   EXPECT_TRUE(edge2.second.isOK());
 
-  EXPECT_TRUE(intGraph.impl_removeEdge(2, 3).isOK());
+  auto result2 = intGraph.impl_removeEdge(2, 3);
+  EXPECT_TRUE(result2.second.isOK());
+  EXPECT_EQ(result2.first, edge2.first);
+  edge2 = intGraph.impl_getEdge(1, 2);
+  EXPECT_FALSE(edge2.second.isOK());
+
+  EXPECT_FALSE(intGraph.impl_removeEdge(5, 6).second.isOK());
+}
+
+// Added test to validate removeEdge functionality in a unweighted graph
+TEST_F(AdjacencyStorageShardTest, RemoveEdgeWithoutWeight) {
+  EXPECT_TRUE(intGraph.impl_addEdge(1, 2).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(2, 3).isOK());
+
+  auto edge1 = intGraph.impl_getEdge(1, 2);
+  EXPECT_TRUE(edge1.second.isOK());
+
+  EXPECT_TRUE(intGraph.impl_removeEdge(1, 2).second.isOK());
+  edge1 = intGraph.impl_getEdge(1, 2);
+  EXPECT_FALSE(edge1.second.isOK());
+
+  auto edge2 = intGraph.impl_getEdge(2, 3);
+  EXPECT_TRUE(edge2.second.isOK());
+
+  EXPECT_TRUE(intGraph.impl_removeEdge(2, 3).second.isOK());
   edge2 = intGraph.impl_getEdge(2, 3);
   EXPECT_FALSE(edge2.second.isOK());
 
-  EXPECT_FALSE(intGraph.impl_removeEdge(5, 6).isOK());
+  EXPECT_FALSE(intGraph.impl_removeEdge(5, 6).second.isOK());
 }
 
 TEST_F(AdjacencyStorageShardTest, UpdateEdgeWithWeight) {

--- a/tests/unit/HybridCSR_COO/HybridShard.cpp
+++ b/tests/unit/HybridCSR_COO/HybridShard.cpp
@@ -111,6 +111,31 @@ TEST_F(HybridStorageShardTest, EdgeAdditionBasic) {
   EXPECT_EQ(w2, 25);
 }
 
+// Added test to validate removeEdge functionality
+TEST_F(HybridStorageShardTest, RemoveEdge) {
+  graph->impl_addVertex(1);
+  graph->impl_addVertex(2);
+  graph->impl_addVertex(3);
+
+  EXPECT_TRUE(graph->impl_addEdge(1, 2, 5).isOK());
+  EXPECT_TRUE(graph->impl_addEdge(2, 3, 10).isOK());
+
+  auto edge1 = graph->impl_getEdge(1, 2);
+  EXPECT_TRUE(edge1.second.isOK());
+
+  EXPECT_TRUE(graph->impl_removeEdge(1, 2).isOK());
+  edge1 = graph->impl_getEdge(1, 2);
+  EXPECT_FALSE(edge1.second.isOK());
+
+  auto edge2 = graph->impl_getEdge(2, 3);
+  EXPECT_TRUE(edge2.second.isOK());
+
+  EXPECT_TRUE(graph->impl_removeEdge(2, 3).isOK());
+  edge2 = graph->impl_getEdge(2, 3);
+  EXPECT_FALSE(edge2.second.isOK());
+
+  EXPECT_FALSE(graph->impl_removeEdge(5, 6).isOK());
+}
 TEST_F(HybridStorageShardTest, EdgeWeightUpdation) {
   std::vector<int> vertices = {1, 2, 3, 4, 5};
   for (int v : vertices) {

--- a/tests/unit/HybridCSR_COO/HybridShard.cpp
+++ b/tests/unit/HybridCSR_COO/HybridShard.cpp
@@ -111,8 +111,8 @@ TEST_F(HybridStorageShardTest, EdgeAdditionBasic) {
   EXPECT_EQ(w2, 25);
 }
 
-// Added test to validate removeEdge functionality
-TEST_F(HybridStorageShardTest, RemoveEdge) {
+// Added test to validate removeEdge functionality in a weighted graph
+TEST_F(HybridStorageShardTest, RemoveEdgeWithWeight) {
   graph->impl_addVertex(1);
   graph->impl_addVertex(2);
   graph->impl_addVertex(3);
@@ -123,18 +123,48 @@ TEST_F(HybridStorageShardTest, RemoveEdge) {
   auto edge1 = graph->impl_getEdge(1, 2);
   EXPECT_TRUE(edge1.second.isOK());
 
-  EXPECT_TRUE(graph->impl_removeEdge(1, 2).isOK());
+  auto result1 = graph->impl_removeEdge(1, 2);
+  EXPECT_TRUE(result1.second.isOK());
+  EXPECT_EQ(result1.first, edge1.first);
   edge1 = graph->impl_getEdge(1, 2);
   EXPECT_FALSE(edge1.second.isOK());
 
   auto edge2 = graph->impl_getEdge(2, 3);
   EXPECT_TRUE(edge2.second.isOK());
 
-  EXPECT_TRUE(graph->impl_removeEdge(2, 3).isOK());
+  auto result2 = graph->impl_removeEdge(2, 3);
+  EXPECT_TRUE(result2.second.isOK());
+  EXPECT_EQ(result2.first, edge2.first);
+  edge2 = graph->impl_getEdge(1, 2);
+  EXPECT_FALSE(edge2.second.isOK());
+
+  EXPECT_FALSE(graph->impl_removeEdge(5, 6).second.isOK());
+}
+
+// Added test to validate removeEdge functionality in a unweighted graph
+TEST_F(HybridStorageShardTest, RemoveEdgeWithoutWeight) {
+  graph->impl_addVertex(1);
+  graph->impl_addVertex(2);
+  graph->impl_addVertex(3);
+
+  EXPECT_TRUE(graph->impl_addEdge(1, 2).isOK());
+  EXPECT_TRUE(graph->impl_addEdge(2, 3).isOK());
+
+  auto edge1 = graph->impl_getEdge(1, 2);
+  EXPECT_TRUE(edge1.second.isOK());
+
+  EXPECT_TRUE(graph->impl_removeEdge(1, 2).second.isOK());
+  edge1 = graph->impl_getEdge(1, 2);
+  EXPECT_FALSE(edge1.second.isOK());
+
+  auto edge2 = graph->impl_getEdge(2, 3);
+  EXPECT_TRUE(edge2.second.isOK());
+
+  EXPECT_TRUE(graph->impl_removeEdge(2, 3).second.isOK());
   edge2 = graph->impl_getEdge(2, 3);
   EXPECT_FALSE(edge2.second.isOK());
 
-  EXPECT_FALSE(graph->impl_removeEdge(5, 6).isOK());
+  EXPECT_FALSE(graph->impl_removeEdge(5, 6).second.isOK());
 }
 TEST_F(HybridStorageShardTest, EdgeWeightUpdation) {
   std::vector<int> vertices = {1, 2, 3, 4, 5};


### PR DESCRIPTION
This PR implements the `impl_removeEdge()` method (issue #75 ) in both `AdjacencyList.hpp` and `HybridCSR_COO.hpp` to remove an edge from the graph.

### Changes made:

- `AdjacencyList.hpp`, `HybridCSR_COO.hpp`  - Added `impl_removeEdge()` method to remove an edge.
- `PeakStore.hpp` - Added helper method to call `impl_removeEdge()` method from AdjacencyList.
- `GraphList.hpp` - Added helper method to call `removeEdge()` method from PeakStore.
- `StorageInterface.hpp`  - Added declaration for `impl_removeEdge()` method.
- `AdjacencyShard.cpp`, `HybridCSRCOO.cpp`, `ListExample1.cpp` - Modified to add new tests to validate removeEdge functionality.