### PR TITLE
refactor: remove parallel edge support from codebase

### DIFF
--- a/examples/CinderGraph/addEdge_usage.cpp
+++ b/examples/CinderGraph/addEdge_usage.cpp
@@ -38,22 +38,7 @@ int main() {
          << (added4 ? "success" : "failed") << endl;
     cout << "Total edges: " << g2.numEdges() << endl;
 
-    // 3. Graph with parallel edges
-    cout << "\n--- Parallel Edges ---" << endl;
-    GraphCreationOptions parallelOpts(
-        {GraphCreationOptions::Directed, GraphCreationOptions::ParallelEdges});
-    CinderGraph<int, int> g3(parallelOpts /*,p*/);
-    g3.addVertex(1);
-    g3.addVertex(2);
-
-    g3.addEdge(1, 2, 100);
-    cout << "Added edge (1,2) with weight 100" << endl;
-
-    g3.addEdge(1, 2, 200);
-    cout << "Added parallel edge (1,2) with weight 200" << endl;
-    cout << "Total edges: " << g3.numEdges() << endl;
-
-    // 4. Error handling - vertices don't exist
+    // 3. Error handling - vertices don't exist
     cout << "\n--- Error Cases ---" << endl;
     CinderGraph<int, Unweighted> g4;
     auto [edge5, added5] = g4.addEdge(100, 200);

--- a/examples/CinderGraph/numEdges_usage.cpp
+++ b/examples/CinderGraph/numEdges_usage.cpp
@@ -65,21 +65,6 @@ int main() {
            << g3.numEdges() << endl;
     }
 
-    // Parallel edges (if allowed)
-    cout << "\n--- Parallel Edges ---" << endl;
-    GraphCreationOptions opts(
-        {GraphCreationOptions::Directed, GraphCreationOptions::ParallelEdges});
-    CinderGraph<int, int> g4(opts);
-
-    g4.addVertex(10);
-    g4.addVertex(20);
-
-    g4.addEdge(10, 20, 1);
-    cout << "After first edge: " << g4.numEdges() << endl;
-
-    g4.addEdge(10, 20, 2);
-    cout << "After parallel edge: " << g4.numEdges() << endl;
-
     return 0;
   } catch (const exception &e) {
     cerr << "Error: " << e.what() << endl;

--- a/examples/CinderGraph/toDot_usage.cpp
+++ b/examples/CinderGraph/toDot_usage.cpp
@@ -40,22 +40,7 @@ int main() {
     cout << "Vertices " << g2.numVertices() << endl;
     cout << "Edges " << g2.numEdges() << endl;
 
-    // ===== 3. Parallel Edges (Directed) =====
-    cout << "\n--- Parallel Edges ---" << endl;
-
-    GraphCreationOptions parallelOpts(
-        {GraphCreationOptions::Directed, GraphCreationOptions::ParallelEdges});
-
-    CinderGraph<int, int> g3(parallelOpts);
-    g3.addVertex(1);
-    g3.addVertex(2);
-
-    g3.addEdge(1, 2, 100);
-    g3.addEdge(1, 2, 200);
-
-    cout << "Parallel edges count: " << g3.numEdges() << endl;
-
-    // ===== 4. Undirected Graph =====
+    // ===== 3. Undirected Graph =====
     cout << "\n--- Undirected Graph ---" << endl;
 
     CinderGraph<int, int> g4;
@@ -102,10 +87,6 @@ int main() {
     cout << "\n--- DOT Export (Isolated Nodes) ---" << endl;
     g2.toDot("g2_isolated.dot");
     cout << "Exported to g2_isolated.dot" << endl;
-
-    cout << "\n --- DOT Export (Parallel Edges) ---" << endl;
-    g3.toDot("g3_parallel.dot");
-    cout << "Exported to g3_parallel.dot" << endl;
 
     cout << "\n --- DOT Export (Undirected Graph) ---" << endl;
     g4.toDot("g4_undirected.dot");

--- a/src/GraphConstraints.hpp
+++ b/src/GraphConstraints.hpp
@@ -40,9 +40,7 @@ template <typename VertexType, typename EdgeType> struct GraphConstraints {
     }
 
     if (exists) {
-      if (!ctx.create_options->hasOption(GraphCreationOptions::ParallelEdges)) {
-        return PeakStatus::EdgeAlreadyExists("Edge Already Exists");
-      }
+      return PeakStatus::EdgeAlreadyExists("Edge Already Exists");
     }
 
     return PeakStatus::OK();

--- a/src/GraphEvents.hpp
+++ b/src/GraphEvents.hpp
@@ -8,11 +8,6 @@ template <typename VertexType, typename EdgeType> struct GraphEvents {
   onEdgeAdded(const PeakStore::GraphContext<VertexType, EdgeType> &ctx,
               const VertexType &src, const VertexType &dest) {
 
-    if (ctx.create_options->hasOption(GraphCreationOptions::Directed) &&
-        ctx.active_storage->impl_doesEdgeExist(dest, src)) {
-      ctx.metadata->updateParallelEdgeCount(PeakStore::UpdateOp::Add);
-    }
-
     if (src == dest) {
       ctx.metadata->updateSelfLoopCount(PeakStore::UpdateOp::Add);
     }

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -195,7 +195,6 @@ public:
     if (status.isOK()) {
       ctx->metadata->updateVertexCount(UpdateOp::Clear);
       ctx->metadata->updateEdgeCount(UpdateOp::Clear);
-      ctx->metadata->updateParallelEdgeCount(UpdateOp::Clear);
       ctx->metadata->updateSelfLoopCount(UpdateOp::Clear);
     }
     return status;
@@ -206,7 +205,6 @@ public:
     auto status = ctx->active_storage->impl_clearEdges();
     if (status.isOK()) {
       ctx->metadata->updateEdgeCount(UpdateOp::Clear);
-      ctx->metadata->updateParallelEdgeCount(UpdateOp::Clear);
       ctx->metadata->updateSelfLoopCount(UpdateOp::Clear);
     }
     return status;
@@ -243,11 +241,8 @@ public:
 
     bool isDirected =
         ctx->create_options->hasOption(GraphCreationOptions::Directed);
-    bool allowParallel =
-        ctx->create_options->hasOption(GraphCreationOptions::ParallelEdges);
 
-    std::string content =
-        ctx->adjacency_storage->impl_toDot(isDirected, allowParallel);
+    std::string content = ctx->adjacency_storage->impl_toDot(isDirected);
     outFile << content;
     outFile.close();
 

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -134,7 +134,7 @@ public:
     VertexId srcId = srcIt->second;
     VertexId destId = destIt->second;
 
-    // Append neighbor; duplicate edges allowed only if policy allows.
+    // Append neighbor.
     auto &neighbors = _adj[srcId];
     neighbors.emplace_back(destId, weight);
 
@@ -486,14 +486,12 @@ public:
     return _adj;
   }
 
-  std::string impl_toDot(bool isDirected, bool allowParallel) const {
+  std::string impl_toDot(bool isDirected) const {
     runtime.log(LogLevel::DEBUG, "Executing impl_toDot");
     std::shared_lock<std::shared_mutex> lock(_mtx);
     std::stringstream ss;
 
-    if (!allowParallel) {
-      ss << "strict ";
-    }
+    ss << "strict ";
     ss << (isDirected ? "digraph" : "graph") << " G {\n";
     ss << "  rankdir=LR;\n";
     ss << "  node[shape=circle style=filled fillcolor=\"#E3F2FD\" "

--- a/src/StorageEngine/GraphStatistics.hpp
+++ b/src/StorageEngine/GraphStatistics.hpp
@@ -25,7 +25,6 @@ private:
   size_t num_vertices;
   size_t num_edges;
   size_t num_self_loops;
-  size_t num_parallel_edges;
   float density;
   const std::string graph_type;
   std::string graph_name;
@@ -46,7 +45,6 @@ public:
     num_edges = 0;
     density = 0.0;
     num_self_loops = 0;
-    num_parallel_edges = 0;
     is_graph_weighted = weighted;
     is_graph_unweighted = unweighted;
     graph_name = CinderPeak::generateDefaultGraphName();
@@ -59,7 +57,6 @@ public:
     num_vertices = metadata.num_vertices;
     num_edges = metadata.num_edges;
     num_self_loops = metadata.num_self_loops;
-    num_parallel_edges = metadata.num_parallel_edges;
     density = metadata.density;
     is_vertex_type_primitive = metadata.is_vertex_type_primitive;
     is_edge_type_primitive = metadata.is_edge_type_primitive;
@@ -76,7 +73,6 @@ public:
       num_vertices = metadata.num_vertices;
       num_edges = metadata.num_edges;
       num_self_loops = metadata.num_self_loops;
-      num_parallel_edges = metadata.num_parallel_edges;
       density = metadata.density;
       is_vertex_type_primitive = metadata.is_vertex_type_primitive;
       is_edge_type_primitive = metadata.is_edge_type_primitive;
@@ -134,17 +130,6 @@ public:
       num_vertices = 0;
   }
 
-  void updateParallelEdgeCount(const UpdateOp &opt) {
-    std::unique_lock<std::shared_mutex> lock(_mtx);
-
-    if (opt == UpdateOp::Add)
-      num_parallel_edges++;
-    else if (opt == UpdateOp::Remove)
-      num_parallel_edges--;
-    else if (opt == UpdateOp::Clear)
-      num_parallel_edges = 0;
-  }
-
   void updateSelfLoopCount(const UpdateOp &opt) {
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
@@ -182,7 +167,6 @@ public:
     ss << "Density: " << std::fixed << std::setprecision(2) << density
        << std::endl;
     ss << "Self-loops: " << num_self_loops << std::endl;
-    ss << "Parallel edges: " << num_parallel_edges << std::endl;
 
     return ss.str();
   }

--- a/src/StorageEngine/Utils.hpp
+++ b/src/StorageEngine/Utils.hpp
@@ -26,7 +26,7 @@ using VertexId = uint64_t;
 
 class GraphCreationOptions {
 public:
-  enum GraphType { Directed = 0, SelfLoops, ParallelEdges, Undirected };
+  enum GraphType { Directed = 0, SelfLoops, Undirected };
   GraphCreationOptions(std::initializer_list<GraphType> graph_types) {
     for (auto type : graph_types) {
       options.set(type);

--- a/tests/unit/AdjacencyList/toDot_test.cpp
+++ b/tests/unit/AdjacencyList/toDot_test.cpp
@@ -11,7 +11,7 @@ TEST_F(AdjacencyStorageShardTest, ToDotDirectedGraph) {
   EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 100).isOK());
   EXPECT_TRUE(intGraph.impl_addEdge(2, 3, 200).isOK());
 
-  std::string dot = intGraph.impl_toDot(true, false);
+  std::string dot = intGraph.impl_toDot(true);
 
   EXPECT_NE(dot.find("digraph"), std::string::npos);
   // With cleared graph, IDs start at 1
@@ -27,7 +27,7 @@ TEST_F(AdjacencyStorageShardTest, ToDotUndirectedGraph) {
 
   EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 50).isOK());
 
-  std::string dot = intGraph.impl_toDot(false, false);
+  std::string dot = intGraph.impl_toDot(false);
 
   EXPECT_NE(dot.find("graph"), std::string::npos);
   EXPECT_NE(dot.find("--"), std::string::npos);
@@ -39,7 +39,7 @@ TEST_F(AdjacencyStorageShardTest, ToDotIsolatedNodes) {
   EXPECT_TRUE(intGraph.impl_addVertex(10).isOK());
   EXPECT_TRUE(intGraph.impl_addVertex(20).isOK());
 
-  std::string dot = intGraph.impl_toDot(true, false);
+  std::string dot = intGraph.impl_toDot(true);
 
   // 1st vertex added => ID 1, 2nd => ID 2
   EXPECT_NE(dot.find("node_1 [label=\"10\"]"), std::string::npos);
@@ -75,29 +75,4 @@ TEST_F(AdjacencyStorageShardTest, ToDotFileExport) {
   EXPECT_NE(content.find("node_1 -> node_2 [label=\"50\"]"), std::string::npos);
 
   std::remove(filename.c_str());
-}
-
-TEST_F(AdjacencyStorageShardTest, ToDotParallelEdges) {
-  intGraph.impl_clearVertices();
-  EXPECT_TRUE(intGraph.impl_addVertex(1).isOK());
-  EXPECT_TRUE(intGraph.impl_addVertex(2).isOK());
-
-  // Directly forcing parallel edges into storage for testing visualization
-  // Note: Standard addEdge might reject duplicates depending on policy,
-  // but we are testing the visualization of 'WHAT IS THERE'.
-  // impl_addEdge in AdjacencyList simply appends, so duplicates are possible if
-  // checks are skipped
-  EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 100).isOK());
-  EXPECT_TRUE(intGraph.impl_addEdge(1, 2, 200).isOK());
-
-  // allowParallel = true
-  std::string dot = intGraph.impl_toDot(true, true);
-
-  // Should NOT be strict
-  EXPECT_EQ(dot.find("strict"), std::string::npos);
-  EXPECT_NE(dot.find("digraph"), std::string::npos);
-
-  // Both edges should appear
-  EXPECT_NE(dot.find("label=\"100\""), std::string::npos);
-  EXPECT_NE(dot.find("label=\"200\""), std::string::npos);
 }

--- a/tests/unit/Statistics/Statistics.cpp
+++ b/tests/unit/Statistics/Statistics.cpp
@@ -113,12 +113,10 @@ TEST_F(GraphStatisticsTest, LargeDenseGraph) {
   int vertices = extractValue(stats, "Vertices: ");
   int edges = extractValue(stats, "Edges: ");
   int self_loops = extractValue(stats, "Self-loops: ");
-  int parallel_edges = extractValue(stats, "Parallel edges: ");
 
   EXPECT_EQ(vertices, num_vertices);
   EXPECT_GT(edges, 1000);
   EXPECT_GE(self_loops, 0);
-  EXPECT_GE(parallel_edges, 0);
 }
 
 TEST_F(GraphStatisticsTest, MediumGraphs) {


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #239

---

## Why was this change made?

As discussed with the maintainer (@SharonIV0x86), the project is moving towards removing parallel edge support to simplify the storage engine and overall graph architecture.

Right now, supporting parallel edges adds extra complexity across multiple parts of the codebase like:
- constraint handling
- metadata tracking
- DOT export
- event synchronization

Since the project is also planning larger architectural work around the orchestrator/event system and storage redesign, removing parallel edges first makes the codebase cleaner and easier to maintain going forward.

This PR removes all remaining `ParallelEdges` support and makes duplicate edges consistently rejected by the constraint system.

---

## What changes are included in this PR?

### Core source (`src/`)

- Removed `ParallelEdges` from `GraphCreationOptions::GraphType`
- Removed parallel edge tracking/statistics from `GraphStatistics.hpp`
- Removed parallel edge metadata updates from `GraphEvents.hpp`
- Simplified edge constraint checks in `GraphConstraints.hpp` so duplicate edges are always rejected
- Removed unused parallel edge handling from `PeakStore.hpp`
- Simplified DOT export logic in `AdjacencyList.hpp`
- Removed outdated comments related to duplicate edge policies

---

### Tests (`tests/`)

- Removed tests specifically related to parallel edges
- Updated remaining `impl_toDot()` tests to match the new function signature
- Removed parallel edge assertions from statistics tests

---

### Examples (`examples/`)

Removed parallel edge usage/examples from:
- `addEdge_usage.cpp`
- `toDot_usage.cpp`
- `numEdges_usage.cpp`

---

## Are these changes tested?

Yes.

Existing tests were updated after removing parallel edge support, and the remaining suite validates:
- DOT export behavior with the updated API
- graph statistics output
- duplicate edge rejection through existing `EdgeAlreadyExists` behavior

---

## Any user-facing changes?

Yes — this is a breaking change for users relying on parallel edge support.

The following changes may affect existing code:
1. `GraphCreationOptions::ParallelEdges` no longer exists
2. `getGraphStatistics()` no longer includes the `"Parallel edges"` field
3. `impl_toDot(bool, bool)` now takes a single parameter:
   ```cpp
   impl_toDot(bool isDirected)

PeakStatus::EdgeAlreadyExists