### PR TITLE
feat(logging): Add looging helper utilities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Welcome to **CinderPeak**, a graph library designed to simplify graph representa
 ## Open-Source Participation
 
 CinderPeak is an independent, community-driven project that occasionally takes part in recognized open-source programs. 
-This year, we are taking part in **NSOC'26** ([Nexus Spring of Code](https://www.nsoc.in/#home)).
+This year, we are taking part in **NSOC'26** ([Nexus Spring of Code](https://www.nsoc.in/#home)) and **GSSOC 2026** ([GirlScript Summer of Code](https://gssoc.girlscript.org/)).
 
 Contributions are welcome from everyone, whether you are participating through an open-source program or contributing independently. All contributors are expected to follow the project's contribution guidelines, code of conduct, and established best practices to ensure a respectful and productive collaboration.
 

--- a/src/GraphConstraints.hpp
+++ b/src/GraphConstraints.hpp
@@ -1,0 +1,67 @@
+#pragma once
+#include "StorageEngine/GraphContext.hpp"
+#include "StorageEngine/Utils.hpp"
+
+namespace CinderPeak {
+template <typename VertexType, typename EdgeType> struct GraphConstraints {
+  static PeakStatus checkAddEdgeConstraints(
+      const PeakStore::GraphContext<VertexType, EdgeType> &ctx,
+      const VertexType &src, const VertexType &dest, const EdgeType &weight) {
+
+    if (!ctx.active_storage->impl_hasVertex(src) ||
+        !ctx.active_storage->impl_hasVertex(dest)) {
+      return PeakStatus::VertexNotFound(
+          "Source or destination vertex is missing.");
+    }
+
+    if (src == dest) {
+      if (!ctx.create_options->hasOption(GraphCreationOptions::SelfLoops)) {
+        return PeakStatus::InvalidArgument("Self loops are not allowed");
+      }
+    }
+
+    bool isWeighted = ctx.metadata->isGraphWeighted();
+    bool isDirected =
+        ctx.create_options->hasOption(GraphCreationOptions::Directed);
+
+    bool exists = false;
+
+    if (isWeighted) {
+      exists = ctx.active_storage->impl_doesEdgeExist(src, dest, weight);
+      if (!isDirected) {
+        exists =
+            exists || ctx.active_storage->impl_doesEdgeExist(dest, src, weight);
+      }
+    } else {
+      exists = ctx.active_storage->impl_doesEdgeExist(src, dest);
+      if (!isDirected) {
+        exists = exists || ctx.active_storage->impl_doesEdgeExist(dest, src);
+      }
+    }
+
+    if (exists) {
+      if (!ctx.create_options->hasOption(GraphCreationOptions::ParallelEdges)) {
+        return PeakStatus::EdgeAlreadyExists("Edge Already Exists");
+      }
+    }
+
+    return PeakStatus::OK();
+  }
+  static PeakStatus
+  checkRemoveEdge(const PeakStore::GraphContext<VertexType, EdgeType> &ctx,
+                  const VertexType &src, const VertexType &dest) {
+    if (!ctx.active_storage->impl_hasVertex(src) ||
+        !ctx.active_storage->impl_hasVertex(dest)) {
+      return PeakStatus::VertexNotFound(
+          "Source or destination vertex is missing.");
+    }
+    if (src == dest) {
+      if (!ctx.create_options->hasOption(GraphCreationOptions::SelfLoops)) {
+        return PeakStatus::InvalidArgument("Self loops are not allowed");
+      }
+    }
+    return PeakStatus::OK();
+  }
+};
+
+} // namespace CinderPeak

--- a/src/GraphEvents.hpp
+++ b/src/GraphEvents.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include "StorageEngine/GraphContext.hpp"
+#include "StorageEngine/Utils.hpp"
+
+namespace CinderPeak {
+template <typename VertexType, typename EdgeType> struct GraphEvents {
+  static void
+  onEdgeAdded(const PeakStore::GraphContext<VertexType, EdgeType> &ctx,
+              const VertexType &src, const VertexType &dest) {
+
+    if (ctx.create_options->hasOption(GraphCreationOptions::Directed) &&
+        ctx.active_storage->impl_doesEdgeExist(dest, src)) {
+      ctx.metadata->updateParallelEdgeCount(PeakStore::UpdateOp::Add);
+    }
+
+    if (src == dest) {
+      ctx.metadata->updateSelfLoopCount(PeakStore::UpdateOp::Add);
+    }
+
+    ctx.metadata->updateEdgeCount(PeakStore::UpdateOp::Add);
+  }
+  static void
+  onEdgeRemove(const PeakStore::GraphContext<VertexType, EdgeType> &ctx,
+               const VertexType &src, const VertexType &dest) {
+
+    if (src == dest) {
+      ctx.metadata->updateSelfLoopCount(PeakStore::UpdateOp::Remove);
+    }
+
+    ctx.metadata->updateEdgeCount(PeakStore::UpdateOp::Remove);
+  }
+};
+} // namespace CinderPeak

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -1,9 +1,12 @@
 #pragma once
 #include "Algorithms/CinderPeakAlgorithms.hpp"
 #include "CinderPeak.hpp"
+#include "GraphConstraints.hpp"
+#include "GraphEvents.hpp"
 #include "GraphRuntime.hpp"
 #include "PeakLogger.hpp"
 #include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/DebugUtils.hpp"
 #include "StorageEngine/ErrorCodes.hpp"
 #include "StorageEngine/GraphContext.hpp"
 #include "StorageEngine/GraphStatistics.hpp"
@@ -13,7 +16,6 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <type_traits>
 #include <vector>
 
 namespace CinderPeak {
@@ -71,24 +73,11 @@ public:
 
   PeakStatus addEdge(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight = EdgeType()) {
-    ctx->runtime->log(LogLevel::CRITICAL, "Log from ctx 2\n");
-
     bool isWeighted = ctx->metadata->isGraphWeighted();
-    bool edgeExists;
-    PeakStatus status = PeakStatus::OK();
-    if (isWeighted) {
-      edgeExists = ctx->active_storage->impl_doesEdgeExist(src, dest, weight);
-    } else {
-      edgeExists = ctx->active_storage->impl_doesEdgeExist(src, dest);
-    }
-    if (edgeExists) {
-      if ((isWeighted && !ctx->create_options->hasOption(
-                             GraphCreationOptions::ParallelEdges)) ||
-          !isWeighted) {
-        ctx->log(LogLevel::DEBUG, "Edge already exists");
-        return PeakStatus::EdgeAlreadyExists();
-      }
-    }
+    bool isDirected =
+        ctx->create_options->hasOption(GraphCreationOptions::Directed);
+
+    PeakStatus status;
 
     if (isWeighted) {
       ctx->log(LogLevel::INFO, "Called weighted PeakStore::addEdge");
@@ -98,18 +87,26 @@ public:
       status = ctx->active_storage->impl_addEdge(src, dest);
     }
 
-    if (!status.isOK()) {
+    if (!status.isOK())
       return status;
-    }
 
-    if (ctx->active_storage->impl_doesEdgeExist(dest, src)) {
-      ctx->metadata->updateParallelEdgeCount(UpdateOp::Add);
-    }
-    if (src == dest) {
-      ctx->metadata->updateSelfLoopCount(UpdateOp::Add);
-    }
-    ctx->metadata->updateEdgeCount(UpdateOp::Add);
+    GraphEvents<VertexType, EdgeType>::onEdgeAdded(*ctx, src, dest);
 
+    if (!isDirected && src != dest) {
+      PeakStatus rev_status;
+      if (isWeighted) {
+        rev_status = ctx->active_storage->impl_addEdge(dest, src, weight);
+      } else {
+        rev_status = ctx->active_storage->impl_addEdge(dest, src);
+      }
+      if (rev_status.isOK()) {
+        GraphEvents<VertexType, EdgeType>::onEdgeAdded(*ctx, dest, src);
+      } else {
+        std::string logstr =
+            "Reverse edge add failed from " + dbg(dest) + " to " + dbg(src);
+        ctx->log(LogLevel::DEBUG, logstr);
+      }
+    }
     return status;
   }
 

--- a/src/StorageEngine/DebugUtils.hpp
+++ b/src/StorageEngine/DebugUtils.hpp
@@ -74,4 +74,28 @@ template <typename T> inline std::string dbg(const T &v) {
   }
 }
 
+/**
+ * @brief Helper to format a vertex for logging.
+ */
+template <typename V>
+inline std::string vertexStr(const V &vertex) {
+  return "Vertex(" + dbg(vertex) + ")";
+}
+
+/**
+ * @brief Helper to format an unweighted edge for logging.
+ */
+template <typename V>
+inline std::string edgeStr(const V &src, const V &dest) {
+  return "Edge(" + dbg(src) + " -> " + dbg(dest) + ")";
+}
+
+/**
+ * @brief Helper to format a weighted edge for logging.
+ */
+template <typename V, typename E>
+inline std::string weightedEdgeStr(const V &src, const V &dest, const E &weight) {
+  return "Edge(" + dbg(src) + " -[" + dbg(weight) + "]-> " + dbg(dest) + ")";
+}
+
 } // namespace CinderPeak

--- a/src/StorageEngine/DebugUtils.hpp
+++ b/src/StorageEngine/DebugUtils.hpp
@@ -77,16 +77,14 @@ template <typename T> inline std::string dbg(const T &v) {
 /**
  * @brief Helper to format a vertex for logging.
  */
-template <typename V>
-inline std::string vertexStr(const V &vertex) {
+template <typename V> inline std::string vertexStr(const V &vertex) {
   return "Vertex(" + dbg(vertex) + ")";
 }
 
 /**
  * @brief Helper to format an unweighted edge for logging.
  */
-template <typename V>
-inline std::string edgeStr(const V &src, const V &dest) {
+template <typename V> inline std::string edgeStr(const V &src, const V &dest) {
   return "Edge(" + dbg(src) + " -> " + dbg(dest) + ")";
 }
 
@@ -94,7 +92,8 @@ inline std::string edgeStr(const V &src, const V &dest) {
  * @brief Helper to format a weighted edge for logging.
  */
 template <typename V, typename E>
-inline std::string weightedEdgeStr(const V &src, const V &dest, const E &weight) {
+inline std::string weightedEdgeStr(const V &src, const V &dest,
+                                   const E &weight) {
   return "Edge(" + dbg(src) + " -[" + dbg(weight) + "]-> " + dbg(dest) + ")";
 }
 

--- a/src/StorageEngine/DebugUtils.hpp
+++ b/src/StorageEngine/DebugUtils.hpp
@@ -92,8 +92,7 @@ template <typename V> inline std::string edgeStr(const V &src, const V &dest) {
  * @brief Helper to format a weighted edge for logging.
  */
 template <typename V, typename E>
-inline std::string weightedEdgeStr(const V &src, const V &dest,
-                                   const E &weight) {
+inline std::string weightedEdgeStr(const V &src, const V &dest, const E &weight) {
   return "Edge(" + dbg(src) + " -[" + dbg(weight) + "]-> " + dbg(dest) + ")";
 }
 

--- a/src/StorageEngine/ErrorCodes.hpp
+++ b/src/StorageEngine/ErrorCodes.hpp
@@ -24,7 +24,7 @@ private:
 public:
   PeakStatus(StatusCode code, std::string message = "")
       : code_(code), message_(std::move(message)) {}
-
+  PeakStatus() = default;
   inline static PeakStatus OK() { return PeakStatus(StatusCode::OK); }
   inline static PeakStatus NotFound(std::string msg = "Not Found") {
     return PeakStatus(StatusCode::NOT_FOUND, std::move(msg));


### PR DESCRIPTION

- Closes #229.

## What changes are included in this PR?

Previously, logging graph entities required repetitive and manual string concatenations using the base dbg() function. These new inline template utilities automatically wrap the output into consistent Vertex(...) and Edge(...) string formats

## Are these changes tested?
Yes 