### PR TITLE
feat(policies): Added tests for Ignore and ConsoleAndFile policy

### DIFF
--- a/tests/unit/Policies/EPShard_IgnoreAndConsoleAndFile.cpp
+++ b/tests/unit/Policies/EPShard_IgnoreAndConsoleAndFile.cpp
@@ -14,9 +14,9 @@
 using namespace CinderPeak;
 
 static const std::string kTestLogPath =
-    "test_logfile_and_console_ignore_policy.log";
+    "test_console_and_file_ignore_policy.log";
 
-class IgnoreAndLogFileAndConsolePolicyTest : public ::testing::Test {
+class IgnoreAndConsoleAndFilePolicyTest : public ::testing::Test {
 public:
   PolicyConfiguration ignoreAndLogFC_cfg{PolicyConfiguration::Ignore,
                                          PolicyConfiguration::ConsoleAndFile,
@@ -33,7 +33,7 @@ public:
   PeakStatus sc_alreadyExists = PeakStatus::AlreadyExists();
   PeakStatus sc_edgeAlreadyExists = PeakStatus::EdgeAlreadyExists();
 
-  IgnoreAndLogFileAndConsolePolicyTest() : policy(ignoreAndLogFC_cfg) {}
+  IgnoreAndConsoleAndFilePolicyTest() : policy(ignoreAndLogFC_cfg) {}
 
   void SetUp() override {
     std::ofstream ofs(kTestLogPath, std::ios::trunc);
@@ -128,8 +128,7 @@ public:
   }
 };
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_NotFound) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest, IgnoreAndConsoleAndFile_NotFound) {
   EXPECT_NO_THROW(policy.handleException(sc_notFound));
 
   testing::internal::CaptureStderr();
@@ -140,8 +139,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Not Found", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_InvalidArgument) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_InvalidArgument) {
   EXPECT_NO_THROW(policy.handleException(sc_invalidArgument));
 
   testing::internal::CaptureStderr();
@@ -152,8 +151,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Invalid Argument", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_VertexAlreadyExists) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_VertexAlreadyExists) {
   EXPECT_NO_THROW(policy.handleException(sc_vertexAlreadyExists));
 
   testing::internal::CaptureStderr();
@@ -164,8 +163,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Vertex Already Exists", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_InternalError) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_InternalError) {
   EXPECT_NO_THROW(policy.handleException(sc_internalError));
 
   testing::internal::CaptureStderr();
@@ -176,8 +175,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Internal Error", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_EdgeNotFound) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_EdgeNotFound) {
   EXPECT_NO_THROW(policy.handleException(sc_edgeNotFound));
 
   testing::internal::CaptureStderr();
@@ -188,8 +187,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Edge Not Found", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_VertexNotFound) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_VertexNotFound) {
   EXPECT_NO_THROW(policy.handleException(sc_vertexNotFound));
 
   testing::internal::CaptureStderr();
@@ -200,8 +199,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Vertex Not Found", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_Unimplemented) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_Unimplemented) {
   EXPECT_NO_THROW(policy.handleException(sc_unimplemented));
 
   testing::internal::CaptureStderr();
@@ -212,8 +211,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Method is not implemented", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_AlreadyExists) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_AlreadyExists) {
   EXPECT_NO_THROW(policy.handleException(sc_alreadyExists));
 
   testing::internal::CaptureStderr();
@@ -224,8 +223,8 @@ TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
   verifyConsoleOutput("Already Exists", consoleOutput);
 }
 
-TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
-       IgnoreAndLogFileAndConsole_EdgeAlreadyExists) {
+TEST_F(IgnoreAndConsoleAndFilePolicyTest,
+       IgnoreAndConsoleAndFile_EdgeAlreadyExists) {
   EXPECT_NO_THROW(policy.handleException(sc_edgeAlreadyExists));
 
   testing::internal::CaptureStderr();

--- a/tests/unit/Policies/EPShard_IgnoreAndLogFileAndConsole.cpp
+++ b/tests/unit/Policies/EPShard_IgnoreAndLogFileAndConsole.cpp
@@ -1,0 +1,237 @@
+#include "CinderExceptions.hpp"
+#include "PolicyConfiguration.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <thread>
+
+using namespace CinderPeak;
+
+static const std::string kTestLogPath =
+    "test_logfile_and_console_ignore_policy.log";
+
+class IgnoreAndLogFileAndConsolePolicyTest : public ::testing::Test {
+public:
+  PolicyConfiguration ignoreAndLogFC_cfg{PolicyConfiguration::Ignore,
+                                         PolicyConfiguration::ConsoleAndFile,
+                                         kTestLogPath};
+  PolicyHandler policy;
+
+  PeakStatus sc_notFound = PeakStatus::NotFound();
+  PeakStatus sc_invalidArgument = PeakStatus::InvalidArgument();
+  PeakStatus sc_vertexAlreadyExists = PeakStatus::VertexAlreadyExists();
+  PeakStatus sc_internalError = PeakStatus::InternalError();
+  PeakStatus sc_edgeNotFound = PeakStatus::EdgeNotFound();
+  PeakStatus sc_vertexNotFound = PeakStatus::VertexNotFound();
+  PeakStatus sc_unimplemented = PeakStatus::Unimplemented();
+  PeakStatus sc_alreadyExists = PeakStatus::AlreadyExists();
+  PeakStatus sc_edgeAlreadyExists = PeakStatus::EdgeAlreadyExists();
+
+  IgnoreAndLogFileAndConsolePolicyTest() : policy(ignoreAndLogFC_cfg) {}
+
+  void SetUp() override {
+    std::ofstream ofs(kTestLogPath, std::ios::trunc);
+    ofs.close();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  void writeAllLogLevels(const std::string &msg) {
+    policy.log(LogLevel::TRACE, msg);
+    policy.log(LogLevel::DEBUG, msg);
+    policy.log(LogLevel::INFO, msg);
+    policy.log(LogLevel::WARNING, msg);
+    policy.log(LogLevel::ERROR, msg);
+    policy.log(LogLevel::CRITICAL, msg);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(120));
+  }
+
+  std::string readLogContent() const {
+    std::ifstream in(kTestLogPath);
+    if (!in.good())
+      return "";
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+  }
+
+  void verifyLogFormat(const std::string &expectedMessage) {
+    std::string content = readLogContent();
+    ASSERT_FALSE(content.empty())
+        << "Log file is empty or not present at: " << kTestLogPath;
+
+    std::regex linePattern(
+        R"(\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\] \[(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL)\] .+)");
+
+    std::istringstream lines(content);
+    std::string line;
+    std::set<std::string> foundLevels;
+
+    while (std::getline(lines, line)) {
+      if (line.find(expectedMessage) == std::string::npos)
+        continue;
+
+      EXPECT_TRUE(std::regex_match(line, linePattern))
+          << "Invalid log format: " << line;
+
+      std::smatch m;
+      if (std::regex_search(
+              line, m,
+              std::regex(
+                  R"(\[(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|CRITICAL)\])"))) {
+        std::string lvl = m[1].str();
+        if (lvl == "WARNING")
+          lvl = "WARN";
+        foundLevels.insert(lvl);
+      }
+    }
+
+    const std::vector<std::string> expectedLevels = {
+        "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"};
+    for (auto &lvl : expectedLevels) {
+      EXPECT_TRUE(foundLevels.count(lvl))
+          << "Missing log entry for level: " << lvl
+          << " with message: " << expectedMessage << "\nFull log content:\n"
+          << content;
+    }
+  }
+
+  void verifyConsoleOutput(const std::string &expectedMessage,
+                           const std::string &capturedOutput) {
+    EXPECT_FALSE(capturedOutput.empty())
+        << "ConsoleAndFile policy should print to console";
+
+    EXPECT_TRUE(capturedOutput.find(expectedMessage) != std::string::npos)
+        << "Console output should contain: " << expectedMessage
+        << "\nActual output:\n"
+        << capturedOutput;
+
+    EXPECT_TRUE(capturedOutput.find("TRACE") != std::string::npos)
+        << "Missing TRACE level in console output";
+    EXPECT_TRUE(capturedOutput.find("DEBUG") != std::string::npos)
+        << "Missing DEBUG level in console output";
+    EXPECT_TRUE(capturedOutput.find("INFO") != std::string::npos)
+        << "Missing INFO level in console output";
+    EXPECT_TRUE(capturedOutput.find("WARN") != std::string::npos ||
+                capturedOutput.find("WARNING") != std::string::npos)
+        << "Missing WARNING level in console output";
+    EXPECT_TRUE(capturedOutput.find("ERROR") != std::string::npos)
+        << "Missing ERROR level in console output";
+    EXPECT_TRUE(capturedOutput.find("CRITICAL") != std::string::npos)
+        << "Missing CRITICAL level in console output";
+  }
+};
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_NotFound) {
+  EXPECT_NO_THROW(policy.handleException(sc_notFound));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Not Found");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Not Found");
+  verifyConsoleOutput("Not Found", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_InvalidArgument) {
+  EXPECT_NO_THROW(policy.handleException(sc_invalidArgument));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Invalid Argument");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Invalid Argument");
+  verifyConsoleOutput("Invalid Argument", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_VertexAlreadyExists) {
+  EXPECT_NO_THROW(policy.handleException(sc_vertexAlreadyExists));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Vertex Already Exists");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Vertex Already Exists");
+  verifyConsoleOutput("Vertex Already Exists", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_InternalError) {
+  EXPECT_NO_THROW(policy.handleException(sc_internalError));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Internal Error");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Internal Error");
+  verifyConsoleOutput("Internal Error", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_EdgeNotFound) {
+  EXPECT_NO_THROW(policy.handleException(sc_edgeNotFound));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Edge Not Found");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Edge Not Found");
+  verifyConsoleOutput("Edge Not Found", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_VertexNotFound) {
+  EXPECT_NO_THROW(policy.handleException(sc_vertexNotFound));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Vertex Not Found");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Vertex Not Found");
+  verifyConsoleOutput("Vertex Not Found", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_Unimplemented) {
+  EXPECT_NO_THROW(policy.handleException(sc_unimplemented));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Method is not implemented");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Method is not implemented");
+  verifyConsoleOutput("Method is not implemented", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_AlreadyExists) {
+  EXPECT_NO_THROW(policy.handleException(sc_alreadyExists));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Already Exists");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Already Exists");
+  verifyConsoleOutput("Already Exists", consoleOutput);
+}
+
+TEST_F(IgnoreAndLogFileAndConsolePolicyTest,
+       IgnoreAndLogFileAndConsole_EdgeAlreadyExists) {
+  EXPECT_NO_THROW(policy.handleException(sc_edgeAlreadyExists));
+
+  testing::internal::CaptureStderr();
+  writeAllLogLevels("Edge Already Exists");
+  std::string consoleOutput = testing::internal::GetCapturedStderr();
+
+  verifyLogFormat("Edge Already Exists");
+  verifyConsoleOutput("Edge Already Exists", consoleOutput);
+}


### PR DESCRIPTION
This PR implements comprehensive tests to validate the Ignore and ConsoleAndFile policy configuration (issue https://github.com/SharonIV0x86/CinderPeak/issues/140 ).

### Changes Made
- Created `EPShard_IgnoreAndConsoleAndFile.cpp` test suite to validate that exceptions are not thrown but logged to both file and console
- Covers all error status codes: NotFound, InvalidArgument, VertexAlreadyExists, InternalError, EdgeNotFound, VertexNotFound, Unimplemented, AlreadyExists, EdgeAlreadyExists
- Confirms all 6 log levels (TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL) are correctly written to both file and console