### PR TITLE
feat(graph): Add support for graph names (#211)

### DIFF
--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -1,13 +1,13 @@
 #pragma once
+#include <iostream>
+#include <optional>
+#include <tuple>
+#include <utility>
 #include "Algorithms/CinderPeakAlgorithms.hpp"
 #include "Concepts.hpp"
 #include "PeakStore.hpp"
 #include "StorageEngine/GraphStatistics.hpp"
 #include "StorageEngine/Utils.hpp"
-#include <iostream>
-#include <optional>
-#include <tuple>
-#include <utility>
 
 namespace CinderPeak {
 namespace PeakStore {
@@ -245,6 +245,25 @@ public:
   operator[](const VertexType &v) const {
     return CinderGraphRowProxy<VertexType, EdgeType>(
         const_cast<CinderGraph<VertexType, EdgeType> &>(*this), v);
+  }
+
+  // Set graph name - user-facing API
+  bool setGraphName(const std::string& name) {
+    peak_store->log(LogLevel::INFO, "API: Setting graph name");
+    bool result = peak_store->setGraphName(name);
+    if (!result) {
+      peak_store->log(LogLevel::WARNING, 
+                      "API: Invalid graph name provided");
+    } else {
+      peak_store->log(LogLevel::INFO, 
+                      "API: Graph name set successfully");
+    }
+    return result;
+  }
+
+  // Get graph name - user-facing API
+  std::string getGraphName() {
+    return peak_store->getGraphName();
   }
 };
 

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -1,13 +1,13 @@
 #pragma once
-#include <iostream>
-#include <optional>
-#include <tuple>
-#include <utility>
 #include "Algorithms/CinderPeakAlgorithms.hpp"
 #include "Concepts.hpp"
 #include "PeakStore.hpp"
 #include "StorageEngine/GraphStatistics.hpp"
 #include "StorageEngine/Utils.hpp"
+#include <iostream>
+#include <optional>
+#include <tuple>
+#include <utility>
 
 namespace CinderPeak {
 namespace PeakStore {
@@ -248,15 +248,13 @@ public:
   }
 
   // Set graph name - user-facing API
-  bool setGraphName(const std::string& name) {
+  bool setGraphName(const std::string &name) {
     peak_store->log(LogLevel::INFO, "API: Setting graph name");
     bool result = peak_store->setGraphName(name);
     if (!result) {
-      peak_store->log(LogLevel::WARNING, 
-                      "API: Invalid graph name provided");
+      peak_store->log(LogLevel::WARNING, "API: Invalid graph name provided");
     } else {
-      peak_store->log(LogLevel::INFO, 
-                      "API: Graph name set successfully");
+      peak_store->log(LogLevel::INFO, "API: Graph name set successfully");
     }
     return result;
   }

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -263,7 +263,10 @@ public:
 
   // Get graph name - user-facing API
   std::string getGraphName() {
-    return peak_store->getGraphName();
+    peak_store->log(LogLevel::INFO, "API: Entering getGraphName");
+    std::string name = peak_store->getGraphName();
+    peak_store->log(LogLevel::INFO, "API: getGraphName completed successfully");
+    return name;
   }
 };
 

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -48,6 +48,23 @@ public:
     ctx->runtime->log(LogLevel::CRITICAL, "Log from ctx 1\n");
   }
 
+  // Set graph name
+  bool setGraphName(const std::string& name) {
+    if (!ctx->metadata) {
+      return false;
+    }
+    ctx->log(LogLevel::INFO, "PeakStore: Setting graph name to: " + name);
+    return ctx->metadata->setGraphName(name);
+  }
+
+  // Get graph name
+  std::string getGraphName() {
+    if (!ctx->metadata) {
+      return "";
+    }
+    return ctx->metadata->getGraphName();
+  }
+
   Algorithms::BFSResult<VertexType> bfs(const VertexType &src) {
     Algorithms::BFSResult<VertexType> result;
     if (!hasVertex(src)) {

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -9,6 +9,7 @@
 #include "StorageEngine/GraphStatistics.hpp"
 #include "StorageEngine/HybridCSR_COO.hpp"
 #include "StorageEngine/Utils.hpp"
+#include <cassert>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -50,18 +51,14 @@ public:
 
   // Set graph name
   bool setGraphName(const std::string& name) {
-    if (!ctx->metadata) {
-      return false;
-    }
+    assert(ctx && ctx->metadata && "PeakStore not properly initialized");
     ctx->log(LogLevel::INFO, "PeakStore: Setting graph name to: " + name);
     return ctx->metadata->setGraphName(name);
   }
 
   // Get graph name
   std::string getGraphName() {
-    if (!ctx->metadata) {
-      return "";
-    }
+    assert(ctx && ctx->metadata && "PeakStore not properly initialized");
     return ctx->metadata->getGraphName();
   }
 

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -50,15 +50,13 @@ public:
   }
 
   // Set graph name
-  bool setGraphName(const std::string& name) {
+  bool setGraphName(const std::string &name) {
     ctx->log(LogLevel::INFO, "PeakStore: Setting graph name to: " + name);
     return ctx->metadata->setGraphName(name);
   }
 
   // Get graph name
-  std::string getGraphName() {
-    return ctx->metadata->getGraphName();
-  }
+  std::string getGraphName() { return ctx->metadata->getGraphName(); }
 
   Algorithms::BFSResult<VertexType> bfs(const VertexType &src) {
     Algorithms::BFSResult<VertexType> result;

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -51,14 +51,12 @@ public:
 
   // Set graph name
   bool setGraphName(const std::string& name) {
-    assert(ctx && ctx->metadata && "PeakStore not properly initialized");
     ctx->log(LogLevel::INFO, "PeakStore: Setting graph name to: " + name);
     return ctx->metadata->setGraphName(name);
   }
 
   // Get graph name
   std::string getGraphName() {
-    assert(ctx && ctx->metadata && "PeakStore not properly initialized");
     return ctx->metadata->getGraphName();
   }
 

--- a/src/StorageEngine/GraphStatistics.hpp
+++ b/src/StorageEngine/GraphStatistics.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Utils.hpp"
 #include <atomic>
 #include <bitset>
 #include <chrono>
@@ -48,7 +49,7 @@ public:
     num_parallel_edges = 0;
     is_graph_weighted = weighted;
     is_graph_unweighted = unweighted;
-    graph_name = GraphNameUtils::generateDefaultGraphName();
+    graph_name = CinderPeak::GraphNameUtils::generateDefaultGraphName();
   }
 
   // Custom copy constructor that doesn't copy the mutex
@@ -198,7 +199,7 @@ public:
 
   // Setter for graph name with validation
   bool setGraphName(const std::string& name) {
-    if (!GraphNameUtils::isValidGraphName(name)) {
+    if (!CinderPeak::GraphNameUtils::isValidGraphName(name)) {
       return false;  // Invalid name
     }
     std::unique_lock<std::shared_mutex> lock(_mtx);

--- a/src/StorageEngine/GraphStatistics.hpp
+++ b/src/StorageEngine/GraphStatistics.hpp
@@ -27,6 +27,7 @@ private:
   size_t num_parallel_edges;
   float density;
   const std::string graph_type;
+  std::string graph_name;
   bool is_vertex_type_primitive;
   bool is_edge_type_primitive;
   bool is_graph_weighted;
@@ -36,10 +37,10 @@ private:
 
 public:
   GraphInternalMetadata(const std::string &graphType, bool vertex_tp_p,
-                        bool edge_tp_p, bool weighted, bool unweighted)
+                      bool edge_tp_p, bool weighted, bool unweighted)
       : graph_type(graphType), is_vertex_type_primitive(vertex_tp_p),
         is_edge_type_primitive(edge_tp_p) {
-
+    
     num_vertices = 0;
     num_edges = 0;
     density = 0.0;
@@ -47,6 +48,7 @@ public:
     num_parallel_edges = 0;
     is_graph_weighted = weighted;
     is_graph_unweighted = unweighted;
+    graph_name = GraphNameUtils::generateDefaultGraphName();
   }
 
   // Custom copy constructor that doesn't copy the mutex
@@ -62,6 +64,7 @@ public:
     is_edge_type_primitive = metadata.is_edge_type_primitive;
     is_graph_weighted = metadata.is_graph_weighted;
     is_graph_unweighted = metadata.is_graph_unweighted;
+    graph_name = metadata.graph_name;
   }
 
   // Custom copy assignment operator
@@ -78,6 +81,7 @@ public:
       is_edge_type_primitive = metadata.is_edge_type_primitive;
       is_graph_weighted = metadata.is_graph_weighted;
       is_graph_unweighted = metadata.is_graph_unweighted;
+      graph_name = metadata.graph_name;
     }
     return *this;
   }
@@ -105,6 +109,10 @@ public:
   std::string graphType() {
     std::shared_lock<std::shared_mutex> lock(_mtx);
     return graph_type;
+  }
+  std::string graphName() {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    return graph_name;
   }
 
   void updateEdgeCount(const UpdateOp &opt) {
@@ -180,6 +188,22 @@ public:
     ss << "Parallel edges: " << num_parallel_edges << std::endl;
 
     return ss.str();
+  }
+
+  // Getter for graph name
+  std::string getGraphName() {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    return graph_name;
+  }
+
+  // Setter for graph name with validation
+  bool setGraphName(const std::string& name) {
+    if (!GraphNameUtils::isValidGraphName(name)) {
+      return false;  // Invalid name
+    }
+    std::unique_lock<std::shared_mutex> lock(_mtx);
+    graph_name = name;
+    return true;
   }
 };
 } // namespace PeakStore

--- a/src/StorageEngine/GraphStatistics.hpp
+++ b/src/StorageEngine/GraphStatistics.hpp
@@ -49,7 +49,7 @@ public:
     num_parallel_edges = 0;
     is_graph_weighted = weighted;
     is_graph_unweighted = unweighted;
-    graph_name = CinderPeak::GraphNameUtils::generateDefaultGraphName();
+    graph_name = CinderPeak::generateDefaultGraphName();
   }
 
   // Custom copy constructor that doesn't copy the mutex
@@ -110,10 +110,6 @@ public:
   std::string graphType() {
     std::shared_lock<std::shared_mutex> lock(_mtx);
     return graph_type;
-  }
-  std::string graphName() {
-    std::shared_lock<std::shared_mutex> lock(_mtx);
-    return graph_name;
   }
 
   void updateEdgeCount(const UpdateOp &opt) {
@@ -199,7 +195,7 @@ public:
 
   // Setter for graph name with validation
   bool setGraphName(const std::string& name) {
-    if (!CinderPeak::GraphNameUtils::isValidGraphName(name)) {
+    if (!CinderPeak::isValidGraphName(name)) {
       return false;  // Invalid name
     }
     std::unique_lock<std::shared_mutex> lock(_mtx);

--- a/src/StorageEngine/GraphStatistics.hpp
+++ b/src/StorageEngine/GraphStatistics.hpp
@@ -38,10 +38,10 @@ private:
 
 public:
   GraphInternalMetadata(const std::string &graphType, bool vertex_tp_p,
-                      bool edge_tp_p, bool weighted, bool unweighted)
+                        bool edge_tp_p, bool weighted, bool unweighted)
       : graph_type(graphType), is_vertex_type_primitive(vertex_tp_p),
         is_edge_type_primitive(edge_tp_p) {
-    
+
     num_vertices = 0;
     num_edges = 0;
     density = 0.0;
@@ -194,9 +194,9 @@ public:
   }
 
   // Setter for graph name with validation
-  bool setGraphName(const std::string& name) {
+  bool setGraphName(const std::string &name) {
     if (!CinderPeak::isValidGraphName(name)) {
-      return false;  // Invalid name
+      return false; // Invalid name
     }
     std::unique_lock<std::shared_mutex> lock(_mtx);
     graph_name = name;

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -216,26 +216,26 @@ inline bool operator==(const Unweighted &, const Unweighted &) noexcept {
 
 // Graph Name Utility Functions
 // Validates graph name: alphanumeric only, length 1-32
-inline bool isValidGraphName(const std::string& name) {
-    if (name.length() < 1 || name.length() > 32) {
-        return false;
+inline bool isValidGraphName(const std::string &name) {
+  if (name.length() < 1 || name.length() > 32) {
+    return false;
+  }
+  for (char c : name) {
+    if (!std::isalnum(static_cast<unsigned char>(c))) {
+      return false;
     }
-    for (char c : name) {
-        if (!std::isalnum(static_cast<unsigned char>(c))) {
-            return false;
-        }
-    }
-    return true;
+  }
+  return true;
 }
 
 // Generates default graph name: "cpgraph_0", "cpgraph_1", etc.
 // Uses atomic counter to ensure uniqueness
 inline std::string generateDefaultGraphName() {
-    static std::atomic<uint32_t> graph_counter{0};
-    uint32_t id = graph_counter.fetch_add(1, std::memory_order_relaxed);
-    
-    std::stringstream ss;
-    ss << "cpgraph_" << id;
-    return ss.str();
+  static std::atomic<uint32_t> graph_counter{0};
+  uint32_t id = graph_counter.fetch_add(1, std::memory_order_relaxed);
+
+  std::stringstream ss;
+  ss << "cpgraph_" << id;
+  return ss.str();
 }
 } // namespace CinderPeak

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -215,29 +215,27 @@ inline bool operator==(const Unweighted &, const Unweighted &) noexcept {
 }
 
 // Graph Name Utility Functions
-namespace GraphNameUtils {
-    // Validates graph name: alphanumeric only, length 1-32
-    inline bool isValidGraphName(const std::string& name) {
-        if (name.length() < 1 || name.length() > 32) {
+// Validates graph name: alphanumeric only, length 1-32
+inline bool isValidGraphName(const std::string& name) {
+    if (name.length() < 1 || name.length() > 32) {
+        return false;
+    }
+    for (char c : name) {
+        if (!std::isalnum(static_cast<unsigned char>(c))) {
             return false;
         }
-        for (char c : name) {
-            if (!std::isalnum(static_cast<unsigned char>(c))) {
-                return false;
-            }
-        }
-        return true;
     }
+    return true;
+}
 
-    // Generates default graph name: "cpgraph_0", "cpgraph_1", etc.
-    // Uses atomic counter to ensure uniqueness
-    inline std::string generateDefaultGraphName() {
-        static std::atomic<uint32_t> graph_counter{0};
-        uint32_t id = graph_counter.fetch_add(1, std::memory_order_relaxed);
-        
-        std::stringstream ss;
-        ss << "cpgraph_" << id;
-        return ss.str();
-    }
+// Generates default graph name: "cpgraph_0", "cpgraph_1", etc.
+// Uses atomic counter to ensure uniqueness
+inline std::string generateDefaultGraphName() {
+    static std::atomic<uint32_t> graph_counter{0};
+    uint32_t id = graph_counter.fetch_add(1, std::memory_order_relaxed);
+    
+    std::stringstream ss;
+    ss << "cpgraph_" << id;
+    return ss.str();
 }
 } // namespace CinderPeak

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -2,8 +2,11 @@
 #include "CinderExceptions.hpp"
 #include "ErrorCodes.hpp"
 #include "PeakLogger.hpp"
+#include <atomic>
 #include <bitset>
+#include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -211,8 +214,6 @@ inline bool operator==(const Unweighted &, const Unweighted &) noexcept {
   return true;
 }
 
-} // namespace CinderPeak
-
 // Graph Name Utility Functions
 namespace GraphNameUtils {
     // Validates graph name: alphanumeric only, length 1-32
@@ -228,7 +229,7 @@ namespace GraphNameUtils {
         return true;
     }
 
-    // Generates default graph name: "cpgraph_123"
+    // Generates default graph name: "cpgraph_0", "cpgraph_1", etc.
     // Uses atomic counter to ensure uniqueness
     inline std::string generateDefaultGraphName() {
         static std::atomic<uint32_t> graph_counter{0};
@@ -239,3 +240,4 @@ namespace GraphNameUtils {
         return ss.str();
     }
 }
+} // namespace CinderPeak

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -212,3 +212,30 @@ inline bool operator==(const Unweighted &, const Unweighted &) noexcept {
 }
 
 } // namespace CinderPeak
+
+// Graph Name Utility Functions
+namespace GraphNameUtils {
+    // Validates graph name: alphanumeric only, length 1-32
+    inline bool isValidGraphName(const std::string& name) {
+        if (name.length() < 1 || name.length() > 32) {
+            return false;
+        }
+        for (char c : name) {
+            if (!std::isalnum(static_cast<unsigned char>(c))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Generates default graph name: "cpgraph_123"
+    // Uses atomic counter to ensure uniqueness
+    inline std::string generateDefaultGraphName() {
+        static std::atomic<uint32_t> graph_counter{0};
+        uint32_t id = graph_counter.fetch_add(1, std::memory_order_relaxed);
+        
+        std::stringstream ss;
+        ss << "cpgraph_" << id;
+        return ss.str();
+    }
+}


### PR DESCRIPTION
## Description
Implements graph name support as requested in #211. Each graph can now be assigned a custom name or will automatically receive a unique default name.

## Changes
- Added graph name validation utilities (1-32 alphanumeric characters)
- Added default name generation ("cpgraph_0", "cpgraph_1", etc.)
- Extended `GraphInternalMetadata` with name storage
- Added `setGraphName()` and `getGraphName()` methods through all layers
- Thread-safe implementation using `shared_mutex`

## Features
✅ Custom graph names (1-32 alphanumeric chars)
✅ Auto-generated default names (cpgraph_N format)
✅ Thread-safe getter/setter
✅ Full API integration (CinderGraph → PeakStore → Metadata)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change

## Checklist
- [x] Code follows project style guide
- [x] Changes compile without errors
- [x] Documentation updated (if applicable)
