### PR TITLE
fix: resolve potential subprocess deadlock in run_pipe

### DIFF
--- a/build.py
+++ b/build.py
@@ -38,7 +38,7 @@ def handle_build_errors(func):
             sys.exit(1)
     return wrapper
 
-def run(*args: str, msg: Optional[str] = None, verbose: bool = False, stream: bool = True, **kwargs: Any) -> Popen:
+def run(*args: str, msg: Optional[str] = None, verbose: bool = False, stream: bool = True, **kwargs: Any):
     sys.stdout.flush()
     if verbose:
         print(f"$ {' '.join(args)}")
@@ -47,19 +47,20 @@ def run(*args: str, msg: Optional[str] = None, verbose: bool = False, stream: bo
         kwargs['stdout'] = sys.stdout
         kwargs['stderr'] = sys.stderr
 
-    p = Popen(args, **kwargs)
-    code = p.wait()
-    if code != 0:
-        err = f"\nfailed to run: {' '.join(args)}\nexit with code: {code}\n"
+    import subprocess
+    try:
+        return subprocess.run(args, check=True, **kwargs)
+    except subprocess.CalledProcessError as e:
+        err = f"\nfailed to run: {' '.join(args)}\nexit with code: {e.returncode}\n"
         if msg:
             err += f"error message: {msg}\n"
         raise RuntimeError(err)
-    return p
 
 
-def run_pipe(*args: str, msg: Optional[str] = None, verbose: bool = False, **kwargs: Any):
-    p = run(*args, msg=msg, verbose=verbose, stream=False, stdout=PIPE, universal_newlines=True, **kwargs)
-    return p.stdout
+def run_pipe(*args: str, msg: Optional[str] = None, verbose: bool = False, **kwargs: Any) -> str:
+    import subprocess
+    result = run(*args, msg=msg, verbose=verbose, stream=False, stdout=subprocess.PIPE, text=True, **kwargs)
+    return result.stdout
 
 
 def find_command(command: str, msg: Optional[str] = None) -> str:

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -461,16 +461,14 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing getInternalAdjacency");
     return _adj;
   }
-struct DotConfig {
-  std::string graphName = "G";
-  std::string nodeColor = "#E3F2FD";
-  std::string nodeShape = "circle";
-  std::string fontName = "Arial";
-};
-std::string impl_toDot(
-    bool isDirected,
-    bool allowParallel = false,
-    const DotConfig &config = DotConfig()) const {
+  struct DotConfig {
+    std::string graphName = "G";
+    std::string nodeColor = "#E3F2FD";
+    std::string nodeShape = "circle";
+    std::string fontName = "Arial";
+  };
+  std::string impl_toDot(bool isDirected, bool allowParallel = false,
+                         const DotConfig &config = DotConfig()) const {
     runtime.log(LogLevel::DEBUG, "Executing impl_toDot");
     std::shared_lock<std::shared_mutex> lock(_mtx);
     std::stringstream ss;
@@ -478,17 +476,15 @@ std::string impl_toDot(
     if (!allowParallel) {
       ss << "strict ";
     }
-    ss << (isDirected ? "digraph" : "graph")
-       << " " << config.graphName << " {\n";
+    ss << (isDirected ? "digraph" : "graph") << " " << config.graphName
+       << " {\n";
 
     ss << "  rankdir=LR;\n";
 
-    ss << "  node[shape=" << config.nodeShape
-       << " style=filled fillcolor=\"" << config.nodeColor
-       << "\" fontname=\"" << config.fontName << "\"];\n";
+    ss << "  node[shape=" << config.nodeShape << " style=filled fillcolor=\""
+       << config.nodeColor << "\" fontname=\"" << config.fontName << "\"];\n";
 
-    ss << "  edge[fontname=\"" << config.fontName
-       << "\" fontsize=10];\n\n";
+    ss << "  edge[fontname=\"" << config.fontName << "\" fontsize=10];\n\n";
     // declare all nodes first (ensures isolated nodes appear)
     for (const auto &kv : _vertex_data) {
       VertexId id = kv.first;


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #271.

## Rationale for this change

When run_pipe() spawns a subprocess with stdout redirected to a pipe and then immediately calls p.wait(), it can cause a hard freeze. If the child process writes more data than the pipe’s buffer, the child blocks waiting for the buffer to be read. But the parent is stuck on p.wait() and never reads the buffer, so both processes deadlock and the program hangs.

## What changes are included in this PR?

Replaced the low-level subprocess.Popen usage in run() and run_pipe() with the higher-level subprocess.run().

subprocess.run() uses .communicate() under the hood to manage OS pipe buffers automatically, so the previous deadlock risk is removed.

Simplified error handling by switching to subprocess.CalledProcessError for representing command failures.

## Are these changes tested?

I manually verified this on Windows (PowerShell) by running python build.py configure. The script starts cleanly, calls the updated run() helper, and proceeds successfully through the baseline dependency checks.
