### PR TITLE
chore(logs): remove unused LOG_ macros and related usages

### DIFF
--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -183,7 +183,6 @@ public:
     return {newWeight, true};
   }
   GetEdgeResult getEdge(const VertexType &src, const VertexType &dest) {
-    LOG_INFO("Called getEdge");
     auto [data, status] = peak_store->getEdge(src, dest);
     if (!status.isOK()) {
       Exceptions::handle_exception_map(status);

--- a/src/PeakLogger.hpp
+++ b/src/PeakLogger.hpp
@@ -140,16 +140,3 @@ private:
     logFile << std::endl;
   }
 };
-
-// for now, not removed but disabled the behavior, so that builds dont fail.
-#define LOG_TRACE(msg)
-//  Logger::log(LogLevel::TRACE, msg)
-#define LOG_DEBUG(msg)
-//  Logger::log(LogLevel::DEBUG, msg)
-#define LOG_INFO(msg)
-// Logger::log(LogLevel::INFO, msg)
-#define LOG_WARNING(msg)
-//  Logger::log(LogLevel::WARNING, msg, __FILE__, __LINE__)
-#define LOG_ERROR(msg)
-//  Logger::log(LogLevel::ERROR, msg, __FILE__, __LINE__)
-#define LOG_CRITICAL(msg)

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -189,25 +189,18 @@ namespace Exceptions {
 inline void handle_exception_map(const PeakStatus &status) {
   switch (static_cast<int>(status.code())) {
   case static_cast<int>(StatusCode::NOT_FOUND):
-    
     break;
   case static_cast<int>(StatusCode::UNIMPLEMENTED):
-    
     break;
   case static_cast<int>(StatusCode::ALREADY_EXISTS):
-    
     break;
   case static_cast<int>(StatusCode::VERTEX_ALREADY_EXISTS):
-    
     break;
   case static_cast<int>(StatusCode::VERTEX_NOT_FOUND):
-    
     break;
   case static_cast<int>(StatusCode::EDGE_ALREADY_EXISTS):
-    
     break;
   default:
-    
     break;
   }
 }

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -189,25 +189,25 @@ namespace Exceptions {
 inline void handle_exception_map(const PeakStatus &status) {
   switch (static_cast<int>(status.code())) {
   case static_cast<int>(StatusCode::NOT_FOUND):
-    LOG_INFO("Resource Not Found");
+    
     break;
   case static_cast<int>(StatusCode::UNIMPLEMENTED):
-    LOG_WARNING("Called an Unimplemented method");
+    
     break;
   case static_cast<int>(StatusCode::ALREADY_EXISTS):
-    LOG_INFO("Resource Already Exists");
+    
     break;
   case static_cast<int>(StatusCode::VERTEX_ALREADY_EXISTS):
-    LOG_INFO("Vertex Already Exists");
+    
     break;
   case static_cast<int>(StatusCode::VERTEX_NOT_FOUND):
-    LOG_ERROR("Vertex does not exist");
+    
     break;
   case static_cast<int>(StatusCode::EDGE_ALREADY_EXISTS):
-    LOG_INFO("Edge Already Exists");
+    
     break;
   default:
-    LOG_CRITICAL("Unhandled Exception Occurred");
+    
     break;
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #210

## Rationale for this change

The `LOG_` macros in `PeakLogger.hpp` were unused and had no active implementation, as their logic was commented out. Removing them helps clean up the code and makes it easier to understand.

## What changes are included in this PR?

- Removed unused `LOG_` macro definitions from `PeakLogger.hpp`
- Removed all usages of these macros from:
  - `CinderGraph.hpp`
  - `StorageEngine/Utils.hpp`
- I also ensured that no leftover references to these macros remain in the codebase.

## Are these changes tested?

Yes. I verified that the project builds successfully after making these changes.

## Are there any user-facing changes?

No. These changes are internal and do not affect user-facing functionality.