### PR TITLE
docs: add macOS installation guide and Homebrew prerequisites

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,6 +55,27 @@ cmake --build .
 This configuration is ideal for using CinderPeak as a library dependency in other projects.
 
 ---
+## Build Configurations for macOS
+
+
+### Prerequisites
+Before building CinderPeak on macOS, ensure you have **Homebrew** installed. You will need to install CMake and Google Test (`googletest`) globally by running the following command in your terminal:
+```bash
+brew install cmake googletest
+```
+
+### Setup and Build Options
+1. Create a separate `build` directory in the root of the project and enter it:
+   ```bash
+   mkdir build
+   cd build
+   ```
+2. Run CMake to configure the project and compile using native Apple Clang:
+   ```bash
+   cmake .. -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON
+   cmake --build .
+   ```
+---
 
 ## Build Configurations for Windows
 


### PR DESCRIPTION
Description
This PR introduces explicit setup and compilation steps for macOS users within `installation.md`. It also maintains the standardized layout and corrected Windows toolchain instructions from recent documentation tracking.

Changes Made
* Added a dedicated `## Build Configurations for macOS` section.
* Included the global Homebrew prerequisite command (`brew install cmake googletest`).

📌 GSSoC Participation
Program: GirlScript Summer of Code 2026
GSSoC ID: Aaradhyanegi009

@SharonIV0x86 I have submitted the PR looking forward for it's review.
Linked Issue
Closes #257

 