### PR TITLE
fix(warnings): resolve unused variable and parameter warnings (#189)

### DIFF
--- a/examples/CinderGraph/addVertex_usage.cpp
+++ b/examples/CinderGraph/addVertex_usage.cpp
@@ -24,9 +24,9 @@ int main() {
 
     // 4. String vertices
     CinderGraph<string, double> g2;
-    auto [vs1, addedS1] = g2.addVertex("NodeA");
-    auto [vs2, addedS2] = g2.addVertex("NodeB");
-    auto [vs3, addedS3] = g2.addVertex("NodeC");
+    [[maybe_unused]] auto [vs1, addedS1] = g2.addVertex("NodeA");
+    [[maybe_unused]] auto [vs2, addedS2] = g2.addVertex("NodeB");
+    [[maybe_unused]] auto [vs3, addedS3] = g2.addVertex("NodeC");
     cout << "\nAdded string vertices: " << g2.numVertices() << endl;
 
     // 5. Adding vertices in a loop

--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -16,7 +16,7 @@ public:
       const std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>>
           &hcsr)
       : hcsr(hcsr) {}
-  BFSResult<VertexType> bfs(const VertexType &src) {
+  BFSResult<VertexType> bfs([[maybe_unused]] const VertexType &src) {
     std::cout << "Algorithms::bfs called\n";
 
     BFSResult<VertexType> result;


### PR DESCRIPTION
This PR resolves compiler warnings reported in Issue #189.

Changes:
- Suppressed unused structured binding warnings in addVertex_usage.cpp
- Suppressed unused parameter warning in CinderPeakAlgorithms::bfs()

All changes are minimal, preserve existing behavior, and stay within the issue scope.

Closes #189
