### PR TITLE
feat(algorithms): implement real BFS traversal and backend-independent traversal access

### DIFF
--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -1,11 +1,11 @@
 #pragma once
+#include "../StorageEngine/Utils.hpp"
 #include "Result/bfs_result.hpp"
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <queue>
 #include <unordered_set>
-#include <functional>
-#include "../StorageEngine/Utils.hpp"
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
@@ -217,15 +217,17 @@ public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
       nullptr;
   std::function<bool(const VertexType &)> hasVertexFn;
-  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
-      const VertexType &)> getNeighborsFn;
+  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                          PeakStatus>(const VertexType &)>
+      getNeighborsFn;
 
   CinderPeakAlgorithms(
       const std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>>
           &hybridcsr,
       std::function<bool(const VertexType &)> hasVertex,
-      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
-          const VertexType &)> getNeighbors)
+      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                              PeakStatus>(const VertexType &)>
+          getNeighbors)
       : hcsr(hybridcsr), hasVertexFn(std::move(hasVertex)),
         getNeighborsFn(std::move(getNeighbors)) {}
 

--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -2,6 +2,10 @@
 #include "Result/bfs_result.hpp"
 #include <iostream>
 #include <memory>
+#include <queue>
+#include <unordered_set>
+#include <functional>
+#include "../StorageEngine/Utils.hpp"
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
@@ -212,18 +216,52 @@ template <typename VertexType, typename EdgeType> class CinderPeakAlgorithms {
 public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
       nullptr;
+  std::function<bool(const VertexType &)> hasVertexFn;
+  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+      const VertexType &)> getNeighborsFn;
+
   CinderPeakAlgorithms(
       const std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>>
-          &hybridcsr)
-      : hcsr(hybridcsr) {}
-  BFSResult<VertexType> bfs([[maybe_unused]] const VertexType &src) {
-    std::cout << "Algorithms::bfs called\n";
+          &hybridcsr,
+      std::function<bool(const VertexType &)> hasVertex,
+      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+          const VertexType &)> getNeighbors)
+      : hcsr(hybridcsr), hasVertexFn(std::move(hasVertex)),
+        getNeighborsFn(std::move(getNeighbors)) {}
 
+  BFSResult<VertexType> bfs(const VertexType &src) const {
     BFSResult<VertexType> result;
-    result.order_.push_back(1);
-    result.order_.push_back(2);
-    result.order_.push_back(3);
-    result.order_.push_back(4);
+    if (!hasVertexFn || !hasVertexFn(src)) {
+      result._status =
+          PeakStatus::VertexNotFound("Vertex Not Found During BFS");
+      return result;
+    }
+
+    std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
+    std::queue<VertexType> queue;
+
+    visited.insert(src);
+    queue.push(src);
+
+    while (!queue.empty()) {
+      VertexType current = queue.front();
+      queue.pop();
+      result.order_.push_back(current);
+
+      auto [neighbors, status] = getNeighborsFn(current);
+      if (!status.isOK()) {
+        continue;
+      }
+
+      for (const auto &neighbor_pair : neighbors) {
+        const VertexType &neighbor = neighbor_pair.first;
+        if (visited.find(neighbor) == visited.end()) {
+          visited.insert(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+
     return result;
   }
 };

--- a/src/Events/GraphEvents.hpp
+++ b/src/Events/GraphEvents.hpp
@@ -15,14 +15,8 @@ template <typename V, typename E> struct EdgeRemovedEvent {
   const V &dest;
 };
 
-template <typename V> struct VertexAddedEvent {
+template <typename V> struct VertexAddedEvent { const V &vertex; };
 
-  const V &vertex;
-};
-
-template <typename V> struct VertexRemovedEvent {
-
-  const V &vertex;
-};
+template <typename V> struct VertexRemovedEvent { const V &vertex; };
 
 } // namespace CinderPeak

--- a/src/Events/GraphEvents.hpp
+++ b/src/Events/GraphEvents.hpp
@@ -15,8 +15,12 @@ template <typename V, typename E> struct EdgeRemovedEvent {
   const V &dest;
 };
 
-template <typename V> struct VertexAddedEvent { const V &vertex; };
+template <typename V> struct VertexAddedEvent {
+  const V &vertex;
+};
 
-template <typename V> struct VertexRemovedEvent { const V &vertex; };
+template <typename V> struct VertexRemovedEvent {
+  const V &vertex;
+};
 
 } // namespace CinderPeak

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -40,10 +40,22 @@ private:
     ctx->algorithms = std::make_shared<
         Algorithms::CinderPeakAlgorithms<VertexType, EdgeType>>(
         ctx->hybrid_storage,
-        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+        // hasVertex: prefer hybrid index but fall back to adjacency
+        [hyb = ctx->hybrid_storage,
+         adj = ctx->adjacency_storage](const VertexType &vertex) {
+          if (hyb && hyb->impl_hasVertex(vertex))
+            return true;
           return adj->impl_hasVertex(vertex);
         },
-        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+        // getNeighbors: try hybrid first (including buffered COO), then
+        // fallback to adjacency storage to preserve source-of-truth semantics.
+        [hyb = ctx->hybrid_storage,
+         adj = ctx->adjacency_storage](const VertexType &vertex) {
+          if (hyb) {
+            auto res = hyb->impl_getNeighbors(vertex);
+            if (res.second.isOK())
+              return res;
+          }
           return adj->impl_getNeighbors(vertex);
         });
 

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -39,7 +39,13 @@ private:
     ctx->active_storage = ctx->adjacency_storage;
     ctx->algorithms = std::make_shared<
         Algorithms::CinderPeakAlgorithms<VertexType, EdgeType>>(
-        ctx->hybrid_storage);
+        ctx->hybrid_storage,
+        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+          return adj->impl_hasVertex(vertex);
+        },
+        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+          return adj->impl_getNeighbors(vertex);
+        });
 
     ctx->runtime->log(LogLevel::CRITICAL, "Log from ctx\n");
     registerMetadataListeners(*ctx);

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -461,16 +461,14 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing getInternalAdjacency");
     return _adj;
   }
-struct DotConfig {
-  std::string graphName = "G";
-  std::string nodeColor = "#E3F2FD";
-  std::string nodeShape = "circle";
-  std::string fontName = "Arial";
-};
-std::string impl_toDot(
-    bool isDirected,
-    bool allowParallel = false,
-    const DotConfig &config = DotConfig()) const {
+  struct DotConfig {
+    std::string graphName = "G";
+    std::string nodeColor = "#E3F2FD";
+    std::string nodeShape = "circle";
+    std::string fontName = "Arial";
+  };
+  std::string impl_toDot(bool isDirected, bool allowParallel = false,
+                         const DotConfig &config = DotConfig()) const {
     runtime.log(LogLevel::DEBUG, "Executing impl_toDot");
     std::shared_lock<std::shared_mutex> lock(_mtx);
     std::stringstream ss;
@@ -478,17 +476,15 @@ std::string impl_toDot(
     if (!allowParallel) {
       ss << "strict ";
     }
-    ss << (isDirected ? "digraph" : "graph")
-       << " " << config.graphName << " {\n";
+    ss << (isDirected ? "digraph" : "graph") << " " << config.graphName
+       << " {\n";
 
     ss << "  rankdir=LR;\n";
 
-    ss << "  node[shape=" << config.nodeShape
-       << " style=filled fillcolor=\"" << config.nodeColor
-       << "\" fontname=\"" << config.fontName << "\"];\n";
+    ss << "  node[shape=" << config.nodeShape << " style=filled fillcolor=\""
+       << config.nodeColor << "\" fontname=\"" << config.fontName << "\"];\n";
 
-    ss << "  edge[fontname=\"" << config.fontName
-       << "\" fontsize=10];\n\n";
+    ss << "  edge[fontname=\"" << config.fontName << "\" fontsize=10];\n\n";
     // declare all nodes first (ensures isolated nodes appear)
     for (const auto &kv : _vertex_data) {
       VertexId id = kv.first;

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -551,6 +551,79 @@ public:
     return {EdgeType{}, PeakStatus::EdgeNotFound()};
   }
 
+  const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
+  impl_getNeighbors(const VertexType &vertex) {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+
+    auto it = vertex_to_index.find(vertex);
+    if (it == vertex_to_index.end()) {
+      return std::make_pair(std::vector<std::pair<VertexType, EdgeType>>{},
+                            PeakStatus::VertexNotFound());
+    }
+
+    size_t src_idx = it->second;
+
+    // Ensure CSR is built for fast access. Follow the same pattern used in
+    // impl_getEdge: release shared lock, build, and reacquire.
+    if (!is_built_.load(std::memory_order_acquire)) {
+      lock.unlock();
+      buildStructures();
+      lock.lock();
+    }
+
+    std::vector<std::pair<size_t, EdgeType>> neighbor_indices;
+
+    // Collect neighbors from CSR (if available)
+    if (is_built_.load(std::memory_order_acquire)) {
+      if (src_idx < csr_row_offsets.size() - 1) {
+        size_t start = csr_row_offsets[src_idx];
+        size_t end = csr_row_offsets[src_idx + 1];
+        for (size_t i = start; i < end; ++i) {
+          size_t dest_idx = csr_col_vals[i];
+          if (!_tombstoned.count(dest_idx))
+            neighbor_indices.emplace_back(dest_idx, csr_weights[i]);
+        }
+      }
+    }
+
+    // Include buffered COO entries
+    for (size_t i = 0; i < coo_src.size(); ++i) {
+      if (coo_src[i] == src_idx) {
+        size_t dest_idx = coo_dest[i];
+        if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx))
+          neighbor_indices.emplace_back(dest_idx, coo_weights[i]);
+      }
+    }
+
+    if (neighbor_indices.empty()) {
+      return std::make_pair(std::vector<std::pair<VertexType, EdgeType>>{},
+                            PeakStatus::OK());
+    }
+
+    // Sort and deduplicate by destination index to provide deterministic
+    // neighbor ordering.
+    std::sort(neighbor_indices.begin(), neighbor_indices.end(),
+              [](const auto &a, const auto &b) { return a.first < b.first; });
+    neighbor_indices.erase(std::unique(neighbor_indices.begin(),
+                                       neighbor_indices.end(),
+                                       [](const auto &a, const auto &b) {
+                                         return a.first == b.first;
+                                       }),
+                           neighbor_indices.end());
+
+    // Map indices back to vertex objects
+    std::vector<std::pair<VertexType, EdgeType>> result;
+    result.reserve(neighbor_indices.size());
+    for (const auto &p : neighbor_indices) {
+      size_t dest_idx = p.first;
+      if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx)) {
+        result.emplace_back(vertex_order[dest_idx], p.second);
+      }
+    }
+
+    return std::make_pair(result, PeakStatus::OK());
+  }
+
   [[nodiscard]] const PeakStatus
   impl_removeVertex(const VertexType &vtx) override {
     std::unique_lock<std::shared_mutex> lock(_mtx);

--- a/tests/integration/CinderGraph/functional/bfs_test.cpp
+++ b/tests/integration/CinderGraph/functional/bfs_test.cpp
@@ -1,0 +1,93 @@
+#include "DummyGraphBuilder.hpp"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace CinderPeak;
+
+class CinderGraphBfsTest : public ::testing::Test {
+protected:
+  DummyGraph builder;
+};
+
+TEST_F(CinderGraphBfsTest, DirectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(1, 3).second);
+  EXPECT_TRUE(graph.addEdge(2, 4).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST_F(CinderGraphBfsTest, UndirectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::undirected);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(1, 3).second);
+  EXPECT_TRUE(graph.addEdge(3, 4).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST_F(CinderGraphBfsTest, DisconnectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+  EXPECT_TRUE(graph.addVertex(5).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(2, 3).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST_F(CinderGraphBfsTest, IsolatedVertexTraversal) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(42).second);
+
+  auto result = graph.bfs(42);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({42}));
+}
+
+TEST_F(CinderGraphBfsTest, MissingSourceReturnsNotFound) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+
+  auto result = graph.bfs(100);
+  EXPECT_FALSE(result.isOK());
+  EXPECT_EQ(result._status.code(), StatusCode::VERTEX_NOT_FOUND);
+}
+
+TEST_F(CinderGraphBfsTest, CustomVertexTraversal) {
+  auto graph = builder.CreateCustomUnweightedGraph(GraphOpts::directed);
+  ListVertex v1(1);
+  ListVertex v2(2);
+  ListVertex v3(3);
+
+  EXPECT_TRUE(graph.addVertex(v1).second);
+  EXPECT_TRUE(graph.addVertex(v2).second);
+  EXPECT_TRUE(graph.addVertex(v3).second);
+
+  EXPECT_TRUE(graph.addEdge(v1, v2).second);
+  EXPECT_TRUE(graph.addEdge(v2, v3).second);
+
+  auto result = graph.bfs(v1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<ListVertex>({v1, v2, v3}));
+}

--- a/tests/unit/Algorithms/bfs_parity_test.cpp
+++ b/tests/unit/Algorithms/bfs_parity_test.cpp
@@ -1,0 +1,116 @@
+#include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "GraphRuntime.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/HybridCSR_COO.hpp"
+#include "gtest/gtest.h"
+
+using namespace CinderPeak;
+
+TEST(BFSParityTest, AdjacencyVsHybridPrimitive) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  PeakStore::HybridCSR_COO<int, int> hybrid;
+
+  // Build graph: 1 -> 2, 1 -> 3, 2 -> 4
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+
+  // Prepare adjacency-style map for hybrid population
+  std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>>
+      amap;
+  amap[1] = {{2, 0}, {3, 0}};
+  amap[2] = {{4, 0}};
+  amap[3] = {};
+  amap[4] = {};
+
+  // create shared hybrid and populate
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  // adjacency-only algorithm (no hybrid available)
+  Algorithms::CinderPeakAlgorithms<int, int> alg_adj(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  // hybrid-first algorithm (prefers hybrid, falls back to adjacency)
+  Algorithms::CinderPeakAlgorithms<int, int> alg_hyb(
+      hybrid_ptr,
+      [hyb = hybrid_ptr, &adj](const int &v) {
+        if (hyb->impl_hasVertex(v))
+          return true;
+        return adj.impl_hasVertex(v);
+      },
+      [hyb = hybrid_ptr, &adj](const int &v) {
+        auto res = hyb->impl_getNeighbors(v);
+        if (res.second.isOK())
+          return res;
+        return adj.impl_getNeighbors(v);
+      });
+
+  auto r1 = alg_adj.bfs(1);
+  auto r2 = alg_hyb.bfs(1);
+
+  EXPECT_TRUE(r1.isOK());
+  EXPECT_TRUE(r2.isOK());
+  EXPECT_EQ(r1.order_, r2.order_);
+}
+
+TEST(BFSParityTest, CustomVertexParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<CinderVertex, int> adj(runtime);
+  CinderVertex v1("A"), v2("B"), v3("C");
+  (void)adj.impl_addVertex(v1);
+  (void)adj.impl_addVertex(v2);
+  (void)adj.impl_addVertex(v3);
+  (void)adj.impl_addEdge(v1, v2);
+  (void)adj.impl_addEdge(v2, v3);
+
+  std::unordered_map<CinderVertex, std::vector<std::pair<CinderVertex, int>>,
+                     VertexHasher<CinderVertex>>
+      amap;
+  amap[v1] = {{v2, 0}};
+  amap[v2] = {{v3, 0}};
+  amap[v3] = {};
+
+  // populate hybrid from adjacency map
+  // (handled below via hybrid_ptr->populateFromAdjList)
+
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg_adj(
+      std::make_shared<PeakStore::HybridCSR_COO<CinderVertex, int>>(),
+      [&adj](const CinderVertex &v) { return adj.impl_hasVertex(v); },
+      [&adj](const CinderVertex &v) { return adj.impl_getNeighbors(v); });
+
+  auto hybrid_ptr =
+      std::make_shared<PeakStore::HybridCSR_COO<CinderVertex, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg_hyb(
+      hybrid_ptr,
+      [hyb = hybrid_ptr, &adj](const CinderVertex &v) {
+        if (hyb->impl_hasVertex(v))
+          return true;
+        return adj.impl_hasVertex(v);
+      },
+      [hyb = hybrid_ptr, &adj](const CinderVertex &v) {
+        auto res = hyb->impl_getNeighbors(v);
+        if (res.second.isOK())
+          return res;
+        return adj.impl_getNeighbors(v);
+      });
+
+  auto r1 = alg_adj.bfs(v1);
+  auto r2 = alg_hyb.bfs(v1);
+
+  EXPECT_TRUE(r1.isOK());
+  EXPECT_TRUE(r2.isOK());
+  EXPECT_EQ(r1.order_.size(), r2.order_.size());
+  // Compare __id_ to avoid relying on string names ordering
+  for (size_t i = 0; i < r1.order_.size(); ++i) {
+    EXPECT_EQ(r1.order_[i].__id_, r2.order_[i].__id_);
+  }
+}


### PR DESCRIPTION
- Closes #270 

## Rationale for this change

The existing BFS implementation inside `CinderPeakAlgorithms` was still a mocked/stubbed implementation and did not perform actual graph traversal.

Additionally, traversal-related logic was tightly coupled to storage access patterns, making it harder to extend traversal algorithms in a backend-independent and maintainable manner.

This PR introduces incremental traversal architecture improvements centered around:
- replacing the mocked BFS path with a real traversal implementation
- introducing reusable backend-independent traversal access foundations
- improving traversal consistency and parity across storage backends
- preparing the traversal layer for future extensibility (DFS/topological traversal support)

The implementation was intentionally kept incremental and reviewable instead of introducing a broad traversal-system rewrite or full immutable snapshot framework in a single PR.

## What changes are included in this PR?

### BFS implementation
- replaced the mocked BFS implementation with a real queue-based breadth-first traversal
- removed hardcoded traversal output and debug stdout logging
- added proper visited tracking using existing hashing infrastructure
- preserved deterministic traversal behavior where feasible

### Traversal abstraction improvements
- introduced backend-independent traversal access through adjacency callbacks
- avoided direct traversal coupling with storage internals
- preserved the current public API surface

### Traversal behavior improvements
- improved handling for:
  - missing source vertices
  - disconnected graphs
  - isolated vertices
  - custom vertex types

### Testing and validation
- added BFS integration tests
- added backend parity tests
- added regression coverage for traversal behavior consistency
- validated traversal behavior across storage backends

### Scope intentionally deferred
This PR does **not** yet implement the complete immutable `TraversalSnapshot` framework proposed in the original issue. Snapshot lifecycle management, immutable traversal views, and storage synchronization semantics were intentionally deferred to keep this implementation incremental, maintainable, and easier to review.

## Are these changes tested?

Yes.
Added:
- BFS integration tests
- traversal backend parity tests
- regression coverage for disconnected graphs, isolated vertices, missing sources, and custom vertex types
Validation completed:
- formatter executed successfully
- full test suite passing (`44/44`)

## Are there any user-facing changes?

Yes.
`CinderGraph::bfs()` now performs actual breadth-first traversal instead of returning mocked traversal data.
No breaking public API changes were introduced.