### PR TITLE
Increment 5: fix files producing warnings (#190)

### DIFF
--- a/src/StorageEngine/GraphStatistics.hpp
+++ b/src/StorageEngine/GraphStatistics.hpp
@@ -35,9 +35,9 @@ private:
   mutable std::shared_mutex _mtx;
 
 public:
-  GraphInternalMetadata(const std::string &graph_type, bool vertex_tp_p,
+  GraphInternalMetadata(const std::string &graphType, bool vertex_tp_p,
                         bool edge_tp_p, bool weighted, bool unweighted)
-      : graph_type(graph_type), is_vertex_type_primitive(vertex_tp_p),
+      : graph_type(graphType), is_vertex_type_primitive(vertex_tp_p),
         is_edge_type_primitive(edge_tp_p) {
 
     num_vertices = 0;
@@ -85,11 +85,11 @@ public:
   GraphInternalMetadata(GraphInternalMetadata &&) = delete;
   GraphInternalMetadata &operator=(GraphInternalMetadata &&) = delete;
 
-  const bool isGraphWeighted() {
+  bool isGraphWeighted() {
     std::shared_lock<std::shared_mutex> lock(_mtx);
     return is_graph_weighted;
   }
-  const bool isGraphUnweighted() {
+  bool isGraphUnweighted() {
     std::shared_lock<std::shared_mutex> lock(_mtx);
     return is_graph_unweighted;
   }
@@ -102,7 +102,7 @@ public:
     std::shared_lock<std::shared_mutex> lock(_mtx);
     return num_vertices;
   }
-  const std::string graphType() {
+  std::string graphType() {
     std::shared_lock<std::shared_mutex> lock(_mtx);
     return graph_type;
   }
@@ -165,7 +165,7 @@ public:
       density = 2 * directed_density;
   }
 
-  const std::string getGraphStatistics(bool directed) {
+  std::string getGraphStatistics(bool directed) {
     updateDensity(directed);
 
     std::shared_lock<std::shared_mutex> lock(_mtx);

--- a/tests/unit/AdjacencyList/AdjacencyListTestBase.hpp
+++ b/tests/unit/AdjacencyList/AdjacencyListTestBase.hpp
@@ -47,7 +47,6 @@ public:
   ComplexAdjEdge() = default;
 };
 
-
 class ComplexGraph : public ::testing::Test {
 public:
   ComplexAdjVertex v1, v2, v3;

--- a/tests/unit/AdjacencyList/AdjacencyListTestBase.hpp
+++ b/tests/unit/AdjacencyList/AdjacencyListTestBase.hpp
@@ -35,17 +35,18 @@ class ComplexAdjVertex : public CinderVertex {
 public:
   int vertexData;
   std::string nodeName;
-  ComplexAdjVertex(int vertexData_, std::string node_name)
-      : vertexData{vertexData_}, nodeName{node_name} {}
+  ComplexAdjVertex(int vertex_data, std::string node_name)
+      : vertexData{vertex_data}, nodeName{node_name} {}
   ComplexAdjVertex() = default;
 };
 
 class ComplexAdjEdge : public CinderEdge {
 public:
   float edgeValue;
-  ComplexAdjEdge(float edgeValue_) : edgeValue{edgeValue_} {}
+  ComplexAdjEdge(float edge_value) : edgeValue{edge_value} {}
   ComplexAdjEdge() = default;
 };
+
 
 class ComplexGraph : public ::testing::Test {
 public:

--- a/tests/unit/AdjacencyList/updateEdge_test.cpp
+++ b/tests/unit/AdjacencyList/updateEdge_test.cpp
@@ -17,8 +17,8 @@ TEST_F(AdjacencyStorageShardTest, UpdateEdgeWithWeight) {
   EXPECT_EQ(edge2.first, 1);
 }
 TEST_F(ComplexGraph, UpdateEdgeOnComplexGraph) {
-  ComplexAdjEdge newEdgeValue1(4.3);
-  ComplexAdjEdge newEdgeValue2(467.32);
+  ComplexAdjEdge newEdgeValue1(4.3f);
+  ComplexAdjEdge newEdgeValue2(467.32f);
   EXPECT_TRUE(complexGraph.impl_addEdge(v1, v2, e1).isOK());
   EXPECT_TRUE(complexGraph.impl_addEdge(v2, v3, e2).isOK());
 


### PR DESCRIPTION
## Which issue does this PR close?
Closes #190 

## Rationale for this change
This PR addresses compiler warnings reported in issue #190.
Fixing these warnings improves code quality, readability, and build reliability, and helps ensure the project compiles cleanly under stricter warning flags.

## What changes are included in this PR?
Updated GraphStatistics.hpp to improve const-correctness and naming clarity.
Fixed shadowing warnings in AdjacencyListTestBase.hpp by clarifying member usage.
Resolved float conversion warnings in adjacency list unit tests by using explicit float literals where intended.
Ensured test code aligns with compiler expectations without changing runtime behavior.

## Are these changes tested?
Yes. All existing unit tests continue to cover the modified code paths, and the changes are limited to warning fixes without altering logic or functionality. No new tests were required.

## Are there any user-facing changes?
No.
These changes are internal and do not affect public APIs or user-visible behavior.
