### PR TITLE
refactor: Refactor logging in PeakStore and AdjacencyList to use dbg utility

### DIFF
--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -80,12 +80,14 @@ public:
     PeakStatus status;
 
     if (isWeighted) {
-      ctx->log(LogLevel::INFO, "Called weighted PeakStore::addEdge for " +
-                                   weightedEdgeStr(src, dest, weight));
+      ctx->log(LogLevel::INFO,
+               "Called weighted PeakStore::addEdge for " +
+                   weightedEdgeStr(src, dest, weight));
       status = ctx->active_storage->impl_addEdge(src, dest, weight);
     } else {
-      ctx->log(LogLevel::INFO, "Called unweighted PeakStore::addEdge for " +
-                                   edgeStr(src, dest));
+      ctx->log(LogLevel::INFO,
+               "Called unweighted PeakStore::addEdge for " +
+                   edgeStr(src, dest));
       status = ctx->active_storage->impl_addEdge(src, dest);
     }
 
@@ -114,8 +116,8 @@ public:
 
   std::pair<EdgeType, PeakStatus> removeEdge(const VertexType &src,
                                              const VertexType &dest) {
-    ctx->log(LogLevel::INFO, "Called adjacency:removeEdge() for " +
-                                 edgeStr(src, dest));
+    ctx->log(LogLevel::INFO,
+             "Called adjacency:removeEdge() for " + edgeStr(src, dest));
     auto result = ctx->active_storage->impl_removeEdge(src, dest);
     if (result.second.isOK()) {
       GraphEvents<VertexType, EdgeType>::onEdgeRemove(*ctx, src, dest);
@@ -135,8 +137,9 @@ public:
   std::pair<PeakStatus, EdgeType> updateEdge(const VertexType &src,
                                              const VertexType &dest,
                                              const EdgeType &newWeight) {
-    ctx->log(LogLevel::INFO, "Called adjacency:updateEdge() for " +
-                                 weightedEdgeStr(src, dest, newWeight));
+    ctx->log(LogLevel::INFO,
+             "Called adjacency:updateEdge() for " +
+                 weightedEdgeStr(src, dest, newWeight));
 
     PeakStatus resp =
         ctx->active_storage->impl_updateEdge(src, dest, newWeight);
@@ -157,8 +160,8 @@ public:
 
   std::pair<EdgeType, PeakStatus> getEdge(const VertexType &src,
                                           const VertexType &dest) {
-    ctx->log(LogLevel::INFO, "Called adjacency:getEdge() for " +
-                                 edgeStr(src, dest));
+    ctx->log(LogLevel::INFO,
+             "Called adjacency:getEdge() for " + edgeStr(src, dest));
     auto status = ctx->active_storage->impl_getEdge(src, dest);
     if (!status.second.isOK()) {
       return {EdgeType(), status.second};
@@ -167,8 +170,8 @@ public:
   }
 
   PeakStatus addVertex(const VertexType &src) {
-    ctx->log(LogLevel::INFO, "Called peakStore:addVertex for " +
-                                 vertexStr(src));
+    ctx->log(LogLevel::INFO,
+             "Called peakStore:addVertex for " + vertexStr(src));
     if (PeakStatus resp = ctx->active_storage->impl_addVertex(src);
         !resp.isOK())
       return resp;
@@ -178,14 +181,15 @@ public:
   }
 
   bool hasVertex(const VertexType &v) {
-    ctx->log(LogLevel::INFO, "Called peakStore:hasVertex for " + vertexStr(v));
+    ctx->log(LogLevel::INFO,
+             "Called peakStore:hasVertex for " + vertexStr(v));
     return ctx->active_storage->impl_hasVertex(v);
   }
 
   const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
   getNeighbors(const VertexType &src) const {
-    ctx->log(LogLevel::INFO, "Called adjacency:getNeighbors() for " +
-                                 vertexStr(src));
+    ctx->log(LogLevel::INFO,
+             "Called adjacency:getNeighbors() for " + vertexStr(src));
     auto status = ctx->adjacency_storage->impl_getNeighbors(src);
     if (!status.second.isOK()) {
       std::cout << status.second.message() << "\n";

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -80,10 +80,12 @@ public:
     PeakStatus status;
 
     if (isWeighted) {
-      ctx->log(LogLevel::INFO, "Called weighted PeakStore::addEdge");
+      ctx->log(LogLevel::INFO, "Called weighted PeakStore::addEdge for " +
+                                   weightedEdgeStr(src, dest, weight));
       status = ctx->active_storage->impl_addEdge(src, dest, weight);
     } else {
-      ctx->log(LogLevel::INFO, "Called unweighted PeakStore::addEdge");
+      ctx->log(LogLevel::INFO, "Called unweighted PeakStore::addEdge for " +
+                                   edgeStr(src, dest));
       status = ctx->active_storage->impl_addEdge(src, dest);
     }
 
@@ -112,7 +114,8 @@ public:
 
   std::pair<EdgeType, PeakStatus> removeEdge(const VertexType &src,
                                              const VertexType &dest) {
-    ctx->log(LogLevel::INFO, "Called adjacency:removeEdge()");
+    ctx->log(LogLevel::INFO, "Called adjacency:removeEdge() for " +
+                                 edgeStr(src, dest));
     auto result = ctx->active_storage->impl_removeEdge(src, dest);
     if (result.second.isOK()) {
       GraphEvents<VertexType, EdgeType>::onEdgeRemove(*ctx, src, dest);
@@ -132,7 +135,8 @@ public:
   std::pair<PeakStatus, EdgeType> updateEdge(const VertexType &src,
                                              const VertexType &dest,
                                              const EdgeType &newWeight) {
-    ctx->log(LogLevel::INFO, "Called adjacency:updateEdge()");
+    ctx->log(LogLevel::INFO, "Called adjacency:updateEdge() for " +
+                                 weightedEdgeStr(src, dest, newWeight));
 
     PeakStatus resp =
         ctx->active_storage->impl_updateEdge(src, dest, newWeight);
@@ -153,7 +157,8 @@ public:
 
   std::pair<EdgeType, PeakStatus> getEdge(const VertexType &src,
                                           const VertexType &dest) {
-    ctx->log(LogLevel::INFO, "Called adjacency:getEdge()");
+    ctx->log(LogLevel::INFO, "Called adjacency:getEdge() for " +
+                                 edgeStr(src, dest));
     auto status = ctx->active_storage->impl_getEdge(src, dest);
     if (!status.second.isOK()) {
       return {EdgeType(), status.second};
@@ -162,7 +167,8 @@ public:
   }
 
   PeakStatus addVertex(const VertexType &src) {
-    ctx->log(LogLevel::INFO, "Called peakStore:addVertex");
+    ctx->log(LogLevel::INFO, "Called peakStore:addVertex for " +
+                                 vertexStr(src));
     if (PeakStatus resp = ctx->active_storage->impl_addVertex(src);
         !resp.isOK())
       return resp;
@@ -172,13 +178,14 @@ public:
   }
 
   bool hasVertex(const VertexType &v) {
-    ctx->log(LogLevel::INFO, "Called peakStore:hasVertex");
+    ctx->log(LogLevel::INFO, "Called peakStore:hasVertex for " + vertexStr(v));
     return ctx->active_storage->impl_hasVertex(v);
   }
 
   const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
   getNeighbors(const VertexType &src) const {
-    ctx->log(LogLevel::INFO, "Called adjacency:getNeighbors()");
+    ctx->log(LogLevel::INFO, "Called adjacency:getNeighbors() for " +
+                                 vertexStr(src));
     auto status = ctx->adjacency_storage->impl_getNeighbors(src);
     if (!status.second.isOK()) {
       std::cout << status.second.message() << "\n";

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -80,14 +80,12 @@ public:
     PeakStatus status;
 
     if (isWeighted) {
-      ctx->log(LogLevel::INFO,
-               "Called weighted PeakStore::addEdge for " +
-                   weightedEdgeStr(src, dest, weight));
+      ctx->log(LogLevel::INFO, "Called weighted PeakStore::addEdge for " +
+                                   weightedEdgeStr(src, dest, weight));
       status = ctx->active_storage->impl_addEdge(src, dest, weight);
     } else {
-      ctx->log(LogLevel::INFO,
-               "Called unweighted PeakStore::addEdge for " +
-                   edgeStr(src, dest));
+      ctx->log(LogLevel::INFO, "Called unweighted PeakStore::addEdge for " +
+                                   edgeStr(src, dest));
       status = ctx->active_storage->impl_addEdge(src, dest);
     }
 
@@ -137,9 +135,8 @@ public:
   std::pair<PeakStatus, EdgeType> updateEdge(const VertexType &src,
                                              const VertexType &dest,
                                              const EdgeType &newWeight) {
-    ctx->log(LogLevel::INFO,
-             "Called adjacency:updateEdge() for " +
-                 weightedEdgeStr(src, dest, newWeight));
+    ctx->log(LogLevel::INFO, "Called adjacency:updateEdge() for " +
+                                 weightedEdgeStr(src, dest, newWeight));
 
     PeakStatus resp =
         ctx->active_storage->impl_updateEdge(src, dest, newWeight);
@@ -181,8 +178,7 @@ public:
   }
 
   bool hasVertex(const VertexType &v) {
-    ctx->log(LogLevel::INFO,
-             "Called peakStore:hasVertex for " + vertexStr(v));
+    ctx->log(LogLevel::INFO, "Called peakStore:hasVertex for " + vertexStr(v));
     return ctx->active_storage->impl_hasVertex(v);
   }
 

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -121,9 +121,8 @@ public:
   [[nodiscard]] const PeakStatus
   impl_addEdge(const VertexType &src, const VertexType &dest,
                const EdgeType &weight = EdgeType()) override {
-    runtime.log(LogLevel::DEBUG,
-                "Executing impl_addEdge for " +
-                    weightedEdgeStr(src, dest, weight));
+    runtime.log(LogLevel::DEBUG, "Executing impl_addEdge for " +
+                                     weightedEdgeStr(src, dest, weight));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -238,9 +237,8 @@ public:
   [[nodiscard]] const PeakStatus
   impl_updateEdge(const VertexType &src, const VertexType &dest,
                   const EdgeType &newWeight) override {
-    runtime.log(LogLevel::DEBUG,
-                "Executing impl_updateEdge for " +
-                    weightedEdgeStr(src, dest, newWeight));
+    runtime.log(LogLevel::DEBUG, "Executing impl_updateEdge for " +
+                                     weightedEdgeStr(src, dest, newWeight));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -306,9 +304,8 @@ public:
   [[nodiscard]] bool
   impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight) noexcept override {
-    runtime.log(LogLevel::DEBUG,
-                "Executing impl_doesEdgeExist for " +
-                    weightedEdgeStr(src, dest, weight));
+    runtime.log(LogLevel::DEBUG, "Executing impl_doesEdgeExist for " +
+                                     weightedEdgeStr(src, dest, weight));
     std::shared_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -1,9 +1,9 @@
 #pragma once
 #include "Concepts.hpp"
+#include "DebugUtils.hpp"
 #include "GraphRuntime.hpp"
 #include "StorageEngine/GraphContext.hpp"
 #include "StorageEngine/GraphStatistics.hpp"
-#include "DebugUtils.hpp"
 #include "Utils.hpp"
 #include <algorithm>
 #include <atomic>
@@ -58,7 +58,8 @@ public:
   }
 
   [[nodiscard]] const PeakStatus impl_addVertex(const VertexType &v) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_addVertex for " + vertexStr(v));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_addVertex for " + vertexStr(v));
     VertexId assignedId = 0;
     {
       std::unique_lock<std::shared_mutex> lock(_mtx);
@@ -74,7 +75,8 @@ public:
         } else {
           runtime.log(LogLevel::WARNING,
                       "Failed to add Non Premitive Vertex: Non Premitive "
-                      "Vertex Already Exist. " + vertexStr(v));
+                      "Vertex Already Exist. " +
+                          vertexStr(v));
           return PeakStatus::VertexAlreadyExists(
               "Non Primitive Vertex Already Exists");
         }
@@ -119,8 +121,9 @@ public:
   [[nodiscard]] const PeakStatus
   impl_addEdge(const VertexType &src, const VertexType &dest,
                const EdgeType &weight = EdgeType()) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_addEdge for " +
-                                     weightedEdgeStr(src, dest, weight));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_addEdge for " +
+                    weightedEdgeStr(src, dest, weight));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -201,8 +204,8 @@ public:
 
   [[nodiscard]] const std::pair<EdgeType, PeakStatus>
   impl_removeEdge(const VertexType &src, const VertexType &dest) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_removeEdge for " +
-                                     edgeStr(src, dest));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_removeEdge for " + edgeStr(src, dest));
     std::unique_lock<std::shared_mutex> lock(_mtx);
     EdgeType retWeight = EdgeType();
 
@@ -235,8 +238,9 @@ public:
   [[nodiscard]] const PeakStatus
   impl_updateEdge(const VertexType &src, const VertexType &dest,
                   const EdgeType &newWeight) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_updateEdge for " +
-                                     weightedEdgeStr(src, dest, newWeight));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_updateEdge for " +
+                    weightedEdgeStr(src, dest, newWeight));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -265,8 +269,8 @@ public:
   }
 
   [[nodiscard]] bool impl_hasVertex(const VertexType &v) noexcept override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_hasVertex for " +
-                                     vertexStr(v));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_hasVertex for " + vertexStr(v));
     std::shared_lock<std::shared_mutex> lock(_mtx);
     runtime.log(LogLevel::INFO, "Vertex lookup.");
 
@@ -276,8 +280,8 @@ public:
   [[nodiscard]] bool
   impl_doesEdgeExist(const VertexType &src,
                      const VertexType &dest) noexcept override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_doesEdgeExist for " +
-                                     edgeStr(src, dest));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_doesEdgeExist for " + edgeStr(src, dest));
     std::shared_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -302,8 +306,9 @@ public:
   [[nodiscard]] bool
   impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight) noexcept override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_doesEdgeExist for " +
-                                     weightedEdgeStr(src, dest, weight));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_doesEdgeExist for " +
+                    weightedEdgeStr(src, dest, weight));
     std::shared_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -330,8 +335,8 @@ public:
 
   [[nodiscard]] const std::pair<EdgeType, PeakStatus>
   impl_getEdge(const VertexType &src, const VertexType &dest) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_getEdge for " +
-                                     edgeStr(src, dest));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_getEdge for " + edgeStr(src, dest));
     std::shared_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -355,8 +360,8 @@ public:
 
   const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
   impl_getNeighbors(const VertexType &vertex) const {
-    runtime.log(LogLevel::DEBUG, "Executing impl_getNeighbors for " +
-                                     vertexStr(vertex));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_getNeighbors for " + vertexStr(vertex));
     // data copied under lock
     std::vector<std::pair<VertexId, EdgeType>> neighbor_ids;
     std::unordered_map<VertexId, VertexType> vertex_data_snapshot;
@@ -400,8 +405,8 @@ public:
 
   [[nodiscard]] const PeakStatus
   impl_removeVertex(const VertexType &v) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_removeVertex for " +
-                                     vertexStr(v));
+    runtime.log(LogLevel::DEBUG,
+                "Executing impl_removeVertex for " + vertexStr(v));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto it = _vertex_lookup.find(v);

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -3,6 +3,7 @@
 #include "GraphRuntime.hpp"
 #include "StorageEngine/GraphContext.hpp"
 #include "StorageEngine/GraphStatistics.hpp"
+#include "DebugUtils.hpp"
 #include "Utils.hpp"
 #include <algorithm>
 #include <atomic>
@@ -57,7 +58,7 @@ public:
   }
 
   [[nodiscard]] const PeakStatus impl_addVertex(const VertexType &v) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_addVertex");
+    runtime.log(LogLevel::DEBUG, "Executing impl_addVertex for " + vertexStr(v));
     VertexId assignedId = 0;
     {
       std::unique_lock<std::shared_mutex> lock(_mtx);
@@ -66,13 +67,14 @@ public:
         if constexpr (CinderPeak::Traits::is_primitive_or_string_v<
                           VertexType>) {
           runtime.log(LogLevel::WARNING,
-                      "Failed to add Vertex: Vertex Already Exist.");
+                      "Failed to add Vertex: Vertex Already Exist. " +
+                          vertexStr(v));
           return PeakStatus::VertexAlreadyExists(
               "Primitive Vertex Already Exists");
         } else {
           runtime.log(LogLevel::WARNING,
                       "Failed to add Non Premitive Vertex: Non Premitive "
-                      "Vertex Already Exist.");
+                      "Vertex Already Exist. " + vertexStr(v));
           return PeakStatus::VertexAlreadyExists(
               "Non Primitive Vertex Already Exists");
         }
@@ -117,7 +119,8 @@ public:
   [[nodiscard]] const PeakStatus
   impl_addEdge(const VertexType &src, const VertexType &dest,
                const EdgeType &weight = EdgeType()) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_addEdge");
+    runtime.log(LogLevel::DEBUG, "Executing impl_addEdge for " +
+                                     weightedEdgeStr(src, dest, weight));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -198,7 +201,8 @@ public:
 
   [[nodiscard]] const std::pair<EdgeType, PeakStatus>
   impl_removeEdge(const VertexType &src, const VertexType &dest) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_removeEdge");
+    runtime.log(LogLevel::DEBUG, "Executing impl_removeEdge for " +
+                                     edgeStr(src, dest));
     std::unique_lock<std::shared_mutex> lock(_mtx);
     EdgeType retWeight = EdgeType();
 
@@ -231,7 +235,8 @@ public:
   [[nodiscard]] const PeakStatus
   impl_updateEdge(const VertexType &src, const VertexType &dest,
                   const EdgeType &newWeight) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_updateEdge");
+    runtime.log(LogLevel::DEBUG, "Executing impl_updateEdge for " +
+                                     weightedEdgeStr(src, dest, newWeight));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -260,7 +265,8 @@ public:
   }
 
   [[nodiscard]] bool impl_hasVertex(const VertexType &v) noexcept override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_hasVertex");
+    runtime.log(LogLevel::DEBUG, "Executing impl_hasVertex for " +
+                                     vertexStr(v));
     std::shared_lock<std::shared_mutex> lock(_mtx);
     runtime.log(LogLevel::INFO, "Vertex lookup.");
 
@@ -270,7 +276,8 @@ public:
   [[nodiscard]] bool
   impl_doesEdgeExist(const VertexType &src,
                      const VertexType &dest) noexcept override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_doesEdgeExist");
+    runtime.log(LogLevel::DEBUG, "Executing impl_doesEdgeExist for " +
+                                     edgeStr(src, dest));
     std::shared_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -295,7 +302,8 @@ public:
   [[nodiscard]] bool
   impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight) noexcept override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_doesEdgeExist");
+    runtime.log(LogLevel::DEBUG, "Executing impl_doesEdgeExist for " +
+                                     weightedEdgeStr(src, dest, weight));
     std::shared_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -322,7 +330,8 @@ public:
 
   [[nodiscard]] const std::pair<EdgeType, PeakStatus>
   impl_getEdge(const VertexType &src, const VertexType &dest) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_getEdge");
+    runtime.log(LogLevel::DEBUG, "Executing impl_getEdge for " +
+                                     edgeStr(src, dest));
     std::shared_lock<std::shared_mutex> lock(_mtx);
 
     auto srcIt = _vertex_lookup.find(src);
@@ -346,7 +355,8 @@ public:
 
   const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
   impl_getNeighbors(const VertexType &vertex) const {
-    runtime.log(LogLevel::DEBUG, "Executing impl_getNeighbors");
+    runtime.log(LogLevel::DEBUG, "Executing impl_getNeighbors for " +
+                                     vertexStr(vertex));
     // data copied under lock
     std::vector<std::pair<VertexId, EdgeType>> neighbor_ids;
     std::unordered_map<VertexId, VertexType> vertex_data_snapshot;
@@ -390,7 +400,8 @@ public:
 
   [[nodiscard]] const PeakStatus
   impl_removeVertex(const VertexType &v) override {
-    runtime.log(LogLevel::DEBUG, "Executing impl_removeVertex");
+    runtime.log(LogLevel::DEBUG, "Executing impl_removeVertex for " +
+                                     vertexStr(v));
     std::unique_lock<std::shared_mutex> lock(_mtx);
 
     auto it = _vertex_lookup.find(v);


### PR DESCRIPTION
### Which issue does this PR close?
Closes #247 

### Rationale for this change
As suggested by the maintainers, the internal logging calls in `PeakStore` and `AdjacencyList` previously only reported that a method was called. Refactoring them to use the newly added `dbg` utility provides significantly more context (such as printing the vertex IDs/names and edge weights), making it much easier to debug graph algorithms and storage engine behavior.

### What changes are included in this PR?
- Refactored `ctx->log()` and `runtime.log()` statements in `src/PeakStore.hpp` and `src/StorageEngine/AdjacencyList.hpp`.
- Included `"DebugUtils.hpp"` in `AdjacencyList.hpp`.
- Utilized the `vertexStr`, `edgeStr`, and `weightedEdgeStr` utilities to format vertices and edges cleanly in the log outputs.

### Are these changes tested?
- [x] Yes, I have run the test suite locally (`python build.py test`). All 40/40 tests pass successfully. 
- [x] The changes were verified not to introduce any compilation errors.

### Are there any user-facing changes?
- [ ] Yes
- [x] No (These changes only affect internal debug and trace logs printed to the console/file).
