### PR TITLE
refactor(graph): simplify getEdge return type using std::optional<EdgeType>

### DIFF
--- a/examples/CinderGraph/ListExample1.cpp
+++ b/examples/CinderGraph/ListExample1.cpp
@@ -38,10 +38,10 @@ int main() {
   if (graph.hasVertex(6))
     std::cout << "Vertex 6 exists.\n";
 
-  std::cout << "Does edge (5,3) exists: " << graph.getEdge(5, 3).second
+  std::cout << "Does edge (5,3) exists: " << graph.getEdge(5, 3).has_value()
             << "\n"; // Check edge existence
   graph.removeEdge(5, 3);
-  std::cout << "Does edge (5,3) exists: " << graph.getEdge(5, 3).second
+  std::cout << "Does edge (5,3) exists: " << graph.getEdge(5, 3).has_value()
             << "\n"; // Check edge existence after removal
 
   std::cout << "Number of vertices: " << graph.numVertices()
@@ -115,9 +115,8 @@ int main() {
   else
     std::cout << "Failed to add ListEdge lv1->lv2\n";
 
-  // getEdge returns pair<optional<Edge_t>, bool>
-  auto [maybeBeforeEdge, foundBefore] = listGraph.getEdge(lv1, lv2);
-  if (foundBefore && maybeBeforeEdge)
+  auto maybeBeforeEdge = listGraph.getEdge(lv1, lv2);
+  if (maybeBeforeEdge)
     std::cout << "Edge value before update: " << maybeBeforeEdge->edge_weight
               << "\n";
   else
@@ -132,8 +131,8 @@ int main() {
   else
     std::cout << "updateEdge failed for lv1->lv2\n";
 
-  auto [maybeAfterEdge, foundAfter] = listGraph.getEdge(lv1, lv2);
-  if (foundAfter && maybeAfterEdge)
+  auto maybeAfterEdge = listGraph.getEdge(lv1, lv2);
+  if (maybeAfterEdge)
     std::cout << "Edge value after the update: " << maybeAfterEdge->edge_weight
               << "\n";
   else

--- a/examples/CinderGraph/PrimitiveGraph.cpp
+++ b/examples/CinderGraph/PrimitiveGraph.cpp
@@ -41,8 +41,8 @@ int main() {
 
   // Retrieve an edge safely
   auto getRes = graph.getEdge(2, 5);
-  if (getRes.second && getRes.first.has_value()) {
-    std::cout << "Edge (2->5) value: " << *(getRes.first) << "\n";
+  if (getRes.has_value()) {
+    std::cout << "Edge (2->5) value: " << *getRes << "\n";
   } else {
     std::cout << "Edge (2->5) not found.\n";
   }

--- a/examples/CinderGraph/getEdge_usage.cpp
+++ b/examples/CinderGraph/getEdge_usage.cpp
@@ -18,22 +18,22 @@ int main() {
     g.addEdge(3, 4, 5.25);
 
     // Get existing edge
-    auto [weight1, found1] = g.getEdge(1, 2);
-    if (found1 && weight1.has_value()) {
+    auto weight1 = g.getEdge(1, 2);
+    if (weight1.has_value()) {
       cout << "Edge (1,2) weight: " << weight1.value() << endl;
     } else {
       cout << "Edge (1,2) not found" << endl;
     }
 
     // Get another edge
-    auto [weight2, found2] = g.getEdge(2, 3);
-    if (found2 && weight2.has_value()) {
+    auto weight2 = g.getEdge(2, 3);
+    if (weight2.has_value()) {
       cout << "Edge (2,3) weight: " << weight2.value() << endl;
     }
 
     // Try to get non-existent edge
-    auto [weight3, found3] = g.getEdge(1, 4);
-    cout << "Edge (1,4) found: " << (found3 ? "yes" : "no") << endl;
+    auto weight3 = g.getEdge(1, 4);
+    cout << "Edge (1,4) found: " << (weight3.has_value() ? "yes" : "no") << endl;
 
     // String vertices
     cout << "\n--- String Vertices ---" << endl;
@@ -45,19 +45,19 @@ int main() {
     g2.addEdge("A", "B", 42);
     g2.addEdge("B", "C", 100);
 
-    auto [w4, f4] = g2.getEdge("A", "B");
-    if (f4 && w4.has_value()) {
+    auto w4 = g2.getEdge("A", "B");
+    if (w4.has_value()) {
       cout << "Edge (A,B) weight: " << w4.value() << endl;
     }
 
-    auto [w5, f5] = g2.getEdge("B", "C");
-    if (f5 && w5.has_value()) {
+    auto w5 = g2.getEdge("B", "C");
+    if (w5.has_value()) {
       cout << "Edge (B,C) weight: " << w5.value() << endl;
     }
 
     // Check non-existent edge
-    auto [w6, f6] = g2.getEdge("A", "C");
-    if (f6 && w6.has_value()) {
+    auto w6 = g2.getEdge("A", "C");
+    if (w6.has_value()) {
       cout << "Edge (A,C) weight: " << w6.value() << endl;
     } else {
       cout << "Edge (A,C) does not exist" << endl;
@@ -70,8 +70,8 @@ int main() {
     g3.addVertex(20);
     g3.addEdge(10, 20, 15.5f);
 
-    auto [weight, exists] = g3.getEdge(10, 20);
-    if (exists && weight.has_value()) {
+    auto weight = g3.getEdge(10, 20);
+    if (weight.has_value()) {
       if (weight.value() > 10.0f) {
         cout << "Edge weight " << weight.value() << " is greater than 10.0"
              << endl;
@@ -89,8 +89,8 @@ int main() {
 
     vector<pair<int, int>> edgesToCheck = {{1, 2}, {2, 3}, {1, 3}};
     for (const auto &[src, dest] : edgesToCheck) {
-      auto [w, f] = g4.getEdge(src, dest);
-      if (f && w.has_value()) {
+      auto w = g4.getEdge(src, dest);
+      if (w.has_value()) {
         cout << "Edge (" << src << "," << dest << ") has weight: " << w.value()
              << endl;
       } else {

--- a/examples/CinderGraph/getEdge_usage.cpp
+++ b/examples/CinderGraph/getEdge_usage.cpp
@@ -33,7 +33,8 @@ int main() {
 
     // Try to get non-existent edge
     auto weight3 = g.getEdge(1, 4);
-    cout << "Edge (1,4) found: " << (weight3.has_value() ? "yes" : "no") << endl;
+    cout << "Edge (1,4) found: "
+         << (weight3.has_value() ? "yes" : "no") << endl;
 
     // String vertices
     cout << "\n--- String Vertices ---" << endl;

--- a/examples/CinderGraph/getEdge_usage.cpp
+++ b/examples/CinderGraph/getEdge_usage.cpp
@@ -33,8 +33,8 @@ int main() {
 
     // Try to get non-existent edge
     auto weight3 = g.getEdge(1, 4);
-    cout << "Edge (1,4) found: "
-         << (weight3.has_value() ? "yes" : "no") << endl;
+    cout << "Edge (1,4) found: " << (weight3.has_value() ? "yes" : "no")
+         << endl;
 
     // String vertices
     cout << "\n--- String Vertices ---" << endl;

--- a/examples/CinderGraph/updateEdge_usage.cpp
+++ b/examples/CinderGraph/updateEdge_usage.cpp
@@ -21,8 +21,8 @@ int main() {
     cout << "Initial edge (1,2) with weight 10.0" << endl;
 
     // Get initial weight
-    auto [initialWeight, found1] = g.getEdge(1, 2);
-    if (found1 && initialWeight.has_value()) {
+    auto initialWeight = g.getEdge(1, 2);
+    if (initialWeight.has_value()) {
       cout << "Current weight of edge (1,2): " << initialWeight.value() << endl;
     }
 
@@ -32,8 +32,8 @@ int main() {
          << (updated ? "success" : "failed") << endl;
 
     // Verify update
-    auto [verifyWeight, found2] = g.getEdge(1, 2);
-    if (found2 && verifyWeight.has_value()) {
+    auto verifyWeight = g.getEdge(1, 2);
+    if (verifyWeight.has_value()) {
       cout << "Verified weight of edge (1,2): " << verifyWeight.value() << endl;
     }
 
@@ -75,8 +75,8 @@ int main() {
     g3.updateEdge(10, 20, 20);
     cout << "Updated to: 20" << endl;
 
-    auto [finalWeight, finalFound] = g3.getEdge(10, 20);
-    if (finalFound && finalWeight.has_value()) {
+    auto finalWeight = g3.getEdge(10, 20);
+    if (finalWeight.has_value()) {
       cout << "Final weight: " << finalWeight.value() << endl;
     }
 

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -23,8 +23,8 @@ public:
       : graph(g), src(s) {}
 
   EdgeType operator[](const VertexType &dest) const {
-    auto [optWeight, found] = graph.getEdge(src, dest);
-    if (!found || !optWeight.has_value()) {
+    auto optWeight = graph.getEdge(src, dest);
+    if (!optWeight.has_value()) {
       throw std::runtime_error("Edge not found: " + src + " -> " + dest);
     }
     return *optWeight;
@@ -52,8 +52,8 @@ public:
     }
 
     operator EdgeType() const {
-      auto [optWeight, found] = graph.getEdge(src, dest);
-      return (found && optWeight) ? *optWeight : EdgeType{};
+      auto optWeight = graph.getEdge(src, dest);
+      return optWeight ? *optWeight : EdgeType{};
     }
   };
 
@@ -77,11 +77,6 @@ template <typename VertexType, typename EdgeType> class CinderGraph {
   // UpdateEdgeResult: {previousWeight, updatedFlag}
   // (previousWeight is EdgeType{} when edge missing or unknown)
   using UpdateEdgeResult = std::pair<EdgeType, bool>;
-
-  // GetEdgeResult: {optional(weight), foundFlag}
-  // Note: optional already conveys presence; bool duplicates that info but kept
-  // per typedef.
-  using GetEdgeResult = std::pair<std::optional<EdgeType>, bool>;
 
   using RemoveEdgeResult = std::pair<std::optional<EdgeType>, bool>;
 
@@ -206,13 +201,13 @@ public:
     peak_store->log(LogLevel::INFO, "API: updateEdge completed successfully");
     return {newWeight, true};
   }
-  GetEdgeResult getEdge(const VertexType &src, const VertexType &dest) {
+  std::optional<EdgeType> getEdge(const VertexType &src, const VertexType &dest) {
     auto [data, status] = peak_store->getEdge(src, dest);
     if (!status.isOK()) {
       Exceptions::handle_exception_map(status);
-      return {std::nullopt, false};
+      return std::nullopt;
     }
-    return {std::make_optional(data), true};
+    return data;
   }
   Algorithms::BFSResult<VertexType> bfs(const VertexType &src) {
     return peak_store->bfs(src);

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -201,7 +201,8 @@ public:
     peak_store->log(LogLevel::INFO, "API: updateEdge completed successfully");
     return {newWeight, true};
   }
-  std::optional<EdgeType> getEdge(const VertexType &src, const VertexType &dest) {
+  std::optional<EdgeType> getEdge(const VertexType &src,
+                                  const VertexType &dest) {
     auto [data, status] = peak_store->getEdge(src, dest);
     if (!status.isOK()) {
       Exceptions::handle_exception_map(status);

--- a/tests/integration/CinderGraph/functional/getEdge_test.cpp
+++ b/tests/integration/CinderGraph/functional/getEdge_test.cpp
@@ -19,16 +19,15 @@ TEST_F(CinderGraphFunctionalTest, GetWeightedEdgePrimitive) {
   EXPECT_TRUE(intGraph.addEdge(2, 3, 15).second);
   EXPECT_TRUE(intGraph.addEdge(1, 2, 25).second);
 
-  auto [weight, status] = intGraph.getEdge(1, 3);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 5);
+  auto weight = intGraph.getEdge(1, 3);
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 5);
 
-  auto [weight1, status1] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 25);
+  auto weight1 = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 25);
 
-  auto [weight2, status2] = intGraph.getEdge(1, 6);
-  EXPECT_FALSE(status2);
+  auto weight2 = intGraph.getEdge(1, 6);
   EXPECT_FALSE(weight2.has_value());
 }
 
@@ -43,9 +42,9 @@ TEST_F(CinderGraphFunctionalTest, GetUnWeightedEdgePrimitive) {
   EXPECT_TRUE(intGraph.addEdge(2, 3).second);
   EXPECT_TRUE(intGraph.addEdge(1, 2).second);
 
-  EXPECT_TRUE(intGraph.getEdge(1, 3).second);
-  EXPECT_TRUE(intGraph.getEdge(1, 2).second);
-  EXPECT_FALSE(intGraph.getEdge(1, 6).second);
+  EXPECT_TRUE(intGraph.getEdge(1, 3).has_value());
+  EXPECT_TRUE(intGraph.getEdge(1, 2).has_value());
+  EXPECT_FALSE(intGraph.getEdge(1, 6).has_value());
 }
 
 TEST_F(CinderGraphFunctionalTest, GetWeightedEdgeString) {
@@ -58,16 +57,15 @@ TEST_F(CinderGraphFunctionalTest, GetWeightedEdgeString) {
   EXPECT_TRUE(stringGraph.addEdge("A", "B", 42).second);
   EXPECT_TRUE(stringGraph.addEdge("B", "C", 100).second);
 
-  auto [weight, status] = stringGraph.getEdge("A", "B");
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 42);
+  auto weight = stringGraph.getEdge("A", "B");
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 42);
 
-  auto [weight1, status1] = stringGraph.getEdge("B", "C");
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 100);
+  auto weight1 = stringGraph.getEdge("B", "C");
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 100);
 
-  auto [weight2, status2] = stringGraph.getEdge("A", "C");
-  EXPECT_FALSE(status2);
+  auto weight2 = stringGraph.getEdge("A", "C");
   EXPECT_FALSE(weight2.has_value());
 }
 
@@ -81,9 +79,9 @@ TEST_F(CinderGraphFunctionalTest, GetUnweightedEdgeString) {
   EXPECT_TRUE(stringGraph.addEdge("A", "B").second);
   EXPECT_TRUE(stringGraph.addEdge("B", "C").second);
 
-  EXPECT_TRUE(stringGraph.getEdge("A", "B").second);
-  EXPECT_TRUE(stringGraph.getEdge("B", "C").second);
-  EXPECT_FALSE(stringGraph.getEdge("A", "C").second);
+  EXPECT_TRUE(stringGraph.getEdge("A", "B").has_value());
+  EXPECT_TRUE(stringGraph.getEdge("B", "C").has_value());
+  EXPECT_FALSE(stringGraph.getEdge("A", "C").has_value());
 }
 
 TEST_F(CinderGraphFunctionalTest, GetCustomEdge) {
@@ -99,15 +97,14 @@ TEST_F(CinderGraphFunctionalTest, GetCustomEdge) {
   EXPECT_TRUE(customGraph.addEdge(v1, v2, e1).second);
   EXPECT_TRUE(customGraph.addEdge(v2, v3, e2).second);
 
-  auto [weight, status] = customGraph.getEdge(v1, v2);
-  ASSERT_TRUE(status);
+  auto weight = customGraph.getEdge(v1, v2);
+  ASSERT_TRUE(weight.has_value());
   EXPECT_EQ(weight->edge_weight, 3.5f);
 
-  auto [weight2, status2] = customGraph.getEdge(v2, v3);
-  ASSERT_TRUE(status2);
+  auto weight2 = customGraph.getEdge(v2, v3);
+  ASSERT_TRUE(weight2.has_value());
   EXPECT_EQ(weight2->edge_weight, 7.0f);
 
-  auto [weight3, status3] = customGraph.getEdge(v1, v3);
-  ASSERT_FALSE(status3);
+  auto weight3 = customGraph.getEdge(v1, v3);
   ASSERT_FALSE(weight3.has_value());
 }

--- a/tests/integration/CinderGraph/functional/updateEdge_test.cpp
+++ b/tests/integration/CinderGraph/functional/updateEdge_test.cpp
@@ -16,9 +16,9 @@ TEST_F(CinderGraphFunctionalTest, UpdateEdgePrimitive) {
 
   EXPECT_TRUE(intGraph.addEdge(1, 2, 25).second);
 
-  auto [weight, status] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 25);
+  auto weight = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 25);
 
   auto [new_weight, status1] = intGraph.updateEdge(1, 2, 50);
   EXPECT_TRUE(status1);
@@ -35,9 +35,9 @@ TEST_F(CinderGraphFunctionalTest, UpdateEdgeString) {
 
   EXPECT_TRUE(stringGraph.addEdge("A", "B", 42).second);
 
-  auto [weight, status] = stringGraph.getEdge("A", "B");
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 42);
+  auto weight = stringGraph.getEdge("A", "B");
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 42);
 
   auto [new_weight, status1] = stringGraph.updateEdge("A", "B", 84);
   EXPECT_TRUE(status1);
@@ -58,8 +58,8 @@ TEST_F(CinderGraphFunctionalTest, UpdateCustomEdge) {
 
   EXPECT_TRUE(customGraph.addEdge(v1, v2, e1).second);
 
-  auto [weight, status] = customGraph.getEdge(v1, v2);
-  ASSERT_TRUE(status);
+  auto weight = customGraph.getEdge(v1, v2);
+  ASSERT_TRUE(weight.has_value());
   EXPECT_EQ(weight->edge_weight, 3.5f);
 
   auto [new_weight, status1] = customGraph.updateEdge(v1, v2, e2);

--- a/tests/integration/CinderGraph/scenarios/BasicConnectivity_test.cpp
+++ b/tests/integration/CinderGraph/scenarios/BasicConnectivity_test.cpp
@@ -23,13 +23,13 @@ TEST_F(BasicConnectivityTest, AddVerticesAndEdges) {
 
   EXPECT_EQ(intGraph.numEdges(), 2);
 
-  auto [weight1, status1] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 1);
+  auto weight1 = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 1);
 
-  auto [weight2, status2] = intGraph.getEdge(2, 3);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 2);
+  auto weight2 = intGraph.getEdge(2, 3);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 2);
 }
 
 TEST_F(BasicConnectivityTest, RemoveEdges) {
@@ -50,15 +50,15 @@ TEST_F(BasicConnectivityTest, RemoveEdges) {
   EXPECT_EQ(weight, 2);
 
   EXPECT_EQ(intGraph.numEdges(), 2);
-  EXPECT_FALSE(intGraph.getEdge(2, 3).second);
+  EXPECT_FALSE(intGraph.getEdge(2, 3).has_value());
 
-  auto [weight1, status1] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 1);
+  auto weight1 = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 1);
 
-  auto [weight2, status2] = intGraph.getEdge(1, 3);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 3);
+  auto weight2 = intGraph.getEdge(1, 3);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 3);
 }
 
 TEST_F(BasicConnectivityTest, RemoveVertices) {
@@ -76,9 +76,9 @@ TEST_F(BasicConnectivityTest, RemoveVertices) {
 
   EXPECT_FALSE(intGraph.hasVertex(2));
 
-  auto [weight, status] = intGraph.getEdge(1, 3);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 3);
+  auto weight = intGraph.getEdge(1, 3);
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 3);
 }
 
 TEST_F(BasicConnectivityTest, ComplexGraph) {
@@ -98,22 +98,22 @@ TEST_F(BasicConnectivityTest, ComplexGraph) {
 
   EXPECT_EQ(intGraph.numEdges(), 4);
 
-  auto [weight, status] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 1);
+  auto weight = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 1);
 
-  auto [weight2, status2] = intGraph.getEdge(3, 1);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 3);
+  auto weight2 = intGraph.getEdge(3, 1);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 3);
 
-  auto [weight3, status3] = intGraph.getEdge(1, 3);
-  EXPECT_TRUE(status3);
-  EXPECT_EQ(weight3, 4);
+  auto weight3 = intGraph.getEdge(1, 3);
+  EXPECT_TRUE(weight3.has_value());
+  EXPECT_EQ(*weight3, 4);
 
   intGraph.removeVertex(1);
   EXPECT_EQ(intGraph.numVertices(), 2);
 
-  EXPECT_FALSE(intGraph.getEdge(1, 2).second);
-  EXPECT_FALSE(intGraph.getEdge(3, 1).second);
-  EXPECT_TRUE(intGraph.getEdge(2, 3).second);
+  EXPECT_FALSE(intGraph.getEdge(1, 2).has_value());
+  EXPECT_FALSE(intGraph.getEdge(3, 1).has_value());
+  EXPECT_TRUE(intGraph.getEdge(2, 3).has_value());
 }

--- a/tests/integration/CinderGraph/scenarios/BulkInsertionStress_test.cpp
+++ b/tests/integration/CinderGraph/scenarios/BulkInsertionStress_test.cpp
@@ -46,11 +46,11 @@ TEST_F(BulkInsertionStressTest, BulkWeightedEdgesInsertion) {
 
   EXPECT_EQ(intGraph.numEdges(), numVertices - 1);
 
-  auto [weight1, status1] = intGraph.getEdge(0, 1);
-  EXPECT_TRUE(status1 && weight1 == 0);
+  auto weight1 = intGraph.getEdge(0, 1);
+  EXPECT_TRUE(weight1.has_value() && *weight1 == 0);
 
-  auto [weight2, status2] = intGraph.getEdge(250, 251);
-  EXPECT_TRUE(status2 && weight2 == 1250);
+  auto weight2 = intGraph.getEdge(250, 251);
+  EXPECT_TRUE(weight2.has_value() && *weight2 == 1250);
 }
 
 TEST_F(BulkInsertionStressTest, BulkUnweightedEdgesInsertion) {
@@ -68,13 +68,13 @@ TEST_F(BulkInsertionStressTest, BulkUnweightedEdgesInsertion) {
 
   EXPECT_EQ(intGraph.numEdges(), numVertices - 1);
 
-  auto [weight1, status1] = intGraph.getEdge(0, 1);
-  auto [weight2, status2] = intGraph.getEdge(0, 150);
-  auto [weight3, status3] = intGraph.getEdge(0, 299);
+  auto weight1 = intGraph.getEdge(0, 1);
+  auto weight2 = intGraph.getEdge(0, 150);
+  auto weight3 = intGraph.getEdge(0, 299);
 
-  EXPECT_TRUE(status1);
-  EXPECT_TRUE(status2);
-  EXPECT_TRUE(status3);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_TRUE(weight3.has_value());
 }
 
 TEST_F(BulkInsertionStressTest, DenseGraph) {
@@ -100,13 +100,13 @@ TEST_F(BulkInsertionStressTest, DenseGraph) {
 
   EXPECT_EQ(intGraph.numEdges(), edgeCount);
 
-  auto [weight1, status1] = intGraph.getEdge(0, 5);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 5);
+  auto weight1 = intGraph.getEdge(0, 5);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 5);
 
-  auto [weight2, status2] = intGraph.getEdge(20, 25);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 205);
+  auto weight2 = intGraph.getEdge(20, 25);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 205);
 }
 
 TEST_F(BulkInsertionStressTest, MixedBulkOperations) {
@@ -163,15 +163,15 @@ TEST_F(BulkInsertionStressTest, BulkInsertionWithEdgeUpdates) {
     EXPECT_TRUE(intGraph.updateEdge(src, dest, i * 10).second);
   }
 
-  auto [weight1, status1] = intGraph.getEdge(0, 1);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 0);
+  auto weight1 = intGraph.getEdge(0, 1);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 0);
 
-  auto [weight2, status2] = intGraph.getEdge(10, 11);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 100);
+  auto weight2 = intGraph.getEdge(10, 11);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 100);
 
-  auto [weight3, status3] = intGraph.getEdge(20, 21);
-  EXPECT_TRUE(status3);
-  EXPECT_EQ(weight3, 200);
+  auto weight3 = intGraph.getEdge(20, 21);
+  EXPECT_TRUE(weight3.has_value());
+  EXPECT_EQ(*weight3, 200);
 }

--- a/tests/integration/CinderGraph/scenarios/ClearAndReuseGraph_test.cpp
+++ b/tests/integration/CinderGraph/scenarios/ClearAndReuseGraph_test.cpp
@@ -32,9 +32,9 @@ TEST_F(ClearAndReuseGraphTest, ClearGraph) {
   EXPECT_TRUE(intGraph.hasVertex(2));
   EXPECT_TRUE(intGraph.hasVertex(3));
 
-  EXPECT_FALSE(intGraph.getEdge(1, 2).second);
-  EXPECT_FALSE(intGraph.getEdge(2, 3).second);
-  EXPECT_FALSE(intGraph.getEdge(3, 1).second);
+  EXPECT_FALSE(intGraph.getEdge(1, 2).has_value());
+  EXPECT_FALSE(intGraph.getEdge(2, 3).has_value());
+  EXPECT_FALSE(intGraph.getEdge(3, 1).has_value());
 }
 
 TEST_F(ClearAndReuseGraphTest, ClearAndReuseGraph) {
@@ -58,16 +58,16 @@ TEST_F(ClearAndReuseGraphTest, ClearAndReuseGraph) {
 
   EXPECT_EQ(intGraph.numEdges(), 2);
 
-  EXPECT_FALSE(intGraph.getEdge(1, 2).second);
-  EXPECT_FALSE(intGraph.getEdge(2, 3).second);
+  EXPECT_FALSE(intGraph.getEdge(1, 2).has_value());
+  EXPECT_FALSE(intGraph.getEdge(2, 3).has_value());
 
-  auto [weight, status] = intGraph.getEdge(1, 3);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 30);
+  auto weight = intGraph.getEdge(1, 3);
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 30);
 
-  auto [weight1, status1] = intGraph.getEdge(3, 2);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 40);
+  auto weight1 = intGraph.getEdge(3, 2);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 40);
 
   EXPECT_TRUE(intGraph.addVertex(4).second);
   EXPECT_TRUE(intGraph.addVertex(5).second);
@@ -83,19 +83,19 @@ TEST_F(ClearAndReuseGraphTest, ClearAndReuseGraph) {
 
   EXPECT_EQ(intGraph.numEdges(), 3);
 
-  auto [weight2, status2] = intGraph.getEdge(3, 5);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 30);
+  auto weight2 = intGraph.getEdge(3, 5);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 30);
 
-  auto [weight3, status3] = intGraph.getEdge(1, 3);
-  EXPECT_TRUE(status3);
-  EXPECT_EQ(weight3, 10);
+  auto weight3 = intGraph.getEdge(1, 3);
+  EXPECT_TRUE(weight3.has_value());
+  EXPECT_EQ(*weight3, 10);
 
-  auto [weight4, status4] = intGraph.getEdge(2, 4);
-  EXPECT_TRUE(status4);
-  EXPECT_EQ(weight4, 20);
+  auto weight4 = intGraph.getEdge(2, 4);
+  EXPECT_TRUE(weight4.has_value());
+  EXPECT_EQ(*weight4, 20);
 
-  EXPECT_FALSE(intGraph.getEdge(1, 2).second);
+  EXPECT_FALSE(intGraph.getEdge(1, 2).has_value());
 }
 
 TEST_F(ClearAndReuseGraphTest, ClearAndReuseUnweightedGraph) {
@@ -118,11 +118,11 @@ TEST_F(ClearAndReuseGraphTest, ClearAndReuseUnweightedGraph) {
 
   EXPECT_EQ(intGraph.numEdges(), 2);
 
-  EXPECT_TRUE(intGraph.getEdge(1, 3).second);
-  EXPECT_TRUE(intGraph.getEdge(3, 2).second);
+  EXPECT_TRUE(intGraph.getEdge(1, 3).has_value());
+  EXPECT_TRUE(intGraph.getEdge(3, 2).has_value());
 
-  EXPECT_FALSE(intGraph.getEdge(1, 2).second);
-  EXPECT_FALSE(intGraph.getEdge(2, 3).second);
+  EXPECT_FALSE(intGraph.getEdge(1, 2).has_value());
+  EXPECT_FALSE(intGraph.getEdge(2, 3).has_value());
 }
 
 TEST_F(ClearAndReuseGraphTest, StressTest) {
@@ -139,9 +139,9 @@ TEST_F(ClearAndReuseGraphTest, StressTest) {
 
     EXPECT_EQ(intGraph.numEdges(), 3);
 
-    auto [weight1, status1] = intGraph.getEdge(1, 2);
-    EXPECT_TRUE(status1);
-    EXPECT_EQ(weight1, weight);
+    auto weight1 = intGraph.getEdge(1, 2);
+    EXPECT_TRUE(weight1.has_value());
+    EXPECT_EQ(*weight1, weight);
 
     intGraph.clearEdges();
     EXPECT_EQ(intGraph.numEdges(), 0);

--- a/tests/integration/CinderGraph/scenarios/UpdateAndQueryFlow_test.cpp
+++ b/tests/integration/CinderGraph/scenarios/UpdateAndQueryFlow_test.cpp
@@ -17,17 +17,17 @@ TEST_F(UpdateAndQueryFlowTest, AddUpdateQuery) {
 
   EXPECT_TRUE(intGraph.addEdge(1, 2, 5).second);
 
-  auto [weight1, status1] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 5);
+  auto weight1 = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 5);
 
   auto [newWeight, updated] = intGraph.updateEdge(1, 2, 10);
   EXPECT_TRUE(updated);
   EXPECT_EQ(newWeight, 10);
 
-  auto [weight2, status2] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 10);
+  auto weight2 = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 10);
 }
 
 TEST_F(UpdateAndQueryFlowTest, MultipleUpdates) {
@@ -44,14 +44,14 @@ TEST_F(UpdateAndQueryFlowTest, MultipleUpdates) {
     EXPECT_TRUE(success);
     EXPECT_EQ(updatedWeight, w);
 
-    auto [currentWeight, status] = intGraph.getEdge(10, 20);
-    EXPECT_TRUE(status);
-    EXPECT_EQ(currentWeight, w);
+    auto currentWeight = intGraph.getEdge(10, 20);
+    EXPECT_TRUE(currentWeight.has_value());
+    EXPECT_EQ(*currentWeight, w);
   }
 
-  auto [finalWeight, status] = intGraph.getEdge(10, 20);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(finalWeight, 50);
+  auto finalWeight = intGraph.getEdge(10, 20);
+  EXPECT_TRUE(finalWeight.has_value());
+  EXPECT_EQ(*finalWeight, 50);
 }
 
 TEST_F(UpdateAndQueryFlowTest, MixedOperations) {
@@ -61,25 +61,25 @@ TEST_F(UpdateAndQueryFlowTest, MixedOperations) {
   EXPECT_TRUE(intGraph.addVertex(200).second);
 
   EXPECT_TRUE(intGraph.addEdge(100, 200, 5).second);
-  auto [weight, status] = intGraph.getEdge(100, 200);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 5);
+  auto weight = intGraph.getEdge(100, 200);
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 5);
 
   intGraph.updateEdge(100, 200, 15);
-  auto [weight1, status1] = intGraph.getEdge(100, 200);
-  EXPECT_TRUE(status1);
-  EXPECT_EQ(weight1, 15);
+  auto weight1 = intGraph.getEdge(100, 200);
+  EXPECT_TRUE(weight1.has_value());
+  EXPECT_EQ(*weight1, 15);
 
   for (int i = 0; i < 5; i++) {
-    auto [weight2, status2] = intGraph.getEdge(100, 200);
-    EXPECT_TRUE(status2);
-    EXPECT_EQ(weight2, 15);
+    auto weight2 = intGraph.getEdge(100, 200);
+    EXPECT_TRUE(weight2.has_value());
+    EXPECT_EQ(*weight2, 15);
   }
 
   intGraph.updateEdge(100, 200, 25);
-  auto [weight3, status3] = intGraph.getEdge(100, 200);
-  EXPECT_TRUE(status3);
-  EXPECT_EQ(weight3, 25);
+  auto weight3 = intGraph.getEdge(100, 200);
+  EXPECT_TRUE(weight3.has_value());
+  EXPECT_EQ(*weight3, 25);
 }
 
 TEST_F(UpdateAndQueryFlowTest, RemoveAddQuery) {
@@ -90,25 +90,25 @@ TEST_F(UpdateAndQueryFlowTest, RemoveAddQuery) {
 
   EXPECT_TRUE(intGraph.addEdge(1, 2, 10).second);
 
-  auto [weight, status] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(weight, 10);
+  auto weight = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight.has_value());
+  EXPECT_EQ(*weight, 10);
 
   EXPECT_TRUE(intGraph.removeEdge(1, 2).second);
 
-  EXPECT_FALSE(intGraph.getEdge(1, 2).second);
+  EXPECT_FALSE(intGraph.getEdge(1, 2).has_value());
 
   EXPECT_TRUE(intGraph.addEdge(1, 2, 20).second);
 
-  auto [weight2, status2] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status2);
-  EXPECT_EQ(weight2, 20);
+  auto weight2 = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight2.has_value());
+  EXPECT_EQ(*weight2, 20);
 
   intGraph.updateEdge(1, 2, 30);
 
-  auto [weight3, status3] = intGraph.getEdge(1, 2);
-  EXPECT_TRUE(status3);
-  EXPECT_EQ(weight3, 30);
+  auto weight3 = intGraph.getEdge(1, 2);
+  EXPECT_TRUE(weight3.has_value());
+  EXPECT_EQ(*weight3, 30);
 }
 
 TEST_F(UpdateAndQueryFlowTest, StressTest) {
@@ -121,13 +121,13 @@ TEST_F(UpdateAndQueryFlowTest, StressTest) {
   for (int i = 1; i <= 1000; i++) {
     EXPECT_TRUE(intGraph.updateEdge(100, 200, i).second);
     if (i % 100 == 0) {
-      auto [currentWeight, status] = intGraph.getEdge(100, 200);
-      EXPECT_TRUE(status);
-      EXPECT_EQ(currentWeight, i);
+      auto currentWeight = intGraph.getEdge(100, 200);
+      EXPECT_TRUE(currentWeight.has_value());
+      EXPECT_EQ(*currentWeight, i);
     }
   }
 
-  auto [finalWeight, status] = intGraph.getEdge(100, 200);
-  EXPECT_TRUE(status);
-  EXPECT_EQ(finalWeight, 1000);
+  auto finalWeight = intGraph.getEdge(100, 200);
+  EXPECT_TRUE(finalWeight.has_value());
+  EXPECT_EQ(*finalWeight, 1000);
 }


### PR DESCRIPTION
### Summary
This PR refactors the `getEdge` function to return `std::optional<EdgeType>` instead of `std::pair<std::optional<EdgeType>, bool>`.

### Motivation
The previous design included a boolean flag alongside `std::optional`, which is redundant. Since `std::optional` already represents presence or absence, the additional boolean creates unnecessary duplication and allows inconsistent states (e.g., `nullopt` with `true`).

### Design Decision
Replacing the return type with `std::optional<EdgeType>` ensures:
- A single, consistent representation of state
- Elimination of invalid state combinations
- Improved API clarity and usability
- Alignment with modern C++ best practices

### Changes
- Updated return type of `getEdge` to `std::optional<EdgeType>`
- Removed redundant boolean flag
- Refactored all call sites accordingly
- Updated tests and examples

### Impact
- Simplifies API usage
- Improves maintainability
- Reduces risk of logical errors

### Testing
- Verified behavior for both edge-present and edge-absent cases
- Ensured all updated code paths compile and function correctly

I reviewed all usages of `getEdge` to ensure consistency with the updated return type.

Closes #206

This contribution is part of NSOC'26.