### PR TITLE
refactor(AdjList): Refactor AdjacencyList to use PolicyHandler via Dependency Injection

### DIFF
--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -27,18 +27,8 @@ private:
     ctx->adjacency_storage =
         std::make_shared<AdjacencyList<VertexType, EdgeType>>();
     ctx->pHandler = std::make_shared<PolicyHandler>(cfg);
-    // if (ctx->metadata->graphType() == "graph_matrix") {
-    //   ctx->active_storage = ctx->adjacency_storage;
-    //   LOG_DEBUG("Set active storage to Adjacency Storage (matrix).");
-    // } else if (ctx->metadata->graphType() == "graph_list") {
-    //   ctx->active_storage = ctx->adjacency_storage;
-    //   LOG_DEBUG("Set active storage to Adjacency Storage (list).");
-    // } else {
-    //   LOG_WARNING(
-    //       "Unknown graph type. Defaulting active storage to adjacency
-    //       list.");
-    //     }
     ctx->active_storage = ctx->adjacency_storage;
+    ctx->adjacency_storage->setAdjPolicyHandler(*ctx->pHandler);
   }
 
 public:
@@ -50,7 +40,6 @@ public:
     initializeContext(metadata, options, cfg);
     LOG_INFO("Successfully initialized context object.");
   }
-
   PeakStatus addEdge(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight = EdgeType()) {
     bool isWeighted = ctx->metadata->isGraphWeighted();

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "Concepts.hpp"
+#include "PolicyConfiguration.hpp"
 #include "StorageEngine/GraphContext.hpp"
 #include "StorageEngine/GraphStatistics.hpp"
 #include "Utils.hpp"
@@ -26,10 +27,14 @@ private:
                      VertexHasher<VertexType>>
       _adj_list;
   mutable std::shared_mutex _mtx;
+  std::unique_ptr<PolicyHandler> PHandler = nullptr;
 
 public:
   AdjacencyList() { LOG_INFO("Initialized Adjacency List object"); }
-
+  void setAdjPolicyHandler(const PolicyHandler &handlerRef) {
+    PHandler = std::make_unique<PolicyHandler>(handlerRef);
+    LOG_INFO("AdjacencyList PolicyHandler set successfully");
+  }
   const PeakStatus impl_addEdge(const VertexType &src, const VertexType &dest,
                                 const EdgeType &weight = EdgeType()) override {
     std::unique_lock<std::shared_mutex> lock(_mtx);


### PR DESCRIPTION
This PR refactors the ``AdjacencyList`` class to use ``PolicyHandler`` directly instead of ``PolicyConfiguration``, enabling proper dependency injection and cleaner ownership semantics. This resolves previous issue where ``AdjacencyList`` didnt have access to ``pHandler`` object due to the context sharing.

Added a method
```cpp
void setAdjPolicyHandler(const PolicyHandler &handlerRef)
``` 
to set the ``PolicyHandler`` object in Adj List class.