### PR TITLE
feat(policies): Improved ThrowAndSilent policy tests to verify silent behavior completely

### DIFF
--- a/tests/unit/Policies/EPShard_ThrowAndSilent.cpp
+++ b/tests/unit/Policies/EPShard_ThrowAndSilent.cpp
@@ -1,5 +1,7 @@
 #include "CinderExceptions.hpp"
 #include "PolicyConfiguration.hpp"
+#include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -22,7 +24,36 @@ public:
   PeakStatus sc_alreadyExists = PeakStatus::AlreadyExists();
   PeakStatus sc_edgeAlreadyExists = PeakStatus::EdgeAlreadyExists();
 
+  const std::string test_log_file = "test_policy.log";
+
   ThrowAndSilentPolicyTest() : policy(throwAndSilent_cfg) {}
+
+  void SetUp() override {
+    if (std::filesystem::exists(test_log_file)) {
+      std::filesystem::remove(test_log_file);
+    }
+  }
+
+  bool logFileExists() { return std::filesystem::exists(test_log_file); }
+
+  bool logFileIsEmpty() {
+    if (!logFileExists())
+      return true;
+    std::ifstream file(test_log_file);
+    return file.peek() == std::ifstream::traits_type::eof();
+  }
+
+  void verifyCompletelySilent() {
+    std::string stdout_output = testing::internal::GetCapturedStdout();
+    std::string stderr_output = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(stdout_output.empty())
+        << "Expected no console stdout output, but got: " << stdout_output;
+    EXPECT_TRUE(stderr_output.empty())
+        << "Expected no console stderr output, but got: " << stderr_output;
+    EXPECT_TRUE(!logFileExists() || logFileIsEmpty())
+        << "Expected no log file or empty log file, but file contains data";
+  }
 };
 
 // 1. NotFound exception
@@ -34,12 +65,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_NotFound) {
   } catch (const PeakExceptions::NotFoundException &nfex) {
     EXPECT_STREQ(nfex.what(), "Resource Not Found: Not Found");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::INFO, "NotFound log message");
+  verifyCompletelySilent();
 }
 
 // 2. InvalidArgument exception
@@ -51,12 +78,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_InvalidArgument) {
   } catch (const PeakExceptions::InvalidArgumentException &iaex) {
     EXPECT_STREQ(iaex.what(), "Invalid argument: Invalid Argument");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::ERROR, "InvalidArgument log message");
+  verifyCompletelySilent();
 }
 
 // 3. VertexAlreadyExists exception
@@ -68,12 +91,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_VertexAlreadyExists) {
   } catch (const PeakExceptions::VertexAlreadyExistsException &vaex) {
     EXPECT_STREQ(vaex.what(), "Vertex already exists: Vertex Already Exists");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::WARNING, "VertexAlreadyExists log message");
+  verifyCompletelySilent();
 }
 
 // 4. InternalError exception
@@ -85,12 +104,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_InternalError) {
   } catch (const PeakExceptions::InternalErrorException &ieex) {
     EXPECT_STREQ(ieex.what(), "Internal error: Internal Error");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::ERROR, "InternalError log message");
+  verifyCompletelySilent();
 }
 
 // 5. EdgeNotFound exception
@@ -102,12 +117,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_EdgeNotFound) {
   } catch (const PeakExceptions::EdgeNotFoundException &enfex) {
     EXPECT_STREQ(enfex.what(), "Edge not found: Edge Not Found");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::INFO, "EdgeNotFound log message");
+  verifyCompletelySilent();
 }
 
 // 6. VertexNotFound exception
@@ -119,12 +130,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_VertexNotFound) {
   } catch (const PeakExceptions::VertexNotFoundException &vnfex) {
     EXPECT_STREQ(vnfex.what(), "Vertex not found: Vertex Not Found");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::INFO, "VertexNotFound log message");
+  verifyCompletelySilent();
 }
 
 // 7. Unimplemented exception
@@ -137,12 +144,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_Unimplemented) {
     EXPECT_STREQ(unex.what(), "Unimplemented feature: Method is not "
                               "implemented, there has been an error.");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::WARNING, "Unimplemented log message");
+  verifyCompletelySilent();
 }
 
 // 8. AlreadyExists exception
@@ -154,12 +157,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_AlreadyExists) {
   } catch (const PeakExceptions::AlreadyExistsException &aeex) {
     EXPECT_STREQ(aeex.what(), "Already Exists: Resource Already Exists");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::WARNING, "AlreadyExists log message");
+  verifyCompletelySilent();
 }
 
 // 9. EdgeAlreadyExists exception
@@ -171,12 +170,8 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_EdgeAlreadyExists) {
   } catch (const PeakExceptions::EdgeAlreadyExistsException &eaex) {
     EXPECT_STREQ(eaex.what(), "Edge already exists: Edge Already Exists");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::WARNING, "EdgeAlreadyExists log message");
+  verifyCompletelySilent();
 }
 
 // 10. Multiple exceptions in sequence
@@ -187,20 +182,18 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_MultipleExceptions) {
     policy.handleException(sc_vertexNotFound);
   } catch (const PeakExceptions::VertexNotFoundException &) {
   }
+  policy.log(LogLevel::INFO, "First log message");
   try {
     policy.handleException(sc_edgeNotFound);
   } catch (const PeakExceptions::EdgeNotFoundException &) {
   }
+  policy.log(LogLevel::INFO, "Second log message");
   try {
     policy.handleException(sc_invalidArgument);
   } catch (const PeakExceptions::InvalidArgumentException &) {
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::INFO, "Third log message");
+  verifyCompletelySilent();
 }
 
 // 11. Repeated exception handling
@@ -213,13 +206,9 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_RepeatedException) {
     } catch (const PeakExceptions::InvalidArgumentException &iaex) {
       EXPECT_STREQ(iaex.what(), "Invalid argument: Invalid Argument");
     }
+    policy.log(LogLevel::INFO, "Repeated log message " + std::to_string(i));
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  verifyCompletelySilent();
 }
 
 // 12. EdgeNotFound with custom message
@@ -233,10 +222,6 @@ TEST_F(ThrowAndSilentPolicyTest, ThrowAndSilent_EdgeNotFoundWithCustomMessage) {
   } catch (const PeakExceptions::EdgeNotFoundException &enfex) {
     EXPECT_STREQ(enfex.what(), "Edge not found: Custom edge not found message");
   }
-  std::string stdout_output = testing::internal::GetCapturedStdout();
-  std::string stderr_output = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(stdout_output.empty())
-      << "Expected no console stdout output, but got: " << stdout_output;
-  EXPECT_TRUE(stderr_output.empty())
-      << "Expected no console stderr output, but got: " << stderr_output;
+  policy.log(LogLevel::ERROR, "Custom message log");
+  verifyCompletelySilent();
 }


### PR DESCRIPTION
This PR improves ThrowAndSilent policy tests to verify silent behavior completely (issue #142).

### Key changes:
- Extended `EPShard_ThrowAndSilent.cpp` to validate file logging behavior under Throw + Silent policy.
- Added log file cleanup and validation logic to ensure Silent mode produces no file logs, improving test isolation and reliability.
- Introduced utility functions (`logFileExists`, `logFileIsEmpty`, `verifyCompletelySilent`) to reduce repetitive checks and make assertions more readable.


