### PR TITLE
fix(logging): correct DOT export log severity

### DIFF
--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -256,7 +256,7 @@ public:
     outFile << content;
     outFile.close();
 
-    ctx->log(LogLevel::ERROR, "Successfully wrote DOT output to: " + filename);
+    ctx->log(LogLevel::INFO, "Successfully wrote DOT output to: " + filename);
   }
 
   const std::string getGraphStatistics() {

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -441,42 +441,6 @@ public:
     return PeakStatus::OK();
   }
 
-  // void print_adj_list() {
-  //   // data copied under lock
-  //   struct VertexInfo {
-  //     VertexId id;
-  //     VertexType vertex_data;
-  //     std::vector<std::pair<VertexId, EdgeType>> neighbor_ids;
-  //   };
-  //   std::vector<VertexInfo> vertices_to_print;
-
-  //   {
-  //     std::shared_lock<std::shared_mutex> lock(_mtx);
-  //     for (const auto &kv : _adj) {
-  //       VertexId id = kv.first;
-  //       auto vdIt = _vertex_data.find(id);
-  //       if (vdIt == _vertex_data.end())
-  //         continue;
-
-  //       VertexInfo info;
-  //       info.id = id;
-  //       info.vertex_data = vdIt->second;
-  //       info.neighbor_ids = kv.second;
-
-  //       vertices_to_print.push_back(info);
-  //     }
-  //   }
-
-  //   // perform all I/O outside of lock
-  //   for (const auto &vertex_info : vertices_to_print) {
-  //     std::cout << "Vertex (id=" << vertex_info.id << "): "
-  //               << "\n";
-  //     for (const auto &neighbor_pair : vertex_info.neighbor_ids) {
-  //       VertexId nbId = neighbor_pair.first;
-  //       std::cout << "  Neighbor id=" << nbId << "\n";
-  //     }
-  //   }
-  // }
 
   const std::unordered_map<
       CinderPeak::VertexId,

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -441,7 +441,6 @@ public:
     return PeakStatus::OK();
   }
 
-
   const std::unordered_map<
       CinderPeak::VertexId,
       std::vector<std::pair<CinderPeak::VertexId, EdgeType>>> &


### PR DESCRIPTION
**Rationale for this change**
Successful DOT export operations were being logged using LogLevel::ERROR, which incorrectly categorized successful behavior as an error event. This could lead to misleading diagnostics and noisy logs.

**What changes are included in this PR?**
Replaced LogLevel::ERROR with LogLevel::INFO for successful DOT export logging inside PeakStore::toDot.

**Are these changes tested?**
Project was rebuilt successfully using CMake.
Test suite was executed using ctest --output-on-failure.
Some unrelated pre-existing BAD_COMMAND failures were observed in updateEdge tests.

**Are there any user-facing changes?**
No user-facing functionality changes are introduced. This change only improves internal logging severity classification.


## What changes are included in this PR?
- Removed commented-out `print_adj_list` function from AdjacencyList.hpp
- No functional or behavioral changes introduced

## Rationale for this change
Removes a deprecated commented-out debug utility (`print_adj_list`) from AdjacencyList.hpp to improve code cleanliness and maintainability.

## Are these changes tested?
Project was rebuilt successfully using CMake.
CTest was executed to ensure no regression was introduced.
Observed failures in unrelated modules (BAD_COMMAND / concurrency tests), which are pre-existing and not related to this change.

## Are there any user-facing changes?
No user-facing functionality changes are introduced.