### PR TITLE
feat: Implement vertex existence check in AdjacencyList

### DIFF
--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -111,6 +111,17 @@ public:
     return PeakStatus::OK();
   }
 
+  /**
+   * @brief Checks if a vertex exists in the adjacency list
+   * @param v The vertex to check for existence
+   * @return true if the vertex exists, false otherwise
+   * @note Thread-safe operation using shared_lock for concurrent read access
+   */
+  bool impl_hasVertex(const VertexType &v) override {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    return _adj_list.find(v) != _adj_list.end();
+  }
+
   const PeakStatus impl_addVertices(const std::vector<VertexType> &vertices) {
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
@@ -196,14 +207,6 @@ public:
     return PeakStatus::EdgeNotFound();
   }
 
-  // Method to check whether a vertex exists or not
-  bool impl_hasVertex(const VertexType &v) override {
-    auto it = _adj_list.find(v);
-    if (it == _adj_list.end()) {
-      return false;
-    }
-    return true;
-  }
 
   bool impl_doesEdgeExist(const VertexType &src,
                           const VertexType &dest) override {

--- a/tests/unit/AdjacencyList/has_vertex_test.cpp
+++ b/tests/unit/AdjacencyList/has_vertex_test.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include "CinderPeak.hpp"
+
+using namespace CinderPeak;
+
+TEST(AdjacencyListTest, HasVertexTest) {
+    // Create a graph with string vertices and int edge weights
+    CinderGraph<std::string, int> graph;
+    
+    // Test with a vertex that doesn't exist
+    EXPECT_FALSE(graph.hasVertex("none"));
+    
+    // Add a vertex and test again
+    graph.addVertex("A");
+    EXPECT_TRUE(graph.hasVertex("A"));
+    
+    // Test with a different vertex that wasn't added
+    EXPECT_FALSE(graph.hasVertex("B"));
+    
+    // Add another vertex and test
+    graph.addVertex("B");
+    EXPECT_TRUE(graph.hasVertex("B"));
+    
+    // Test with a non-existent vertex
+    EXPECT_FALSE(graph.hasVertex("C"));
+}
+
+TEST(AdjacencyListTest, HasVertexWithPrimitiveType) {
+    // Test with integer vertices
+    CinderGraph<int, int> intGraph;
+    
+    // Test with a vertex that doesn't exist
+    EXPECT_FALSE(intGraph.hasVertex(1));
+    
+    // Add a vertex and test
+    intGraph.addVertex(1);
+    EXPECT_TRUE(intGraph.hasVertex(1));
+    
+    // Test with a different vertex
+    EXPECT_FALSE(intGraph.hasVertex(2));
+}
+
+TEST(AdjacencyListTest, HasVertexAfterRemoval) {
+    CinderGraph<std::string, int> graph;
+    
+    // Add and then remove a vertex
+    graph.addVertex("A");
+    EXPECT_TRUE(graph.hasVertex("A"));
+    
+    graph.removeVertex("A");
+    EXPECT_FALSE(graph.hasVertex("A"));
+    
+    // Test with a vertex that was never added
+    EXPECT_FALSE(graph.hasVertex("B"));
+}

--- a/tests/unit/AdjacencyList/has_vertex_test.cpp
+++ b/tests/unit/AdjacencyList/has_vertex_test.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 CinderPeak Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>


### PR DESCRIPTION
This PR implements the vertex existence check functionality in the [AdjacencyList]

### Changes Made
- Implemented  impl_hasVertex  method in AdjacencyList class
- Added comprehensive unit tests covering various scenarios
- Included Doxygen documentation for the new method
- Ensured thread-safety using `shared_lock`

### Technical Details
- Uses `std::unordered_map::find` for O(1) average case lookup
- Thread-safe implementation using `std::shared_lock` for concurrent read access
- Follows the project's coding standards and patterns

### Testing
- Added test cases for:
  - Checking non-existent vertices
  - Verifying vertex existence after addition
  - Testing with both string and primitive vertex types
- All tests are passing

### Related Issue
Fixes #116

### Checklist
- [x] Code follows the project's coding standards
- [x] Tests have been added/updated
- [x] Documentation has been updated
- [x] Code has been tested locally