### PR TITLE
Fix generic vertex formatting in proxy edge error handling

### DIFF
--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -47,7 +47,7 @@ public:
   EdgeType operator[](const VertexType &dest) const {
     auto optWeight = graph.getEdge(src, dest);
     if (!optWeight.has_value()) {
-      throw std::runtime_error("Edge not found: " + src + " -> " + dest);
+      throw std::runtime_error("Edge not found: " + edgeStr(src, dest));
     }
     return *optWeight;
   }

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -2,6 +2,7 @@
 #include "Algorithms/CinderPeakAlgorithms.hpp"
 #include "Concepts.hpp"
 #include "PeakStore.hpp"
+#include "StorageEngine/DebugUtils.hpp"
 #include "StorageEngine/GraphStatistics.hpp"
 #include "StorageEngine/Utils.hpp"
 #include <iostream>

--- a/src/StorageEngine/DebugUtils.hpp
+++ b/src/StorageEngine/DebugUtils.hpp
@@ -92,7 +92,8 @@ template <typename V> inline std::string edgeStr(const V &src, const V &dest) {
  * @brief Helper to format a weighted edge for logging.
  */
 template <typename V, typename E>
-inline std::string weightedEdgeStr(const V &src, const V &dest, const E &weight) {
+inline std::string weightedEdgeStr(const V &src, const V &dest,
+                                   const E &weight) {
   return "Edge(" + dbg(src) + " -[" + dbg(weight) + "]-> " + dbg(dest) + ")";
 }
 

--- a/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
+++ b/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
@@ -1,0 +1,37 @@
+#include "StorageEngine/DebugUtils.hpp"
+#include <gtest/gtest.h>
+
+using namespace CinderPeak;
+
+struct CustomVertex {
+  int __id_;
+
+  bool operator==(const CustomVertex &other) const {
+    return __id_ == other.__id_;
+  }
+
+  bool operator<(const CustomVertex &other) const {
+    return __id_ < other.__id_;
+  }
+};
+
+namespace std {
+template <> struct hash<CustomVertex> {
+  size_t operator()(const CustomVertex &v) const {
+    return hash<int>()(v.__id_);
+  }
+};
+} // namespace std
+
+TEST(CinderGraphOperatorProxyTest,
+     EdgeFormattingSupportsCustomVertexTypes) {
+
+  CustomVertex v1{1};
+  CustomVertex v2{2};
+
+  auto formatted = edgeStr(v1, v2);
+
+  EXPECT_NE(formatted.find("Edge("), std::string::npos);
+  EXPECT_NE(formatted.find("id:1"), std::string::npos);
+  EXPECT_NE(formatted.find("id:2"), std::string::npos);
+}

--- a/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
+++ b/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
@@ -3,8 +3,10 @@
 
 using namespace CinderPeak;
 
-struct CustomVertex {
-  int __id_;
+struct CustomVertex : public CinderPeak::CinderVertex {
+  explicit CustomVertex(int id) {
+    __id_ = id;
+  }
 
   bool operator==(const CustomVertex &other) const {
     return __id_ == other.__id_;
@@ -14,14 +16,6 @@ struct CustomVertex {
     return __id_ < other.__id_;
   }
 };
-
-namespace std {
-template <> struct hash<CustomVertex> {
-  size_t operator()(const CustomVertex &v) const {
-    return hash<int>()(v.__id_);
-  }
-};
-} // namespace std
 
 TEST(CinderGraphOperatorProxyTest, EdgeFormattingSupportsCustomVertexTypes) {
 

--- a/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
+++ b/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
@@ -4,9 +4,7 @@
 using namespace CinderPeak;
 
 struct CustomVertex : public CinderPeak::CinderVertex {
-  explicit CustomVertex(int id) {
-    __id_ = id;
-  }
+  explicit CustomVertex(int id) { __id_ = id; }
 
   bool operator==(const CustomVertex &other) const {
     return __id_ == other.__id_;

--- a/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
+++ b/tests/integration/CinderGraph/functional/operatorProxyAccess_test.cpp
@@ -23,8 +23,7 @@ template <> struct hash<CustomVertex> {
 };
 } // namespace std
 
-TEST(CinderGraphOperatorProxyTest,
-     EdgeFormattingSupportsCustomVertexTypes) {
+TEST(CinderGraphOperatorProxyTest, EdgeFormattingSupportsCustomVertexTypes) {
 
   CustomVertex v1{1};
   CustomVertex v2{2};


### PR DESCRIPTION
Closes #237

## Rationale for this change

`CinderGraphRowProxy::operator[]` previously constructed exception messages using direct concatenation of arbitrary `VertexType` values into strings.

This created unsafe behavior for custom templated vertex types that do not support implicit string conversion or formatting operations, leading to compilation or formatting issues depending on the selected graph vertex type.

The project already provides generic-safe formatting helpers through the existing `dbg()` and `edgeStr()` utilities. This PR updates the proxy error formatting flow to reuse those utilities instead of relying on direct string concatenation.

This keeps formatting behavior centralized and improves compatibility with custom vertex types while preserving the existing API behavior.

## What changes are included in this PR?

- replaced direct `VertexType` string concatenation in `CinderGraphRowProxy::operator[]`
- integrated existing `edgeStr()` / `dbg()` utility helpers for generic-safe formatting
- improved compatibility with custom vertex types
- added regression coverage validating custom vertex formatting support
- ran formatter and validated the full test suite successfully

## Are these changes tested?

Yes. Added regression coverage for custom vertex formatting support using `edgeStr()` and `dbg()` utility paths.

Validation performed:
- formatter executed successfully
- full test suite passing (`41/41`)

## Are there any user-facing changes?

No breaking API changes.

This PR only improves internal exception/error formatting behavior for generic/custom vertex types.