### PR TITLE
Enforce Comprehensive Compiler Warnings for All Builds (No Warnings-as-Errors, Cross-Compiler Support)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Install gcovr
       run: sudo apt-get update && sudo apt-get install -y gcovr
     - name: Configure CMake (Coverage)
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DCOVERAGE=ON
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_COVERAGE=ON
     - name: Build
       run: cmake --build build
     - name: Run Tests
@@ -80,7 +80,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Configure (ASAN + UBSAN)
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DSANITIZE_ADDRESS=ON -DSANITIZE_UNDEFINED=ON
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DSANITIZE=ON
     - name: Build
       run: cmake --build build
     - name: Run Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,8 @@
 on:
   pull_request:
   push:
-    branches: [ main ]
-    tags: [ "v*" ]
+    branches: [main]
+    tags: ["v*"]
 
 jobs:
   build-and-test:
@@ -13,88 +13,88 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        compiler: [ gcc, clang, msvc ]
-        build_type: [ Debug, Release ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        compiler: [gcc, clang, msvc]
+        build_type: [Debug, Release]
         exclude:
-        - os: macos-latest
-          compiler: msvc
-        - os: windows-latest
-          compiler: gcc
-        - os: windows-latest
-          compiler: clang
+          - os: macos-latest
+            compiler: msvc
+          - os: windows-latest
+            compiler: gcc
+          - os: windows-latest
+            compiler: clang
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup CMake
-      uses: jwlawson/actions-setup-cmake@v1
-      with:
-        cmake-version: '3.20'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1
+        with:
+          cmake-version: "3.20"
 
-    - name: Setup Ninja
-      if: matrix.os == 'windows-latest'
-      uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Setup Ninja
+        if: matrix.os == 'windows-latest'
+        uses: seanmiddleditch/gha-setup-ninja@master
 
-    - name: Setup MSVC
-      if: matrix.compiler == 'msvc'
-      uses: ilammy/msvc-dev-cmd@v1
+      - name: Setup MSVC
+        if: matrix.compiler == 'msvc'
+        uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Configure CMake
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON
 
-    - name: Build
-      run: cmake --build build --config ${{ matrix.build_type }}
+      - name: Build
+        run: cmake --build build --config ${{ matrix.build_type }}
 
-    - name: Run Tests (CTest)
-      run: ctest --test-dir build --output-on-failure
+      - name: Run Tests (CTest)
+        run: ctest --test-dir build --output-on-failure
 
-    - name: Upload binaries
-      uses: actions/upload-artifact@v4
-      with:
-        name: binaries-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}
-        path: build/bin/
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}
+          path: build/bin/
 
   coverage:
     name: Coverage (Linux GCC)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install gcovr
-      run: sudo apt-get update && sudo apt-get install -y gcovr
-    - name: Configure CMake (Coverage)
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_COVERAGE=ON
-    - name: Build
-      run: cmake --build build
-    - name: Run Tests
-      run: ctest --test-dir build --output-on-failure
-    - name: Generate Coverage
-      run: gcovr -r . --xml-pretty > coverage.xml
-    - uses: codecov/codecov-action@v4
-      with:
-        files: coverage.xml
+      - uses: actions/checkout@v4
+      - name: Install gcovr
+        run: sudo apt-get update && sudo apt-get install -y gcovr
+      - name: Configure CMake (Coverage)
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_COVERAGE=ON
+      - name: Build
+        run: cmake --build build
+      - name: Run Tests
+        run: ctest --test-dir build --output-on-failure
+      - name: Generate Coverage
+        run: gcovr --gcov-ignore-parse-errors=negative_hits.warn -r . --xml-pretty > coverage.xml
+      - uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
 
   sanitizers:
     name: Sanitizers (Linux Clang)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Configure (ASAN + UBSAN)
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DSANITIZE=ON
-    - name: Build
-      run: cmake --build build
-    - name: Run Tests
-      run: ctest --test-dir build --output-on-failure
+      - uses: actions/checkout@v4
+      - name: Configure (ASAN + UBSAN)
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DSANITIZE=ON
+      - name: Build
+        run: cmake --build build
+      - name: Run Tests
+        run: ctest --test-dir build --output-on-failure
 
   lint:
     name: Lint & Static Analysis
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install tools
-      run: sudo apt-get update && sudo apt-get install -y clang-format python3-pip
-    - name: Run clang-format (check)
-      run: clang-format --Werror --dry-run $(git ls-files '*.cpp' '*.h' || true)
+      - uses: actions/checkout@v4
+      - name: Install tools
+        run: sudo apt-get update && sudo apt-get install -y clang-format python3-pip
+      - name: Run clang-format (check)
+        run: clang-format --Werror --dry-run $(git ls-files '*.cpp' '*.h' || true)
 
   clang-tidy-full-analysis:
     name: Clang-Tidy Full Project Analysis
@@ -102,89 +102,89 @@ jobs:
     continue-on-error: true
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang clang-tidy python3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang clang-tidy python3
 
-    - name: Configure CMake (export compile_commands)
-      run: |
-        cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Configure CMake (export compile_commands)
+        run: |
+          cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-    - name: Build project
-      run: |
-        cmake --build build -- -j$(nproc)
+      - name: Build project
+        run: |
+          cmake --build build -- -j$(nproc)
 
-    - name: Run clang-tidy on ALL C/C++ files (FULL REPORT)
-      id: run_tidy
-      run: |
-        mkdir -p tidy-reports
+      - name: Run clang-tidy on ALL C/C++ files (FULL REPORT)
+        id: run_tidy
+        run: |
+          mkdir -p tidy-reports
 
-        echo "Collecting all C/C++ source and header files..."
+          echo "Collecting all C/C++ source and header files..."
 
-        find . \
-          -type f \
-          \( \
-            -name '*.c' -o \
-            -name '*.cc' -o \
-            -name '*.cpp' -o \
-            -name '*.cxx' -o \
-            -name '*.h' -o \
-            -name '*.hpp' \
-          \) \
-          ! -path './build/*' \
-          > tidy-reports/files.txt
+          find . \
+            -type f \
+            \( \
+              -name '*.c' -o \
+              -name '*.cc' -o \
+              -name '*.cpp' -o \
+              -name '*.cxx' -o \
+              -name '*.h' -o \
+              -name '*.hpp' \
+            \) \
+            ! -path './build/*' \
+            > tidy-reports/files.txt
 
-        FILE_COUNT=$(wc -l < tidy-reports/files.txt)
-        echo "Found $FILE_COUNT files"
+          FILE_COUNT=$(wc -l < tidy-reports/files.txt)
+          echo "Found $FILE_COUNT files"
 
-        if [ "$FILE_COUNT" -eq 0 ]; then
-          echo "No C/C++ files found."
-          exit 0
-        fi
+          if [ "$FILE_COUNT" -eq 0 ]; then
+            echo "No C/C++ files found."
+            exit 0
+          fi
 
-        echo "Running clang-tidy (this may take time)..."
+          echo "Running clang-tidy (this may take time)..."
 
-        set +e
-        while IFS= read -r file; do
-          echo "===== $file =====" >> tidy-reports/clang-tidy-report.txt
-          clang-tidy "$file" -p build \
-            >> tidy-reports/clang-tidy-report.txt 2>&1
-          echo "" >> tidy-reports/clang-tidy-report.txt
-        done < tidy-reports/files.txt
-        set -e
+          set +e
+          while IFS= read -r file; do
+            echo "===== $file =====" >> tidy-reports/clang-tidy-report.txt
+            clang-tidy "$file" -p build \
+              >> tidy-reports/clang-tidy-report.txt 2>&1
+            echo "" >> tidy-reports/clang-tidy-report.txt
+          done < tidy-reports/files.txt
+          set -e
 
-        echo "Clang-tidy analysis completed."
+          echo "Clang-tidy analysis completed."
 
-    - name: Upload clang-tidy report
-      uses: actions/upload-artifact@v4
-      with:
-        name: clang-tidy-full-report
-        path: tidy-reports/clang-tidy-report.txt
+      - name: Upload clang-tidy report
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-full-report
+          path: tidy-reports/clang-tidy-report.txt
 
   release:
     name: Release Packaging
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v4
-    - name: Configure CMake
-      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-    - name: Build
-      run: cmake --build build --config Release
-    - name: Package
-      run: cpack -C Release
-    - name: Upload Release Artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: release-packages
-        path: build/*.tar.gz
-    - name: Publish GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: build/*.tar.gz
+      - uses: actions/checkout@v4
+      - name: Configure CMake
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Package
+        run: cpack -C Release
+      - name: Upload Release Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-packages
+          path: build/*.tar.gz
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/*.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if(BUILD_TESTS)
     include(FetchContent)
     FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+        URL "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip"
         DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,48 +55,102 @@ function(apply_warning_flags target_name)
             -Wall               # Enable most warning flags
             -Wextra             # Enable extra warning flags
             -Wpedantic          # Warn on language extensions
+        )
+        
+        # Additional safe warnings that work across all versions
+        target_compile_options(${target_name} PRIVATE
             -Wshadow            # Warn when a local variable shadows another
             -Wformat=2          # Extra format string checks
-            -Wconversion        # Warn on implicit type conversions
-            -Wold-style-cast    # Warn on C-style casts
-            -Wcast-align        # Warn on pointer casts with increased alignment
             -Wunused            # Warn on unused entities
-            -Woverloaded-virtual # Warn when derived class hides virtual function
-            -Wdouble-promotion  # Warn on implicit float to double promotion
             -Wnon-virtual-dtor  # Warn on non-virtual destructor
-            -Wno-error          # Do NOT treat warnings as errors
         )
+        
+        # More aggressive warnings (may not be supported on all compilers)
+        # Only add if compiler supports them
+        include(CheckCXXCompilerFlag)
+        
+        check_cxx_compiler_flag("-Wconversion" HAS_WCONVERSION)
+        if(HAS_WCONVERSION)
+            target_compile_options(${target_name} PRIVATE -Wconversion)
+        endif()
+        
+        check_cxx_compiler_flag("-Wold-style-cast" HAS_WOLD_STYLE_CAST)
+        if(HAS_WOLD_STYLE_CAST)
+            target_compile_options(${target_name} PRIVATE -Wold-style-cast)
+        endif()
+        
+        check_cxx_compiler_flag("-Wcast-align" HAS_WCAST_ALIGN)
+        if(HAS_WCAST_ALIGN)
+            target_compile_options(${target_name} PRIVATE -Wcast-align)
+        endif()
+        
+        check_cxx_compiler_flag("-Woverloaded-virtual" HAS_WOVERLOADED_VIRTUAL)
+        if(HAS_WOVERLOADED_VIRTUAL)
+            target_compile_options(${target_name} PRIVATE -Woverloaded-virtual)
+        endif()
+        
+        check_cxx_compiler_flag("-Wdouble-promotion" HAS_WDOUBLE_PROMOTION)
+        if(HAS_WDOUBLE_PROMOTION)
+            target_compile_options(${target_name} PRIVATE -Wdouble-promotion)
+        endif()
+        
+        # IMPORTANT: Do NOT treat warnings as errors - only show them
+        target_compile_options(${target_name} PRIVATE -Wno-error)
         
         # GCC-specific warnings
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            target_compile_options(${target_name} PRIVATE
-                -Wlogical-op    # Warn on suspicious logical operations
-            )
+            check_cxx_compiler_flag("-Wlogical-op" HAS_WLOGICAL_OP)
+            if(HAS_WLOGICAL_OP)
+                target_compile_options(${target_name} PRIVATE -Wlogical-op)
+            endif()
             
-            # GCC 7+ only warnings
+            # GCC 7+ warnings
             if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)
-                target_compile_options(${target_name} PRIVATE
-                    -Wnull-dereference      # Warn if a null dereference is detected
-                    -Wduplicated-branches   # Warn on duplicated branches
-                    -Wimplicit-fallthrough  # Warn on implicit fallthrough in switch
-                )
+                check_cxx_compiler_flag("-Wnull-dereference" HAS_WNULL_DEREF)
+                if(HAS_WNULL_DEREF)
+                    target_compile_options(${target_name} PRIVATE -Wnull-dereference)
+                endif()
+                
+                check_cxx_compiler_flag("-Wduplicated-branches" HAS_WDUP_BRANCHES)
+                if(HAS_WDUP_BRANCHES)
+                    target_compile_options(${target_name} PRIVATE -Wduplicated-branches)
+                endif()
+                
+                check_cxx_compiler_flag("-Wimplicit-fallthrough" HAS_WIMPLICIT_FALLTHROUGH)
+                if(HAS_WIMPLICIT_FALLTHROUGH)
+                    target_compile_options(${target_name} PRIVATE -Wimplicit-fallthrough)
+                endif()
             endif()
             
             # GCC 6+ warnings
             if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0)
-                target_compile_options(${target_name} PRIVATE
-                    -Wduplicated-cond       # Warn on duplicated conditions
-                    -Wmisleading-indentation # Warn on misleading indentation
-                    -Wuseless-cast          # Warn on useless casts
-                )
+                check_cxx_compiler_flag("-Wduplicated-cond" HAS_WDUP_COND)
+                if(HAS_WDUP_COND)
+                    target_compile_options(${target_name} PRIVATE -Wduplicated-cond)
+                endif()
+                
+                check_cxx_compiler_flag("-Wmisleading-indentation" HAS_WMISLEADING_INDENT)
+                if(HAS_WMISLEADING_INDENT)
+                    target_compile_options(${target_name} PRIVATE -Wmisleading-indentation)
+                endif()
+                
+                check_cxx_compiler_flag("-Wuseless-cast" HAS_WUSELESS_CAST)
+                if(HAS_WUSELESS_CAST)
+                    target_compile_options(${target_name} PRIVATE -Wuseless-cast)
+                endif()
             endif()
         endif()
         
         # Clang-specific warnings
         if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            check_cxx_compiler_flag("-Wrange-loop-analysis" HAS_WRANGE_LOOP)
+            if(HAS_WRANGE_LOOP)
+                target_compile_options(${target_name} PRIVATE -Wrange-loop-analysis)
+            endif()
+            
+            # Disable C++98 compatibility warnings for Clang
             target_compile_options(${target_name} PRIVATE
-                -Wrange-loop-analysis   # Warn on range loop issues
-                -Wno-c++98-compat       # Don't warn about C++98 compatibility
+                -Wno-c++98-compat
                 -Wno-c++98-compat-pedantic
             )
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,80 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(BIN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/bin)
 
+# === Comprehensive Warning Flags (applied per-target) ===
+option(PEDANTIC_WARNINGS "Enable comprehensive compiler warnings" ON)
+
+# Function to apply warnings to a target
+function(apply_warning_flags target_name)
+    if(NOT PEDANTIC_WARNINGS)
+        return()
+    endif()
+    
+    if(MSVC)
+        # MSVC: Show all useful warnings
+        target_compile_options(${target_name} PRIVATE
+            /W4                 # Enable level 4 warnings (most warnings)
+            /permissive-        # Enforce standards conformance
+            # Disable specific noisy warnings that are not actionable
+            /wd4100             # Unreferenced formal parameter (common in interfaces/templates)
+            /wd4201             # Nonstandard extension used: nameless struct/union
+            /wd4458             # Declaration hides class member
+            /wd4459             # Declaration hides global declaration
+        )
+    else()
+        # GCC/Clang: Enable comprehensive warnings
+        target_compile_options(${target_name} PRIVATE
+            -Wall               # Enable most warning flags
+            -Wextra             # Enable extra warning flags
+            -Wpedantic          # Warn on language extensions
+            -Wshadow            # Warn when a local variable shadows another
+            -Wformat=2          # Extra format string checks
+            -Wconversion        # Warn on implicit type conversions
+            -Wold-style-cast    # Warn on C-style casts
+            -Wcast-align        # Warn on pointer casts with increased alignment
+            -Wunused            # Warn on unused entities
+            -Woverloaded-virtual # Warn when derived class hides virtual function
+            -Wdouble-promotion  # Warn on implicit float to double promotion
+            -Wnon-virtual-dtor  # Warn on non-virtual destructor
+            -Wno-error          # Do NOT treat warnings as errors
+        )
+        
+        # GCC-specific warnings
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            target_compile_options(${target_name} PRIVATE
+                -Wlogical-op    # Warn on suspicious logical operations
+            )
+            
+            # GCC 7+ only warnings
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)
+                target_compile_options(${target_name} PRIVATE
+                    -Wnull-dereference      # Warn if a null dereference is detected
+                    -Wduplicated-branches   # Warn on duplicated branches
+                    -Wimplicit-fallthrough  # Warn on implicit fallthrough in switch
+                )
+            endif()
+            
+            # GCC 6+ warnings
+            if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 6.0)
+                target_compile_options(${target_name} PRIVATE
+                    -Wduplicated-cond       # Warn on duplicated conditions
+                    -Wmisleading-indentation # Warn on misleading indentation
+                    -Wuseless-cast          # Warn on useless casts
+                )
+            endif()
+        endif()
+        
+        # Clang-specific warnings
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            target_compile_options(${target_name} PRIVATE
+                -Wrange-loop-analysis   # Warn on range loop issues
+                -Wno-c++98-compat       # Don't warn about C++98 compatibility
+                -Wno-c++98-compat-pedantic
+            )
+        endif()
+    endif()
+endfunction()
+
 add_library(CinderPeak INTERFACE)
 target_include_directories(CinderPeak INTERFACE 
     ${CMAKE_SOURCE_DIR}/src
@@ -41,7 +115,8 @@ if(BUILD_TESTS)
     include(FetchContent)
     FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+        URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
@@ -60,6 +135,9 @@ foreach(test_file ${TEST_SOURCES})
 
     add_executable(${test_name} ${test_file})
     target_link_libraries(${test_name} PRIVATE CinderPeak GTest::gtest_main)
+    
+    # Apply warning flags to this test target
+    apply_warning_flags(${test_name})
 
     set_target_properties(${test_name} PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY ${BIN_OUTPUT_DIR}/tests/${test_dir}
@@ -97,6 +175,9 @@ if(BUILD_EXAMPLES)
 
         add_executable(${example_target}_example ${example})
         target_link_libraries(${example_target}_example PRIVATE CinderPeak)
+        
+        # Apply warning flags to this example target
+        apply_warning_flags(${example_target}_example)
 
         # Preserve directory structure in output
         set_target_properties(${example_target}_example PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,8 +169,8 @@ if(BUILD_TESTS)
     include(FetchContent)
     FetchContent_Declare(
         googletest
-        URL "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip"
-        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG release-1.12.1
     )
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)

--- a/build.py
+++ b/build.py
@@ -22,6 +22,8 @@ FLAG_MAP = {
     "with_examples": ("-DBUILD_EXAMPLES=ON",),
     "sanitize": ("-DSANITIZE=ON",),
     "coverage": ("-DBUILD_COVERAGE=ON",),
+    "pedantic_warnings": ("-DPEDANTIC_WARNINGS=ON",),
+    "no_warnings": ("-DPEDANTIC_WARNINGS=OFF",),
 }
 
 def handle_build_errors(func):
@@ -82,6 +84,7 @@ def detect_generator() -> Optional[str]:
 def configure(build_dir: str = None, build_type: str = None,
               with_tests: bool = False, with_examples: bool = False,
               sanitize: bool = False, coverage: bool = False,
+              pedantic_warnings: bool = True, no_warnings: bool = False,
               generator: Optional[str] = None, toolchain: Optional[str] = None,
               cmake_path: str = None, ninja: bool = False,
               D: Optional[List[str]] = None, **kwargs: Any) -> None:
@@ -105,6 +108,12 @@ def configure(build_dir: str = None, build_type: str = None,
         cmake_options.extend(FLAG_MAP["sanitize"])
     if coverage:
         cmake_options.extend(FLAG_MAP["coverage"])
+    
+    # Enable comprehensive warnings by default unless explicitly disabled
+    if no_warnings:
+        cmake_options.extend(FLAG_MAP["no_warnings"])
+    elif pedantic_warnings:
+        cmake_options.extend(FLAG_MAP["pedantic_warnings"])
         
     if ninja:
         cmake_options.append("-GNinja")
@@ -352,6 +361,7 @@ def package(subcommand: str = None, release_version: str = None, **kwargs: Any) 
 def all_command(build_dir: str = None, build_type: str = None,
                 with_tests: bool = False, with_examples: bool = False,
                 sanitize: bool = False, coverage: bool = False,
+                pedantic_warnings: bool = True, no_warnings: bool = False,
                 jobs: Optional[int] = None, skip_tests: bool = False,
                 config: Optional[str] = None, **kwargs: Any) -> None:
     build_dir = build_dir or Config.DEFAULT_BUILD_DIR
@@ -361,7 +371,8 @@ def all_command(build_dir: str = None, build_type: str = None,
     
     configure(build_dir=build_dir, build_type=build_type,
               with_tests=with_tests, with_examples=with_examples,
-              sanitize=sanitize, coverage=coverage, **kwargs)
+              sanitize=sanitize, coverage=coverage,
+              pedantic_warnings=pedantic_warnings, no_warnings=no_warnings, **kwargs)
     
     build(build_dir=build_dir, jobs=jobs, config=config, **kwargs)
     
@@ -385,6 +396,10 @@ if __name__ == '__main__':
     p.add_argument('--with-examples', action='store_true')
     p.add_argument('--sanitize', action='store_true')
     p.add_argument('--coverage', action='store_true')
+    p.add_argument('--pedantic-warnings', action='store_true', default=True,
+                   help='Enable comprehensive compiler warnings (default: ON)')
+    p.add_argument('--no-warnings', action='store_true',
+                   help='Disable comprehensive compiler warnings')
     p.add_argument('--generator')
     p.add_argument('--toolchain')
     p.add_argument('--cmake-path', default='cmake')
@@ -452,6 +467,10 @@ if __name__ == '__main__':
     p.add_argument('--with-examples', action='store_true')
     p.add_argument('--sanitize', action='store_true')
     p.add_argument('--coverage', action='store_true')
+    p.add_argument('--pedantic-warnings', action='store_true', default=True,
+                   help='Enable comprehensive compiler warnings (default: ON)')
+    p.add_argument('--no-warnings', action='store_true',
+                   help='Disable comprehensive compiler warnings')
     p.add_argument('-j', '--jobs', type=int, help="Number of parallel build jobs")
     p.add_argument('--config', help='Build/test configuration (Debug, Release, etc.)')
     p.add_argument('--skip-tests', action='store_true', help="Skip running tests")


### PR DESCRIPTION
Rationale for this change
The build system did not enforce strict compilation standards, allowing code quality issues to go unnoticed. This change enables comprehensive compiler warnings for all builds, helping developers catch issues early without breaking builds due to warnings.

Fixes #168 

What changes are included in this PR?
Added a PEDANTIC_WARNINGS option to [CMakeLists.txt] (enabled by default).
Implemented a CMake function to apply industry-standard warning flags per target, supporting GCC, Clang, and MSVC.
Updated test and example targets to inherit these warning flags.
Updated [build.py] to support --pedantic-warnings and --no-warnings CLI options.
Warnings are now visible in all builds but do not break the build (only errors do).
Ensured compatibility with sanitizers and coverage options.

Are these changes tested?
Manual test: Compiling with g++ shows all relevant warnings.
The warning system was verified with a demo file and by building the project.
No new automated tests added, as this is a build system enhancement.

Are there any user-facing changes?
Developers will see more comprehensive warnings during builds.
New CLI options: --pedantic-warnings (default ON) and --no-warnings to control warning behavior.
No breaking changes to public APIs.
