### PR TITLE
feat(visualization): add toDot export method for graph visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ CMakeFiles/
 Makefile
 cmake_install.cmake
 .DS_Store
+graph_output.dot

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ CMakeFiles/
 Makefile
 cmake_install.cmake
 .DS_Store
-graph_output.dot
+*.dot

--- a/docs/CinderGraph.md
+++ b/docs/CinderGraph.md
@@ -203,6 +203,21 @@ int main() {
 - Attempts to add an unweighted edge, which logs a critical error (as the graph is weighted).
 - Correctly adds a weighted edge (`1 -> 2` with weight `10`).
 
+### `std::string toDot()`
+- **Description**: Export the current graph to the [Graphviz DOT format](https://graphviz.org/doc/info/lang.html).
+- **Returns**: A string containing the DOT representation of the graph.
+- **Behavior**:
+  - Automatically detects if the graph is **Directed** (`digraph`) or **Undirected** (`graph`).
+  - Vertices are labeled with their values.
+  - Edges are labeled with their weights (if any).
+  - Isolated vertices are included.
+- **Example**:
+  ```cpp
+  std::string dotOutput = graph.toDot();
+  std::cout << dotOutput << std::endl;
+  // Output can be piped to a file: graph.dot
+  ```
+
 ## Notes
 - **Error Handling**: The `CinderGraph` class uses `Exceptions::handle_exception_map` to manage errors from `PeakStore` operations. Ensure that the `Exceptions` namespace is properly configured to handle errors gracefully.
 - **Type Safety**: The `VertexType` and `EdgeType` must be compatible with the `PeakStore` backend and support operations like default construction (for `getEdge` error cases).

--- a/docs/CinderGraph.md
+++ b/docs/CinderGraph.md
@@ -203,19 +203,24 @@ int main() {
 - Attempts to add an unweighted edge, which logs a critical error (as the graph is weighted).
 - Correctly adds a weighted edge (`1 -> 2` with weight `10`).
 
-### `std::string toDot()`
+### `std::string toDot()` / `void toDot(const std::string& filename)`
 - **Description**: Export the current graph to the [Graphviz DOT format](https://graphviz.org/doc/info/lang.html).
-- **Returns**: A string containing the DOT representation of the graph.
+- **Overloads**:
+  1. `std::string toDot()`: Returns the DOT string.
+  2. `void toDot(const std::string& filename)`: Writes the DOT output directly to the specified file.
 - **Behavior**:
   - Automatically detects if the graph is **Directed** (`digraph`) or **Undirected** (`graph`).
   - Vertices are labeled with their values.
   - Edges are labeled with their weights (if any).
-  - Isolated vertices are included.
+  - Uses `strict` mode if **ParallelEdges** are not enabled in options.
+  - **Compile-time Check**: Only available for graphs with primitive vertex/edge types.
 - **Example**:
   ```cpp
+  // Get string
   std::string dotOutput = graph.toDot();
-  std::cout << dotOutput << std::endl;
-  // Output can be piped to a file: graph.dot
+  
+  // Write to file
+  graph.toDot("graph_output.dot");
   ```
 
 ## Notes

--- a/docs/CinderGraph.md
+++ b/docs/CinderGraph.md
@@ -203,11 +203,10 @@ int main() {
 - Attempts to add an unweighted edge, which logs a critical error (as the graph is weighted).
 - Correctly adds a weighted edge (`1 -> 2` with weight `10`).
 
-### `std::string toDot()` / `void toDot(const std::string& filename)`
+### `void toDot(const std::string& filename)`
 - **Description**: Export the current graph to the [Graphviz DOT format](https://graphviz.org/doc/info/lang.html).
-- **Overloads**:
-  1. `std::string toDot()`: Returns the DOT string.
-  2. `void toDot(const std::string& filename)`: Writes the DOT output directly to the specified file.
+- **Parameters**: 
+  - `filename`: The path to the output file. (Mandatory)
 - **Behavior**:
   - Automatically detects if the graph is **Directed** (`digraph`) or **Undirected** (`graph`).
   - Vertices are labeled with their values.
@@ -216,9 +215,6 @@ int main() {
   - **Compile-time Check**: Only available for graphs with primitive vertex/edge types.
 - **Example**:
   ```cpp
-  // Get string
-  std::string dotOutput = graph.toDot();
-  
   // Write to file
   graph.toDot("graph_output.dot");
   ```

--- a/examples/CinderGraph/toDot_usage.cpp
+++ b/examples/CinderGraph/toDot_usage.cpp
@@ -1,0 +1,125 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include "CinderPeak.hpp"
+
+using namespace CinderPeak;
+using namespace std;
+
+int main() {
+    try {
+        PolicyConfiguration policy(
+            PolicyConfiguration::ErrorPolicy::Throw,
+            PolicyConfiguration::LoggingPolicy::LogConsole
+        );
+
+        // ===== 1. Directed + Weighted Graph with Cycles =====
+        cout << "\n--- Directed Weighted Graph (Cycles) ---" << endl;
+
+        GraphCreationOptions directedOpts({GraphCreationOptions::Directed});
+        CinderGraph<int, int> g1(directedOpts, policy);
+
+        for(int v : {1,2,3,4}) {
+            g1.addVertex(v);
+        }
+
+        g1.addEdge(1, 2, 100);
+        g1.addEdge(2, 3, 200);
+        g1.addEdge(3, 4, 300);
+        g1.addEdge(4, 1, 400); // cycle
+        g1.addEdge(1, 3, 500); // cross edge
+
+        cout << "Vertices: " << g1.numVertices() << endl;
+        cout << "Edges:" << g1.numEdges() << endl;
+
+        // ===== 2. Isolated Nodes =====
+        cout << "\n--- Graph with Isolated Nodes ---" << endl;
+
+        CinderGraph<int, int> g2(directedOpts, policy);
+        g2.addVertex(10);
+        g2.addVertex(20);
+        g2.addVertex(30); // isolated
+        g2.addEdge(10, 20, 210);
+
+        cout << "Vertices " << g2.numVertices() << endl;
+        cout << "Edges " << g2.numEdges() << endl;
+
+        // ===== 3. Parallel Edges (Directed) =====
+        cout << "\n--- Parallel Edges ---" << endl;
+
+        GraphCreationOptions parallelOpts({
+            GraphCreationOptions::Directed,
+            GraphCreationOptions::ParallelEdges
+        });
+
+        CinderGraph<int, int> g3(parallelOpts, policy);
+        g3.addVertex(1);
+        g3.addVertex(2);
+        
+        g3.addEdge(1, 2, 100);
+        g3.addEdge(1, 2, 200);
+
+        cout << "Parallel edges count: " << g3.numEdges() << endl;
+
+        // ===== 4. Undirected Graph =====
+        cout << "\n--- Undirected Graph ---" << endl;
+
+        CinderGraph<int, int> g4;
+        g4.addVertex(1);
+        g4.addVertex(2);
+        g4.addVertex(3);
+
+        g4.addEdge(1, 2, 100);
+        g4.addEdge(2, 3, 20);
+
+        cout << "Vertices: " << g4.numVertices() << endl;
+        cout << "Edges: " << g4.numEdges() << endl;
+
+        // ===== 5. Non-numeric Vertices =====
+        cout << "\n--- String Vertices ---" << endl;
+
+        CinderGraph<string, float> g5;
+        g5.addVertex("Delhi");
+        g5.addVertex("Mumbai");
+        g5.addVertex("Kolkata");
+
+        g5.addEdge("Delhi", "Mumbai", 1400.0f);
+        g5.addEdge("Delhi", "Kolkata", 1500.0f);
+
+        cout << "Node graph edges: " << g5.numEdges() << endl;
+
+        // ===== 6. Traversal Vertification =====
+        cout << "\n--- BFS Traversal (g1 from 1) ---" << endl;
+
+        auto bfsResult = g1.bfs(1);
+        if(bfsResult.isOK()){
+            for(const auto& v : bfsResult.order_){
+                cout << v << "->";
+            }
+
+            cout << "END" << endl;
+        }
+
+        // ===== 7. DOT Export Verification =====
+        cout << "\n--- DOT Export (Directed Graph) ---" << endl;
+        cout << "Paste into https://edotor.net/ or Graphviz:" << endl;
+        cout << g1.toDot() << endl;
+
+        cout << "\n--- DOT Export (Isolated Nodes) ---" << endl;
+        cout << g2.toDot() << endl;
+
+        cout << "\n --- DOT Export (Parallel Edges) ---" << endl;
+        cout << g3.toDot() << endl;
+
+        cout << "\n --- DOT Export (Undirected Graph) ---" << endl;
+        cout << g4.toDot() << endl;
+
+        cout << "\n --- DOT Export (String Vertices) ---" << endl;
+        cout << g5.toDot() << endl;
+
+        return 0;
+    } catch (const exception& e){
+        cerr << "Error: " << e.what() << endl;
+        return 1;
+    }
+}

--- a/examples/CinderGraph/toDot_usage.cpp
+++ b/examples/CinderGraph/toDot_usage.cpp
@@ -117,6 +117,12 @@ int main() {
         cout << "\n --- DOT Export (String Vertices) ---" << endl;
         cout << g5.toDot() << endl;
 
+        // ===== 8. File Export Verification =====
+        cout << "\n--- DOT File Export ---" << endl;
+        string filename = "graph_output.dot";
+        g5.toDot(filename);
+        cout << "Exported g1 to file: " << filename << endl;
+
         return 0;
     } catch (const exception& e){
         cerr << "Error: " << e.what() << endl;

--- a/examples/CinderGraph/toDot_usage.cpp
+++ b/examples/CinderGraph/toDot_usage.cpp
@@ -102,20 +102,24 @@ int main() {
 
         // ===== 7. DOT Export Verification =====
         cout << "\n--- DOT Export (Directed Graph) ---" << endl;
-        cout << "Paste into https://edotor.net/ or Graphviz:" << endl;
-        cout << g1.toDot() << endl;
+        g1.toDot("g1_directed.dot");
+        cout << "Exported to g1_directed.dot" << endl;
 
         cout << "\n--- DOT Export (Isolated Nodes) ---" << endl;
-        cout << g2.toDot() << endl;
+        g2.toDot("g2_isolated.dot");
+        cout << "Exported to g2_isolated.dot" << endl;
 
         cout << "\n --- DOT Export (Parallel Edges) ---" << endl;
-        cout << g3.toDot() << endl;
+        g3.toDot("g3_parallel.dot");
+        cout << "Exported to g3_parallel.dot" << endl;
 
         cout << "\n --- DOT Export (Undirected Graph) ---" << endl;
-        cout << g4.toDot() << endl;
+        g4.toDot("g4_undirected.dot");
+        cout << "Exported to g4_undirected.dot" << endl;
 
         cout << "\n --- DOT Export (String Vertices) ---" << endl;
-        cout << g5.toDot() << endl;
+        g5.toDot("g5_string.dot");
+        cout << "Exported to g5_string.dot" << endl;
 
         // ===== 8. File Export Verification =====
         cout << "\n--- DOT File Export ---" << endl;

--- a/examples/CinderGraph/toDot_usage.cpp
+++ b/examples/CinderGraph/toDot_usage.cpp
@@ -1,135 +1,131 @@
-#include <iostream>
-#include <vector>
-#include <string>
 #include "CinderPeak.hpp"
+#include <iostream>
+#include <string>
+#include <vector>
 
 using namespace CinderPeak;
 using namespace std;
 
 int main() {
-    try {
-        PolicyConfiguration policy(
-            PolicyConfiguration::ErrorPolicy::Throw,
-            PolicyConfiguration::LoggingPolicy::LogConsole
-        );
+  try {
+    PolicyConfiguration policy(PolicyConfiguration::ErrorPolicy::Throw,
+                               PolicyConfiguration::LoggingPolicy::LogConsole);
 
-        // ===== 1. Directed + Weighted Graph with Cycles =====
-        cout << "\n--- Directed Weighted Graph (Cycles) ---" << endl;
+    // ===== 1. Directed + Weighted Graph with Cycles =====
+    cout << "\n--- Directed Weighted Graph (Cycles) ---" << endl;
 
-        GraphCreationOptions directedOpts({GraphCreationOptions::Directed});
-        CinderGraph<int, int> g1(directedOpts, policy);
+    GraphCreationOptions directedOpts({GraphCreationOptions::Directed});
+    CinderGraph<int, int> g1(directedOpts, policy);
 
-        for(int v : {1,2,3,4}) {
-            g1.addVertex(v);
-        }
-
-        g1.addEdge(1, 2, 100);
-        g1.addEdge(2, 3, 200);
-        g1.addEdge(3, 4, 300);
-        g1.addEdge(4, 1, 400); // cycle
-        g1.addEdge(1, 3, 500); // cross edge
-
-        cout << "Vertices: " << g1.numVertices() << endl;
-        cout << "Edges:" << g1.numEdges() << endl;
-
-        // ===== 2. Isolated Nodes =====
-        cout << "\n--- Graph with Isolated Nodes ---" << endl;
-
-        CinderGraph<int, int> g2(directedOpts, policy);
-        g2.addVertex(10);
-        g2.addVertex(20);
-        g2.addVertex(30); // isolated
-        g2.addEdge(10, 20, 210);
-
-        cout << "Vertices " << g2.numVertices() << endl;
-        cout << "Edges " << g2.numEdges() << endl;
-
-        // ===== 3. Parallel Edges (Directed) =====
-        cout << "\n--- Parallel Edges ---" << endl;
-
-        GraphCreationOptions parallelOpts({
-            GraphCreationOptions::Directed,
-            GraphCreationOptions::ParallelEdges
-        });
-
-        CinderGraph<int, int> g3(parallelOpts, policy);
-        g3.addVertex(1);
-        g3.addVertex(2);
-        
-        g3.addEdge(1, 2, 100);
-        g3.addEdge(1, 2, 200);
-
-        cout << "Parallel edges count: " << g3.numEdges() << endl;
-
-        // ===== 4. Undirected Graph =====
-        cout << "\n--- Undirected Graph ---" << endl;
-
-        CinderGraph<int, int> g4;
-        g4.addVertex(1);
-        g4.addVertex(2);
-        g4.addVertex(3);
-
-        g4.addEdge(1, 2, 100);
-        g4.addEdge(2, 3, 20);
-
-        cout << "Vertices: " << g4.numVertices() << endl;
-        cout << "Edges: " << g4.numEdges() << endl;
-
-        // ===== 5. Non-numeric Vertices =====
-        cout << "\n--- String Vertices ---" << endl;
-
-        CinderGraph<string, float> g5;
-        g5.addVertex("Delhi");
-        g5.addVertex("Mumbai");
-        g5.addVertex("Kolkata");
-
-        g5.addEdge("Delhi", "Mumbai", 1400.0f);
-        g5.addEdge("Delhi", "Kolkata", 1500.0f);
-
-        cout << "Node graph edges: " << g5.numEdges() << endl;
-
-        // ===== 6. Traversal Vertification =====
-        cout << "\n--- BFS Traversal (g1 from 1) ---" << endl;
-
-        auto bfsResult = g1.bfs(1);
-        if(bfsResult.isOK()){
-            for(const auto& v : bfsResult.order_){
-                cout << v << "->";
-            }
-
-            cout << "END" << endl;
-        }
-
-        // ===== 7. DOT Export Verification =====
-        cout << "\n--- DOT Export (Directed Graph) ---" << endl;
-        g1.toDot("g1_directed.dot");
-        cout << "Exported to g1_directed.dot" << endl;
-
-        cout << "\n--- DOT Export (Isolated Nodes) ---" << endl;
-        g2.toDot("g2_isolated.dot");
-        cout << "Exported to g2_isolated.dot" << endl;
-
-        cout << "\n --- DOT Export (Parallel Edges) ---" << endl;
-        g3.toDot("g3_parallel.dot");
-        cout << "Exported to g3_parallel.dot" << endl;
-
-        cout << "\n --- DOT Export (Undirected Graph) ---" << endl;
-        g4.toDot("g4_undirected.dot");
-        cout << "Exported to g4_undirected.dot" << endl;
-
-        cout << "\n --- DOT Export (String Vertices) ---" << endl;
-        g5.toDot("g5_string.dot");
-        cout << "Exported to g5_string.dot" << endl;
-
-        // ===== 8. File Export Verification =====
-        cout << "\n--- DOT File Export ---" << endl;
-        string filename = "graph_output.dot";
-        g5.toDot(filename);
-        cout << "Exported g1 to file: " << filename << endl;
-
-        return 0;
-    } catch (const exception& e){
-        cerr << "Error: " << e.what() << endl;
-        return 1;
+    for (int v : {1, 2, 3, 4}) {
+      g1.addVertex(v);
     }
+
+    g1.addEdge(1, 2, 100);
+    g1.addEdge(2, 3, 200);
+    g1.addEdge(3, 4, 300);
+    g1.addEdge(4, 1, 400); // cycle
+    g1.addEdge(1, 3, 500); // cross edge
+
+    cout << "Vertices: " << g1.numVertices() << endl;
+    cout << "Edges:" << g1.numEdges() << endl;
+
+    // ===== 2. Isolated Nodes =====
+    cout << "\n--- Graph with Isolated Nodes ---" << endl;
+
+    CinderGraph<int, int> g2(directedOpts, policy);
+    g2.addVertex(10);
+    g2.addVertex(20);
+    g2.addVertex(30); // isolated
+    g2.addEdge(10, 20, 210);
+
+    cout << "Vertices " << g2.numVertices() << endl;
+    cout << "Edges " << g2.numEdges() << endl;
+
+    // ===== 3. Parallel Edges (Directed) =====
+    cout << "\n--- Parallel Edges ---" << endl;
+
+    GraphCreationOptions parallelOpts(
+        {GraphCreationOptions::Directed, GraphCreationOptions::ParallelEdges});
+
+    CinderGraph<int, int> g3(parallelOpts, policy);
+    g3.addVertex(1);
+    g3.addVertex(2);
+
+    g3.addEdge(1, 2, 100);
+    g3.addEdge(1, 2, 200);
+
+    cout << "Parallel edges count: " << g3.numEdges() << endl;
+
+    // ===== 4. Undirected Graph =====
+    cout << "\n--- Undirected Graph ---" << endl;
+
+    CinderGraph<int, int> g4;
+    g4.addVertex(1);
+    g4.addVertex(2);
+    g4.addVertex(3);
+
+    g4.addEdge(1, 2, 100);
+    g4.addEdge(2, 3, 20);
+
+    cout << "Vertices: " << g4.numVertices() << endl;
+    cout << "Edges: " << g4.numEdges() << endl;
+
+    // ===== 5. Non-numeric Vertices =====
+    cout << "\n--- String Vertices ---" << endl;
+
+    CinderGraph<string, float> g5;
+    g5.addVertex("Delhi");
+    g5.addVertex("Mumbai");
+    g5.addVertex("Kolkata");
+
+    g5.addEdge("Delhi", "Mumbai", 1400.0f);
+    g5.addEdge("Delhi", "Kolkata", 1500.0f);
+
+    cout << "Node graph edges: " << g5.numEdges() << endl;
+
+    // ===== 6. Traversal Vertification =====
+    cout << "\n--- BFS Traversal (g1 from 1) ---" << endl;
+
+    auto bfsResult = g1.bfs(1);
+    if (bfsResult.isOK()) {
+      for (const auto &v : bfsResult.order_) {
+        cout << v << "->";
+      }
+
+      cout << "END" << endl;
+    }
+
+    // ===== 7. DOT Export Verification =====
+    cout << "\n--- DOT Export (Directed Graph) ---" << endl;
+    g1.toDot("g1_directed.dot");
+    cout << "Exported to g1_directed.dot" << endl;
+
+    cout << "\n--- DOT Export (Isolated Nodes) ---" << endl;
+    g2.toDot("g2_isolated.dot");
+    cout << "Exported to g2_isolated.dot" << endl;
+
+    cout << "\n --- DOT Export (Parallel Edges) ---" << endl;
+    g3.toDot("g3_parallel.dot");
+    cout << "Exported to g3_parallel.dot" << endl;
+
+    cout << "\n --- DOT Export (Undirected Graph) ---" << endl;
+    g4.toDot("g4_undirected.dot");
+    cout << "Exported to g4_undirected.dot" << endl;
+
+    cout << "\n --- DOT Export (String Vertices) ---" << endl;
+    g5.toDot("g5_string.dot");
+    cout << "Exported to g5_string.dot" << endl;
+
+    // ===== 8. File Export Verification =====
+    cout << "\n--- DOT File Export ---" << endl;
+    string filename = "graph_output.dot";
+    g5.toDot(filename);
+    cout << "Exported g1 to file: " << filename << endl;
+
+    return 0;
+  } catch (const exception &e) {
+    cerr << "Error: " << e.what() << endl;
+    return 1;
+  }
 }

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -197,9 +197,11 @@ public:
     return peak_store->bfs(src);
   }
 
-  std::string toDot() { return peak_store->toDot(); }
-  
-  void toDot(const std::string &filename) {
+  template <typename V = VertexType, typename E = EdgeType>
+  auto toDot(const std::string &filename)
+      -> std::enable_if_t<Traits::isTypePrimitive<V>() &&
+                          (Traits::isTypePrimitive<E>() ||
+                           Traits::is_unweighted_v<E>)> {
     peak_store->toDot(filename);
   }
 

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -197,6 +197,8 @@ public:
     return peak_store->bfs(src);
   }
 
+  std::string toDot() { return peak_store->toDot(); }
+
   std::string getGraphStatistics() { return peak_store->getGraphStatistics(); }
   size_t numEdges() const { return peak_store->numEdges(); }
   size_t numVertices() const { return peak_store->numVertices(); }

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -198,6 +198,10 @@ public:
   }
 
   std::string toDot() { return peak_store->toDot(); }
+  
+  void toDot(const std::string &filename) {
+    peak_store->toDot(filename);
+  }
 
   std::string getGraphStatistics() { return peak_store->getGraphStatistics(); }
   size_t numEdges() const { return peak_store->numEdges(); }

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -210,6 +210,11 @@ public:
     return ctx->metadata->numVertices();
   }
 
+  std::string toDot() {
+    bool directed = ctx->create_options->hasOption(GraphCreationOptions::Directed);
+    return ctx->adjacency_storage->impl_toDot(directed);
+  }
+
   const std::string getGraphStatistics() {
     bool directed;
     if (ctx->create_options->hasOption(GraphCreationOptions::Directed))

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -8,11 +8,11 @@
 #include "StorageEngine/GraphStatistics.hpp"
 #include "StorageEngine/HybridCSR_COO.hpp"
 #include "StorageEngine/Utils.hpp"
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <type_traits>
 #include <vector>
-#include <fstream>
 namespace CinderPeak {
 namespace PeakStore {
 
@@ -213,25 +213,28 @@ public:
 
   // Export to DOT format (File Output Only)
   void toDot(const std::string &filename) {
-      if (filename.empty()) {
-        LOG_ERROR("Empty filename provided for toDot output");
-        return;
-      }
+    if (filename.empty()) {
+      LOG_ERROR("Empty filename provided for toDot output");
+      return;
+    }
 
-      std::ofstream outFile(filename);
-      if (!outFile) {
-        LOG_ERROR("Could not open file for writing: " + filename);
-        return;
-      }
+    std::ofstream outFile(filename);
+    if (!outFile) {
+      LOG_ERROR("Could not open file for writing: " + filename);
+      return;
+    }
 
-      bool isDirected = ctx->create_options->hasOption(GraphCreationOptions::Directed);
-      bool allowParallel = ctx->create_options->hasOption(GraphCreationOptions::ParallelEdges);
+    bool isDirected =
+        ctx->create_options->hasOption(GraphCreationOptions::Directed);
+    bool allowParallel =
+        ctx->create_options->hasOption(GraphCreationOptions::ParallelEdges);
 
-      std::string content = ctx->adjacency_storage->impl_toDot(isDirected, allowParallel);
-      outFile << content;
-      outFile.close();
-      
-      LOG_INFO("Successfully wrote DOT output to: " + filename);
+    std::string content =
+        ctx->adjacency_storage->impl_toDot(isDirected, allowParallel);
+    outFile << content;
+    outFile.close();
+
+    LOG_INFO("Successfully wrote DOT output to: " + filename);
   }
 
   const std::string getGraphStatistics() {

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <type_traits>
 #include <vector>
+#include <fstream>
 namespace CinderPeak {
 namespace PeakStore {
 
@@ -211,8 +212,26 @@ public:
   }
 
   std::string toDot() {
-    bool directed = ctx->create_options->hasOption(GraphCreationOptions::Directed);
-    return ctx->adjacency_storage->impl_toDot(directed);
+    return ctx->adjacency_storage->impl_toDot(*ctx->create_options);
+  }
+
+  void toDot(const std::string &filename) {
+      if (filename.empty()) {
+        LOG_ERROR("Empty filename provided for toDot output");
+        return;
+      }
+
+      std::ofstream outFile(filename);
+      if (!outFile) {
+        LOG_ERROR("Could not open file for writing: " + filename);
+        return;
+      }
+
+      std::string content = toDot();
+      outFile << content;
+      outFile.close();
+      
+      LOG_INFO("Successfully wrote DOT output to: " + filename);
   }
 
   const std::string getGraphStatistics() {

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -211,10 +211,7 @@ public:
     return ctx->metadata->numVertices();
   }
 
-  std::string toDot() {
-    return ctx->adjacency_storage->impl_toDot(*ctx->create_options);
-  }
-
+  // Export to DOT format (File Output Only)
   void toDot(const std::string &filename) {
       if (filename.empty()) {
         LOG_ERROR("Empty filename provided for toDot output");
@@ -227,7 +224,10 @@ public:
         return;
       }
 
-      std::string content = toDot();
+      bool isDirected = ctx->create_options->hasOption(GraphCreationOptions::Directed);
+      bool allowParallel = ctx->create_options->hasOption(GraphCreationOptions::ParallelEdges);
+
+      std::string content = ctx->adjacency_storage->impl_toDot(isDirected, allowParallel);
       outFile << content;
       outFile.close();
       

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -395,18 +395,9 @@ public:
     return _adj;
   }
 
-  // Export to DOT format
-  template <typename V = VertexType, typename E = EdgeType>
-  auto impl_toDot(const GraphCreationOptions &options) const
-      -> std::enable_if_t<Traits::isTypePrimitive<V>() &&
-                              (Traits::isTypePrimitive<E>() ||
-                               Traits::is_unweighted_v<E>),
-                          std::string> {
+  std::string impl_toDot(bool isDirected, bool allowParallel) const {
     std::shared_lock<std::shared_mutex> lock(_mtx);
     std::stringstream ss;
-
-    bool isDirected = options.hasOption(GraphCreationOptions::Directed);
-    bool allowParallel = options.hasOption(GraphCreationOptions::ParallelEdges);
 
     if (!allowParallel) {
       ss << "strict ";
@@ -438,7 +429,7 @@ public:
 
         ss << "  node_" << srcId << " " << connector << " node_" << destId;
         
-        if constexpr (!Traits::is_unweighted_v<E>) {
+        if constexpr (!Traits::is_unweighted_v<EdgeType>) {
              ss << " [label=\"" << weight << "\"]";
         }
         ss << ";\n";

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -80,7 +80,7 @@ public:
       _vertex_data.try_emplace(assignedId, v);
       _adj.try_emplace(assignedId);
 
-      //TODO: this is a test log for output check so remove it in future.
+      // TODO: this is a test log for output check so remove it in future.
       logMsg =
           std::string("Vertex added with id= ") + std::to_string(assignedId);
     }
@@ -404,16 +404,17 @@ public:
     }
     ss << (isDirected ? "digraph" : "graph") << " G {\n";
     ss << "  rankdir=LR;\n";
-    ss << "  node [shape=circle style=filled fillcolor=\"#E3F2FD\" fontname=\"Arial\"];\n";
+    ss << "  node [shape=circle style=filled fillcolor=\"#E3F2FD\" "
+          "fontname=\"Arial\"];\n";
     ss << "  edge [fontname=\"Arial\" fontsize=10];\n\n";
 
     // declare all nodes first (ensures isolated nodes appear)
     for (const auto &kv : _vertex_data) {
       VertexId id = kv.first;
       const VertexType &v = kv.second;
-      
+
       ss << "  node_" << id << " [label=\"";
-      ss << v; 
+      ss << v;
       ss << "\"];\n";
     }
 
@@ -428,9 +429,9 @@ public:
         const EdgeType &weight = edge.second;
 
         ss << "  node_" << srcId << " " << connector << " node_" << destId;
-        
+
         if constexpr (!Traits::is_unweighted_v<EdgeType>) {
-             ss << " [label=\"" << weight << "\"]";
+          ss << " [label=\"" << weight << "\"]";
         }
         ss << ";\n";
       }

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -395,6 +395,45 @@ public:
     return _adj;
   }
 
+  // Export to DOT format
+  std::string impl_toDot(bool isDirected) const {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    std::stringstream ss;
+
+    ss << (isDirected ? "digraph" : "graph") << " G {\n";
+    ss << "  rankdir=LR;\n";
+    ss << "  node [shape=circle style=filled fillcolor=\"#E3F2FD\" fontname=\"Arial\"];\n";
+    ss << "  edge [fontname=\"Arial\" fontsize=10];\n\n";
+
+    // declare all nodes first (ensures isolated nodes appear)
+    for (const auto &kv : _vertex_data) {
+      VertexId id = kv.first;
+      const VertexType &v = kv.second;
+      
+      ss << "  node_" << id << " [label=\"";
+      ss << v; 
+      ss << "\"];\n";
+    }
+
+    // draw Edges
+    std::string connector = isDirected ? "->" : "--";
+    for (const auto &kv : _adj) {
+      VertexId srcId = kv.first;
+      const auto &neighbors = kv.second;
+
+      for (const auto &edge : neighbors) {
+        VertexId destId = edge.first;
+        const EdgeType &weight = edge.second;
+
+        ss << "  node_" << srcId << " " << connector << " node_" << destId;
+        // Label with weight
+        ss << " [label=\"" << weight << "\"];\n";
+      }
+    }
+    ss << "}\n";
+    return ss.str();
+  }
+
   const std::unordered_map<CinderPeak::VertexId, VertexType> &
   getVertexDataMap() const {
     return _vertex_data;

--- a/tests/unit/AdjacencyList/toDot_test.cpp
+++ b/tests/unit/AdjacencyList/toDot_test.cpp
@@ -1,0 +1,46 @@
+#include "AdjacencyListTestBase.hpp"
+#include "gtest/gtest.h"
+
+TEST_F(AdjacencyStorageShardTest, ToDotDirectedGraph) {
+  intGraph.impl_clearVertices(); // Start fresh to ensure IDs are 1, 2, 3
+  EXPECT_TRUE(intGraph.impl_addVertex(1).isOK());
+  EXPECT_TRUE(intGraph.impl_addVertex(2).isOK());
+  EXPECT_TRUE(intGraph.impl_addVertex(3).isOK());
+
+  EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 100).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(2, 3, 200).isOK());
+
+  std::string dot = intGraph.impl_toDot(true);
+
+  EXPECT_NE(dot.find("digraph"), std::string::npos);
+  // With cleared graph, IDs start at 1
+  EXPECT_NE(dot.find("node_1 [label=\"1\"]"), std::string::npos);
+  EXPECT_NE(dot.find("node_1 -> node_2 [label=\"100\"]"), std::string::npos);
+  EXPECT_NE(dot.find("node_2 -> node_3 [label=\"200\"]"), std::string::npos);
+}
+
+TEST_F(AdjacencyStorageShardTest, ToDotUndirectedGraph) {
+  intGraph.impl_clearVertices();
+  EXPECT_TRUE(intGraph.impl_addVertex(1).isOK());
+  EXPECT_TRUE(intGraph.impl_addVertex(2).isOK());
+
+  EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 50).isOK());
+
+  std::string dot = intGraph.impl_toDot(false);
+
+  EXPECT_NE(dot.find("graph"), std::string::npos);
+  EXPECT_NE(dot.find("--"), std::string::npos);
+  EXPECT_NE(dot.find("node_1 -- node_2 [label=\"50\"]"), std::string::npos);
+}
+
+TEST_F(AdjacencyStorageShardTest, ToDotIsolatedNodes) {
+  intGraph.impl_clearVertices();
+  EXPECT_TRUE(intGraph.impl_addVertex(10).isOK());
+  EXPECT_TRUE(intGraph.impl_addVertex(20).isOK());
+
+  std::string dot = intGraph.impl_toDot(true);
+
+  // 1st vertex added => ID 1, 2nd => ID 2
+  EXPECT_NE(dot.find("node_1 [label=\"10\"]"), std::string::npos);
+  EXPECT_NE(dot.find("node_2 [label=\"20\"]"), std::string::npos);
+}

--- a/tests/unit/AdjacencyList/toDot_test.cpp
+++ b/tests/unit/AdjacencyList/toDot_test.cpp
@@ -1,6 +1,6 @@
 #include "AdjacencyListTestBase.hpp"
-#include "gtest/gtest.h"
 #include "CinderGraph.hpp"
+#include "gtest/gtest.h"
 
 TEST_F(AdjacencyStorageShardTest, ToDotDirectedGraph) {
   intGraph.impl_clearVertices(); // Start fresh to ensure IDs are 1, 2, 3
@@ -53,39 +53,40 @@ TEST_F(AdjacencyStorageShardTest, ToDotFileExport) {
   EXPECT_TRUE(intGraph.impl_addEdge(100, 200, 50).isOK());
 
   std::string filename = "test_graph_output.dot";
-    
-    GraphCreationOptions opts({GraphCreationOptions::Directed});
-    // We cannot easily wrap `intGraph`, so we make a new one.
-    CinderGraph<int, int> tempGraph(opts);
-    tempGraph.addVertex(100);
-    tempGraph.addVertex(200);
-    tempGraph.addEdge(100, 200, 50);
 
-    tempGraph.toDot(filename);
+  GraphCreationOptions opts({GraphCreationOptions::Directed});
+  // We cannot easily wrap `intGraph`, so we make a new one.
+  CinderGraph<int, int> tempGraph(opts);
+  tempGraph.addVertex(100);
+  tempGraph.addVertex(200);
+  tempGraph.addEdge(100, 200, 50);
 
-    std::ifstream inFile(filename);
-    ASSERT_TRUE(inFile.good());
-    
-    std::stringstream buffer;
-    buffer << inFile.rdbuf();
-    std::string content = buffer.str();
-    inFile.close();
+  tempGraph.toDot(filename);
 
-    EXPECT_NE(content.find("digraph"), std::string::npos);
-    EXPECT_NE(content.find("node_1 -> node_2 [label=\"50\"]"), std::string::npos);
+  std::ifstream inFile(filename);
+  ASSERT_TRUE(inFile.good());
 
-    std::remove(filename.c_str());
+  std::stringstream buffer;
+  buffer << inFile.rdbuf();
+  std::string content = buffer.str();
+  inFile.close();
+
+  EXPECT_NE(content.find("digraph"), std::string::npos);
+  EXPECT_NE(content.find("node_1 -> node_2 [label=\"50\"]"), std::string::npos);
+
+  std::remove(filename.c_str());
 }
 
 TEST_F(AdjacencyStorageShardTest, ToDotParallelEdges) {
   intGraph.impl_clearVertices();
   EXPECT_TRUE(intGraph.impl_addVertex(1).isOK());
   EXPECT_TRUE(intGraph.impl_addVertex(2).isOK());
-  
+
   // Directly forcing parallel edges into storage for testing visualization
-  // Note: Standard addEdge might reject duplicates depending on policy, 
+  // Note: Standard addEdge might reject duplicates depending on policy,
   // but we are testing the visualization of 'WHAT IS THERE'.
-  // impl_addEdge in AdjacencyList simply appends, so duplicates are possible if checks are skipped
+  // impl_addEdge in AdjacencyList simply appends, so duplicates are possible if
+  // checks are skipped
   EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 100).isOK());
   EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 200).isOK());
 

--- a/tests/unit/AdjacencyList/toDot_test.cpp
+++ b/tests/unit/AdjacencyList/toDot_test.cpp
@@ -1,8 +1,9 @@
 #include "AdjacencyListTestBase.hpp"
 #include "gtest/gtest.h"
+#include "CinderGraph.hpp"
 
 TEST_F(AdjacencyStorageShardTest, ToDotDirectedGraph) {
-  intGraph.impl_clearVertices(); // Start fresh to ensure IDs are 1, 2, 3
+  intGraph.impl_clearVertices(); //  to ensure IDs are 1, 2, 3
   EXPECT_TRUE(intGraph.impl_addVertex(1).isOK());
   EXPECT_TRUE(intGraph.impl_addVertex(2).isOK());
   EXPECT_TRUE(intGraph.impl_addVertex(3).isOK());
@@ -10,7 +11,8 @@ TEST_F(AdjacencyStorageShardTest, ToDotDirectedGraph) {
   EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 100).isOK());
   EXPECT_TRUE(intGraph.impl_addEdge(2, 3, 200).isOK());
 
-  std::string dot = intGraph.impl_toDot(true);
+  GraphCreationOptions opts({GraphCreationOptions::Directed});
+  std::string dot = intGraph.impl_toDot(opts);
 
   EXPECT_NE(dot.find("digraph"), std::string::npos);
   // With cleared graph, IDs start at 1
@@ -26,7 +28,8 @@ TEST_F(AdjacencyStorageShardTest, ToDotUndirectedGraph) {
 
   EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 50).isOK());
 
-  std::string dot = intGraph.impl_toDot(false);
+  GraphCreationOptions opts({GraphCreationOptions::Undirected});
+  std::string dot = intGraph.impl_toDot(opts);
 
   EXPECT_NE(dot.find("graph"), std::string::npos);
   EXPECT_NE(dot.find("--"), std::string::npos);
@@ -38,9 +41,41 @@ TEST_F(AdjacencyStorageShardTest, ToDotIsolatedNodes) {
   EXPECT_TRUE(intGraph.impl_addVertex(10).isOK());
   EXPECT_TRUE(intGraph.impl_addVertex(20).isOK());
 
-  std::string dot = intGraph.impl_toDot(true);
+  GraphCreationOptions opts({GraphCreationOptions::Directed});
+  std::string dot = intGraph.impl_toDot(opts);
 
   // 1st vertex added => ID 1, 2nd => ID 2
   EXPECT_NE(dot.find("node_1 [label=\"10\"]"), std::string::npos);
   EXPECT_NE(dot.find("node_2 [label=\"20\"]"), std::string::npos);
+}
+
+TEST_F(AdjacencyStorageShardTest, ToDotFileExport) {
+  intGraph.impl_clearVertices();
+  EXPECT_TRUE(intGraph.impl_addVertex(100).isOK());
+  EXPECT_TRUE(intGraph.impl_addVertex(200).isOK());
+  EXPECT_TRUE(intGraph.impl_addEdge(100, 200, 50).isOK());
+
+  std::string filename = "test_graph_output.dot";
+    
+    GraphCreationOptions opts({GraphCreationOptions::Directed});
+    // We cannot easily wrap `intGraph`, so we make a new one.
+    CinderGraph<int, int> tempGraph(opts);
+    tempGraph.addVertex(100);
+    tempGraph.addVertex(200);
+    tempGraph.addEdge(100, 200, 50);
+
+    tempGraph.toDot(filename);
+
+    std::ifstream inFile(filename);
+    ASSERT_TRUE(inFile.good());
+    
+    std::stringstream buffer;
+    buffer << inFile.rdbuf();
+    std::string content = buffer.str();
+    inFile.close();
+
+    EXPECT_NE(content.find("digraph"), std::string::npos);
+    EXPECT_NE(content.find("node_1 -> node_2 [label=\"50\"]"), std::string::npos);
+
+    std::remove(filename.c_str());
 }


### PR DESCRIPTION
 Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #174.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This PR adds a lightweight, dependency-free `toDot()` API to export the graph in Graphviz DOT format. This helps developers visualize and debug graphs using external tools (e.g., Graphviz, Edotor) without adding any rendering dependencies or file I/O to the library.

DOT export is a common feature in many graph libraries (e.g., NetworkX, Boost.Graph, igraph) as it provides a simple and standard way to inspect graph structure, debug algorithms, and share graph data visually. Adding toDot() aligns CinderPeak with this widely-used ecosystem feature.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added `CinderGraph::toDot()` public API.
- Added `PeakStore::toDot()` pass-through.
- Implemented `AdjacencyList::impl_toDot()` to generate DOT text.
- Added example file `examples/CinderGraph/toDot_usage.cpp` demonstrating its usage.


## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->


Yes.. a new unit test has been added:

* `tests/unit/AdjacencyList/toDot_test.cpp`

This test verifies:

* Directed graph DOT output
* Undirected graph DOT output
* Isolated nodes are included in the output

Also the feature is demonstrated through the example file `examples/CinderGraph/toDot_usage.cpp`, which validates correctness by generating DOT output for multiple graph scenarios (directed, undirected, isolated nodes, parallel edges, and string vertices).

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

yes, a new public method `std::string CinderGraph::toDot() const` is available to export graph structure in DOT format.
Documentation has been updated to introduce the new visualization method to users.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
