### PR TITLE
feat(algorithms): introduce traversal snapshot foundation

### DIFF
--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -1,11 +1,11 @@
 #pragma once
+#include "../StorageEngine/Utils.hpp"
 #include "Result/bfs_result.hpp"
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <queue>
 #include <unordered_set>
-#include <functional>
-#include "../StorageEngine/Utils.hpp"
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
@@ -217,15 +217,17 @@ public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
       nullptr;
   std::function<bool(const VertexType &)> hasVertexFn;
-  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
-      const VertexType &)> getNeighborsFn;
+  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                          PeakStatus>(const VertexType &)>
+      getNeighborsFn;
 
   CinderPeakAlgorithms(
       const std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>>
           &hybridcsr,
       std::function<bool(const VertexType &)> hasVertex,
-      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
-          const VertexType &)> getNeighbors)
+      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                              PeakStatus>(const VertexType &)>
+          getNeighbors)
       : hcsr(hybridcsr), hasVertexFn(std::move(hasVertex)),
         getNeighborsFn(std::move(getNeighbors)) {}
 

--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -2,6 +2,10 @@
 #include "Result/bfs_result.hpp"
 #include <iostream>
 #include <memory>
+#include <queue>
+#include <unordered_set>
+#include <functional>
+#include "../StorageEngine/Utils.hpp"
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
@@ -212,18 +216,52 @@ template <typename VertexType, typename EdgeType> class CinderPeakAlgorithms {
 public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
       nullptr;
+  std::function<bool(const VertexType &)> hasVertexFn;
+  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+      const VertexType &)> getNeighborsFn;
+
   CinderPeakAlgorithms(
       const std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>>
-          &hybridcsr)
-      : hcsr(hybridcsr) {}
-  BFSResult<VertexType> bfs([[maybe_unused]] const VertexType &src) {
-    std::cout << "Algorithms::bfs called\n";
+          &hybridcsr,
+      std::function<bool(const VertexType &)> hasVertex,
+      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+          const VertexType &)> getNeighbors)
+      : hcsr(hybridcsr), hasVertexFn(std::move(hasVertex)),
+        getNeighborsFn(std::move(getNeighbors)) {}
 
+  BFSResult<VertexType> bfs(const VertexType &src) const {
     BFSResult<VertexType> result;
-    result.order_.push_back(1);
-    result.order_.push_back(2);
-    result.order_.push_back(3);
-    result.order_.push_back(4);
+    if (!hasVertexFn || !hasVertexFn(src)) {
+      result._status =
+          PeakStatus::VertexNotFound("Vertex Not Found During BFS");
+      return result;
+    }
+
+    std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
+    std::queue<VertexType> queue;
+
+    visited.insert(src);
+    queue.push(src);
+
+    while (!queue.empty()) {
+      VertexType current = queue.front();
+      queue.pop();
+      result.order_.push_back(current);
+
+      auto [neighbors, status] = getNeighborsFn(current);
+      if (!status.isOK()) {
+        continue;
+      }
+
+      for (const auto &neighbor_pair : neighbors) {
+        const VertexType &neighbor = neighbor_pair.first;
+        if (visited.find(neighbor) == visited.end()) {
+          visited.insert(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+
     return result;
   }
 };

--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -1,16 +1,17 @@
 #pragma once
 #include "../StorageEngine/Utils.hpp"
 #include "Result/bfs_result.hpp"
+#include "TraversalSnapshot.hpp"
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <queue>
 #include <unordered_set>
+
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
 
-}
+} // namespace PeakStore
 /*
 ================================================================================
                                 CINDERPEAK NOTE
@@ -131,6 +132,11 @@ template <typename VertexType, typename EdgeType> class HybridCSR_COO;
         - Synchronization overhead
         - Cache invalidation logic
 
+    TraversalSnapshot provides a lightweight immutable adjacency view for
+    algorithms that need point-in-time connectivity without exposing storage
+    internals. PeakStore owns snapshot creation; algorithms consume snapshots
+    through hasVertex/getNeighbors-style access only.
+
     ------------------------------------------------------------------------
     Current Development Priority
     ------------------------------------------------------------------------
@@ -212,6 +218,51 @@ template <typename VertexType, typename EdgeType> class HybridCSR_COO;
 ================================================================================
 */
 namespace Algorithms {
+namespace detail {
+
+template <typename VertexType, typename EdgeType>
+BFSResult<VertexType>
+runBfs(const std::function<bool(const VertexType &)> &hasVertex,
+       const std::function<
+           std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+               const VertexType &)> &getNeighbors,
+       const VertexType &src) {
+  BFSResult<VertexType> result;
+  if (!hasVertex || !hasVertex(src)) {
+    result._status = PeakStatus::VertexNotFound("Vertex Not Found During BFS");
+    return result;
+  }
+
+  std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
+  std::queue<VertexType> queue;
+
+  visited.insert(src);
+  queue.push(src);
+
+  while (!queue.empty()) {
+    VertexType current = queue.front();
+    queue.pop();
+    result.order_.push_back(current);
+
+    auto [neighbors, status] = getNeighbors(current);
+    if (!status.isOK()) {
+      continue;
+    }
+
+    for (const auto &neighbor_pair : neighbors) {
+      const VertexType &neighbor = neighbor_pair.first;
+      if (visited.find(neighbor) == visited.end()) {
+        visited.insert(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return result;
+}
+
+} // namespace detail
+
 template <typename VertexType, typename EdgeType> class CinderPeakAlgorithms {
 public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
@@ -232,39 +283,17 @@ public:
         getNeighborsFn(std::move(getNeighbors)) {}
 
   BFSResult<VertexType> bfs(const VertexType &src) const {
-    BFSResult<VertexType> result;
-    if (!hasVertexFn || !hasVertexFn(src)) {
-      result._status =
-          PeakStatus::VertexNotFound("Vertex Not Found During BFS");
-      return result;
-    }
+    return detail::runBfs<VertexType, EdgeType>(hasVertexFn, getNeighborsFn,
+                                                src);
+  }
 
-    std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
-    std::queue<VertexType> queue;
-
-    visited.insert(src);
-    queue.push(src);
-
-    while (!queue.empty()) {
-      VertexType current = queue.front();
-      queue.pop();
-      result.order_.push_back(current);
-
-      auto [neighbors, status] = getNeighborsFn(current);
-      if (!status.isOK()) {
-        continue;
-      }
-
-      for (const auto &neighbor_pair : neighbors) {
-        const VertexType &neighbor = neighbor_pair.first;
-        if (visited.find(neighbor) == visited.end()) {
-          visited.insert(neighbor);
-          queue.push(neighbor);
-        }
-      }
-    }
-
-    return result;
+  BFSResult<VertexType>
+  bfs(const VertexType &src,
+      const TraversalSnapshot<VertexType, EdgeType> &snapshot) const {
+    return detail::runBfs<VertexType, EdgeType>(
+        [&snapshot](const VertexType &v) { return snapshot.hasVertex(v); },
+        [&snapshot](const VertexType &v) { return snapshot.getNeighbors(v); },
+        src);
   }
 };
 } // namespace Algorithms

--- a/src/Algorithms/TraversalSnapshot.hpp
+++ b/src/Algorithms/TraversalSnapshot.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../StorageEngine/Utils.hpp"
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace CinderPeak {
+namespace Algorithms {
+
+/// Selects which storage backend PeakStore uses when materializing a snapshot.
+enum class TraversalSnapshotBackend { Adjacency, Hybrid };
+
+/// Immutable, backend-independent adjacency view for traversal algorithms.
+///
+/// Snapshots are owned by the caller (typically via shared_ptr from PeakStore)
+/// and capture graph connectivity at creation time. Live storage mutations do
+/// not affect an existing snapshot.
+///
+/// Future algorithms (DFS, topological sort, concurrent policies) should prefer
+/// this view over direct storage access.
+template <typename VertexType, typename EdgeType> class TraversalSnapshot {
+public:
+  using AdjacencyMap =
+      std::unordered_map<VertexType,
+                         std::vector<std::pair<VertexType, EdgeType>>,
+                         VertexHasher<VertexType>>;
+
+  TraversalSnapshot() = default;
+
+  explicit TraversalSnapshot(AdjacencyMap adjacency)
+      : adjacency_(std::move(adjacency)) {}
+
+  [[nodiscard]] bool hasVertex(const VertexType &vertex) const {
+    return adjacency_.find(vertex) != adjacency_.end();
+  }
+
+  [[nodiscard]] std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                          PeakStatus>
+  getNeighbors(const VertexType &vertex) const {
+    auto it = adjacency_.find(vertex);
+    if (it == adjacency_.end()) {
+      return {std::vector<std::pair<VertexType, EdgeType>>{},
+              PeakStatus::VertexNotFound()};
+    }
+    return {it->second, PeakStatus::OK()};
+  }
+
+  [[nodiscard]] std::size_t vertexCount() const { return adjacency_.size(); }
+
+  [[nodiscard]] const AdjacencyMap &adjacency() const { return adjacency_; }
+
+private:
+  AdjacencyMap adjacency_;
+};
+
+} // namespace Algorithms
+} // namespace CinderPeak

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -441,6 +441,21 @@ public:
     return peak_store->bfs(src);
   }
 
+  Algorithms::BFSResult<VertexType>
+  bfs(const VertexType &src,
+      const std::shared_ptr<
+          const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+          &snapshot) {
+    return peak_store->bfs(src, snapshot);
+  }
+
+  std::shared_ptr<const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+  createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend backend =
+          Algorithms::TraversalSnapshotBackend::Adjacency) const {
+    return peak_store->createTraversalSnapshot(backend);
+  }
+
   template <typename V = VertexType, typename E = EdgeType>
 
   /**

--- a/src/Events/GraphEvents.hpp
+++ b/src/Events/GraphEvents.hpp
@@ -15,14 +15,8 @@ template <typename V, typename E> struct EdgeRemovedEvent {
   const V &dest;
 };
 
-template <typename V> struct VertexAddedEvent {
+template <typename V> struct VertexAddedEvent { const V &vertex; };
 
-  const V &vertex;
-};
-
-template <typename V> struct VertexRemovedEvent {
-
-  const V &vertex;
-};
+template <typename V> struct VertexRemovedEvent { const V &vertex; };
 
 } // namespace CinderPeak

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -40,10 +40,22 @@ private:
     ctx->algorithms = std::make_shared<
         Algorithms::CinderPeakAlgorithms<VertexType, EdgeType>>(
         ctx->hybrid_storage,
-        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+        // hasVertex: prefer hybrid index but fall back to adjacency
+        [hyb = ctx->hybrid_storage,
+         adj = ctx->adjacency_storage](const VertexType &vertex) {
+          if (hyb && hyb->impl_hasVertex(vertex))
+            return true;
           return adj->impl_hasVertex(vertex);
         },
-        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+        // getNeighbors: try hybrid first (including buffered COO), then
+        // fallback to adjacency storage to preserve source-of-truth semantics.
+        [hyb = ctx->hybrid_storage,
+         adj = ctx->adjacency_storage](const VertexType &vertex) {
+          if (hyb) {
+            auto res = hyb->impl_getNeighbors(vertex);
+            if (res.second.isOK())
+              return res;
+          }
           return adj->impl_getNeighbors(vertex);
         });
 

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -39,7 +39,13 @@ private:
     ctx->active_storage = ctx->adjacency_storage;
     ctx->algorithms = std::make_shared<
         Algorithms::CinderPeakAlgorithms<VertexType, EdgeType>>(
-        ctx->hybrid_storage);
+        ctx->hybrid_storage,
+        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+          return adj->impl_hasVertex(vertex);
+        },
+        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+          return adj->impl_getNeighbors(vertex);
+        });
 
     ctx->runtime->log(LogLevel::CRITICAL, "Log from ctx\n");
     registerMetadataListeners(*ctx);

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "Algorithms/TraversalSnapshot.hpp"
 #include "CinderPeak.hpp"
 #include "Constraints/Constraints.hpp"
 #include "Events/DefaultListeners.hpp"
@@ -82,6 +83,28 @@ public:
   // Get graph name
   std::string getGraphName() { return ctx->metadata->getGraphName(); }
 
+  /// Captures an immutable adjacency snapshot for traversal algorithms.
+  /// Hybrid snapshots fall back to adjacency when the hybrid index is empty.
+  std::shared_ptr<const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+  createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend backend =
+          Algorithms::TraversalSnapshotBackend::Adjacency) const {
+    typename Algorithms::TraversalSnapshot<VertexType, EdgeType>::AdjacencyMap
+        adjacency;
+    if (backend == Algorithms::TraversalSnapshotBackend::Hybrid &&
+        ctx->hybrid_storage) {
+      adjacency = ctx->hybrid_storage->impl_captureTraversalAdjacency();
+      if (adjacency.empty() && ctx->adjacency_storage) {
+        adjacency = ctx->adjacency_storage->impl_captureTraversalAdjacency();
+      }
+    } else if (ctx->adjacency_storage) {
+      adjacency = ctx->adjacency_storage->impl_captureTraversalAdjacency();
+    }
+    return std::make_shared<
+        const Algorithms::TraversalSnapshot<VertexType, EdgeType>>(
+        std::move(adjacency));
+  }
+
   Algorithms::BFSResult<VertexType> bfs(const VertexType &src) {
     Algorithms::BFSResult<VertexType> result;
     if (!hasVertex(src)) {
@@ -91,6 +114,25 @@ public:
     }
     result = std::move(ctx->algorithms->bfs(src));
     return result;
+  }
+
+  /// BFS over an immutable snapshot; ignores live storage mutations during
+  /// traversal. When snapshot is null, delegates to callback-based bfs().
+  Algorithms::BFSResult<VertexType>
+  bfs(const VertexType &src,
+      const std::shared_ptr<
+          const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+          &snapshot) {
+    if (!snapshot) {
+      return bfs(src);
+    }
+    Algorithms::BFSResult<VertexType> result;
+    if (!snapshot->hasVertex(src)) {
+      result._status =
+          PeakStatus::VertexNotFound("Vertex Not Found During the BFS");
+      return result;
+    }
+    return ctx->algorithms->bfs(src, *snapshot);
   }
 
   PeakStatus addEdge(const VertexType &src, const VertexType &dest,

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -461,16 +461,14 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing getInternalAdjacency");
     return _adj;
   }
-struct DotConfig {
-  std::string graphName = "G";
-  std::string nodeColor = "#E3F2FD";
-  std::string nodeShape = "circle";
-  std::string fontName = "Arial";
-};
-std::string impl_toDot(
-    bool isDirected,
-    bool allowParallel = false,
-    const DotConfig &config = DotConfig()) const {
+  struct DotConfig {
+    std::string graphName = "G";
+    std::string nodeColor = "#E3F2FD";
+    std::string nodeShape = "circle";
+    std::string fontName = "Arial";
+  };
+  std::string impl_toDot(bool isDirected, bool allowParallel = false,
+                         const DotConfig &config = DotConfig()) const {
     runtime.log(LogLevel::DEBUG, "Executing impl_toDot");
     std::shared_lock<std::shared_mutex> lock(_mtx);
     std::stringstream ss;
@@ -478,17 +476,15 @@ std::string impl_toDot(
     if (!allowParallel) {
       ss << "strict ";
     }
-    ss << (isDirected ? "digraph" : "graph")
-       << " " << config.graphName << " {\n";
+    ss << (isDirected ? "digraph" : "graph") << " " << config.graphName
+       << " {\n";
 
     ss << "  rankdir=LR;\n";
 
-    ss << "  node[shape=" << config.nodeShape
-       << " style=filled fillcolor=\"" << config.nodeColor
-       << "\" fontname=\"" << config.fontName << "\"];\n";
+    ss << "  node[shape=" << config.nodeShape << " style=filled fillcolor=\""
+       << config.nodeColor << "\" fontname=\"" << config.fontName << "\"];\n";
 
-    ss << "  edge[fontname=\"" << config.fontName
-       << "\" fontsize=10];\n\n";
+    ss << "  edge[fontname=\"" << config.fontName << "\" fontsize=10];\n\n";
     // declare all nodes first (ensures isolated nodes appear)
     for (const auto &kv : _vertex_data) {
       VertexId id = kv.first;

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -522,6 +522,35 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing getVertexDataMap");
     return _vertex_data;
   }
+
+  /// Copies vertex-keyed adjacency for immutable traversal snapshots.
+  std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                     VertexHasher<VertexType>>
+  impl_captureTraversalAdjacency() const {
+    std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                       VertexHasher<VertexType>>
+        snapshot;
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    snapshot.reserve(_vertex_data.size());
+    for (const auto &[id, vertex] : _vertex_data) {
+      const auto adj_it = _adj.find(id);
+      if (adj_it == _adj.end()) {
+        snapshot.emplace(vertex,
+                         std::vector<std::pair<VertexType, EdgeType>>{});
+        continue;
+      }
+      std::vector<std::pair<VertexType, EdgeType>> neighbors;
+      neighbors.reserve(adj_it->second.size());
+      for (const auto &edge : adj_it->second) {
+        auto dest_it = _vertex_data.find(edge.first);
+        if (dest_it != _vertex_data.end()) {
+          neighbors.emplace_back(dest_it->second, edge.second);
+        }
+      }
+      snapshot.emplace(vertex, std::move(neighbors));
+    }
+    return snapshot;
+  }
 };
 
 } // namespace PeakStore

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -638,6 +638,70 @@ public:
 
     return PeakStatus::OK();
   }
+
+  /// Materializes vertex-keyed adjacency from CSR and any buffered COO edges.
+  std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                     VertexHasher<VertexType>>
+  impl_captureTraversalAdjacency() {
+    if (!is_built_.load(std::memory_order_acquire)) {
+      buildStructures();
+    }
+
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                       VertexHasher<VertexType>>
+        snapshot;
+    snapshot.reserve(vertex_order.size());
+
+    for (size_t src_idx = 0; src_idx < vertex_order.size(); ++src_idx) {
+      if (_tombstoned.count(src_idx)) {
+        continue;
+      }
+      const VertexType &src_vertex = vertex_order[src_idx];
+      std::vector<std::pair<size_t, EdgeType>> neighbor_indices;
+
+      if (is_built_.load(std::memory_order_acquire) &&
+          src_idx + 1 < csr_row_offsets.size()) {
+        const size_t start = csr_row_offsets[src_idx];
+        const size_t end = csr_row_offsets[src_idx + 1];
+        for (size_t i = start; i < end; ++i) {
+          const size_t dest_idx = csr_col_vals[i];
+          if (!_tombstoned.count(dest_idx)) {
+            neighbor_indices.emplace_back(dest_idx, csr_weights[i]);
+          }
+        }
+      }
+
+      for (size_t i = 0; i < coo_src.size(); ++i) {
+        if (coo_src[i] == src_idx) {
+          const size_t dest_idx = coo_dest[i];
+          if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx)) {
+            neighbor_indices.emplace_back(dest_idx, coo_weights[i]);
+          }
+        }
+      }
+
+      std::vector<std::pair<VertexType, EdgeType>> neighbors;
+      if (!neighbor_indices.empty()) {
+        std::sort(
+            neighbor_indices.begin(), neighbor_indices.end(),
+            [](const auto &a, const auto &b) { return a.first < b.first; });
+        neighbor_indices.erase(std::unique(neighbor_indices.begin(),
+                                           neighbor_indices.end(),
+                                           [](const auto &a, const auto &b) {
+                                             return a.first == b.first;
+                                           }),
+                               neighbor_indices.end());
+        neighbors.reserve(neighbor_indices.size());
+        for (const auto &p : neighbor_indices) {
+          neighbors.emplace_back(vertex_order[p.first], p.second);
+        }
+      }
+
+      snapshot.emplace(src_vertex, std::move(neighbors));
+    }
+    return snapshot;
+  }
 };
 
 } // namespace PeakStore

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -551,6 +551,79 @@ public:
     return {EdgeType{}, PeakStatus::EdgeNotFound()};
   }
 
+  const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
+  impl_getNeighbors(const VertexType &vertex) {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+
+    auto it = vertex_to_index.find(vertex);
+    if (it == vertex_to_index.end()) {
+      return std::make_pair(std::vector<std::pair<VertexType, EdgeType>>{},
+                            PeakStatus::VertexNotFound());
+    }
+
+    size_t src_idx = it->second;
+
+    // Ensure CSR is built for fast access. Follow the same pattern used in
+    // impl_getEdge: release shared lock, build, and reacquire.
+    if (!is_built_.load(std::memory_order_acquire)) {
+      lock.unlock();
+      buildStructures();
+      lock.lock();
+    }
+
+    std::vector<std::pair<size_t, EdgeType>> neighbor_indices;
+
+    // Collect neighbors from CSR (if available)
+    if (is_built_.load(std::memory_order_acquire)) {
+      if (src_idx < csr_row_offsets.size() - 1) {
+        size_t start = csr_row_offsets[src_idx];
+        size_t end = csr_row_offsets[src_idx + 1];
+        for (size_t i = start; i < end; ++i) {
+          size_t dest_idx = csr_col_vals[i];
+          if (!_tombstoned.count(dest_idx))
+            neighbor_indices.emplace_back(dest_idx, csr_weights[i]);
+        }
+      }
+    }
+
+    // Include buffered COO entries
+    for (size_t i = 0; i < coo_src.size(); ++i) {
+      if (coo_src[i] == src_idx) {
+        size_t dest_idx = coo_dest[i];
+        if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx))
+          neighbor_indices.emplace_back(dest_idx, coo_weights[i]);
+      }
+    }
+
+    if (neighbor_indices.empty()) {
+      return std::make_pair(std::vector<std::pair<VertexType, EdgeType>>{},
+                            PeakStatus::OK());
+    }
+
+    // Sort and deduplicate by destination index to provide deterministic
+    // neighbor ordering.
+    std::sort(neighbor_indices.begin(), neighbor_indices.end(),
+              [](const auto &a, const auto &b) { return a.first < b.first; });
+    neighbor_indices.erase(std::unique(neighbor_indices.begin(),
+                                       neighbor_indices.end(),
+                                       [](const auto &a, const auto &b) {
+                                         return a.first == b.first;
+                                       }),
+                           neighbor_indices.end());
+
+    // Map indices back to vertex objects
+    std::vector<std::pair<VertexType, EdgeType>> result;
+    result.reserve(neighbor_indices.size());
+    for (const auto &p : neighbor_indices) {
+      size_t dest_idx = p.first;
+      if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx)) {
+        result.emplace_back(vertex_order[dest_idx], p.second);
+      }
+    }
+
+    return std::make_pair(result, PeakStatus::OK());
+  }
+
   [[nodiscard]] const PeakStatus
   impl_removeVertex(const VertexType &vtx) override {
     std::unique_lock<std::shared_mutex> lock(_mtx);

--- a/tests/integration/CinderGraph/functional/bfs_test.cpp
+++ b/tests/integration/CinderGraph/functional/bfs_test.cpp
@@ -1,0 +1,93 @@
+#include "DummyGraphBuilder.hpp"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace CinderPeak;
+
+class CinderGraphBfsTest : public ::testing::Test {
+protected:
+  DummyGraph builder;
+};
+
+TEST_F(CinderGraphBfsTest, DirectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(1, 3).second);
+  EXPECT_TRUE(graph.addEdge(2, 4).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST_F(CinderGraphBfsTest, UndirectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::undirected);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(1, 3).second);
+  EXPECT_TRUE(graph.addEdge(3, 4).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST_F(CinderGraphBfsTest, DisconnectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+  EXPECT_TRUE(graph.addVertex(5).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(2, 3).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST_F(CinderGraphBfsTest, IsolatedVertexTraversal) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(42).second);
+
+  auto result = graph.bfs(42);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({42}));
+}
+
+TEST_F(CinderGraphBfsTest, MissingSourceReturnsNotFound) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+
+  auto result = graph.bfs(100);
+  EXPECT_FALSE(result.isOK());
+  EXPECT_EQ(result._status.code(), StatusCode::VERTEX_NOT_FOUND);
+}
+
+TEST_F(CinderGraphBfsTest, CustomVertexTraversal) {
+  auto graph = builder.CreateCustomUnweightedGraph(GraphOpts::directed);
+  ListVertex v1(1);
+  ListVertex v2(2);
+  ListVertex v3(3);
+
+  EXPECT_TRUE(graph.addVertex(v1).second);
+  EXPECT_TRUE(graph.addVertex(v2).second);
+  EXPECT_TRUE(graph.addVertex(v3).second);
+
+  EXPECT_TRUE(graph.addEdge(v1, v2).second);
+  EXPECT_TRUE(graph.addEdge(v2, v3).second);
+
+  auto result = graph.bfs(v1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<ListVertex>({v1, v2, v3}));
+}

--- a/tests/unit/Algorithms/bfs_parity_test.cpp
+++ b/tests/unit/Algorithms/bfs_parity_test.cpp
@@ -1,0 +1,116 @@
+#include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "GraphRuntime.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/HybridCSR_COO.hpp"
+#include "gtest/gtest.h"
+
+using namespace CinderPeak;
+
+TEST(BFSParityTest, AdjacencyVsHybridPrimitive) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  PeakStore::HybridCSR_COO<int, int> hybrid;
+
+  // Build graph: 1 -> 2, 1 -> 3, 2 -> 4
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+
+  // Prepare adjacency-style map for hybrid population
+  std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>>
+      amap;
+  amap[1] = {{2, 0}, {3, 0}};
+  amap[2] = {{4, 0}};
+  amap[3] = {};
+  amap[4] = {};
+
+  // create shared hybrid and populate
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  // adjacency-only algorithm (no hybrid available)
+  Algorithms::CinderPeakAlgorithms<int, int> alg_adj(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  // hybrid-first algorithm (prefers hybrid, falls back to adjacency)
+  Algorithms::CinderPeakAlgorithms<int, int> alg_hyb(
+      hybrid_ptr,
+      [hyb = hybrid_ptr, &adj](const int &v) {
+        if (hyb->impl_hasVertex(v))
+          return true;
+        return adj.impl_hasVertex(v);
+      },
+      [hyb = hybrid_ptr, &adj](const int &v) {
+        auto res = hyb->impl_getNeighbors(v);
+        if (res.second.isOK())
+          return res;
+        return adj.impl_getNeighbors(v);
+      });
+
+  auto r1 = alg_adj.bfs(1);
+  auto r2 = alg_hyb.bfs(1);
+
+  EXPECT_TRUE(r1.isOK());
+  EXPECT_TRUE(r2.isOK());
+  EXPECT_EQ(r1.order_, r2.order_);
+}
+
+TEST(BFSParityTest, CustomVertexParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<CinderVertex, int> adj(runtime);
+  CinderVertex v1("A"), v2("B"), v3("C");
+  (void)adj.impl_addVertex(v1);
+  (void)adj.impl_addVertex(v2);
+  (void)adj.impl_addVertex(v3);
+  (void)adj.impl_addEdge(v1, v2);
+  (void)adj.impl_addEdge(v2, v3);
+
+  std::unordered_map<CinderVertex, std::vector<std::pair<CinderVertex, int>>,
+                     VertexHasher<CinderVertex>>
+      amap;
+  amap[v1] = {{v2, 0}};
+  amap[v2] = {{v3, 0}};
+  amap[v3] = {};
+
+  // populate hybrid from adjacency map
+  // (handled below via hybrid_ptr->populateFromAdjList)
+
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg_adj(
+      std::make_shared<PeakStore::HybridCSR_COO<CinderVertex, int>>(),
+      [&adj](const CinderVertex &v) { return adj.impl_hasVertex(v); },
+      [&adj](const CinderVertex &v) { return adj.impl_getNeighbors(v); });
+
+  auto hybrid_ptr =
+      std::make_shared<PeakStore::HybridCSR_COO<CinderVertex, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg_hyb(
+      hybrid_ptr,
+      [hyb = hybrid_ptr, &adj](const CinderVertex &v) {
+        if (hyb->impl_hasVertex(v))
+          return true;
+        return adj.impl_hasVertex(v);
+      },
+      [hyb = hybrid_ptr, &adj](const CinderVertex &v) {
+        auto res = hyb->impl_getNeighbors(v);
+        if (res.second.isOK())
+          return res;
+        return adj.impl_getNeighbors(v);
+      });
+
+  auto r1 = alg_adj.bfs(v1);
+  auto r2 = alg_hyb.bfs(v1);
+
+  EXPECT_TRUE(r1.isOK());
+  EXPECT_TRUE(r2.isOK());
+  EXPECT_EQ(r1.order_.size(), r2.order_.size());
+  // Compare __id_ to avoid relying on string names ordering
+  for (size_t i = 0; i < r1.order_.size(); ++i) {
+    EXPECT_EQ(r1.order_[i].__id_, r2.order_[i].__id_);
+  }
+}

--- a/tests/unit/Algorithms/traversal_snapshot_test.cpp
+++ b/tests/unit/Algorithms/traversal_snapshot_test.cpp
@@ -1,0 +1,186 @@
+#include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "Algorithms/TraversalSnapshot.hpp"
+#include "CinderGraph.hpp"
+#include "GraphRuntime.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/HybridCSR_COO.hpp"
+#include "gtest/gtest.h"
+
+using namespace CinderPeak;
+
+namespace {
+
+Algorithms::TraversalSnapshot<int, int>
+makeSnapshotFromAdjacency(PeakStore::AdjacencyList<int, int> &adj) {
+  return Algorithms::TraversalSnapshot<int, int>(
+      adj.impl_captureTraversalAdjacency());
+}
+
+} // namespace
+
+TEST(TraversalSnapshotTest, SnapshotBfsMatchesCallbackBfs) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+
+  auto snapshot = makeSnapshotFromAdjacency(adj);
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  auto callback_result = alg.bfs(1);
+  auto snapshot_result = alg.bfs(1, snapshot);
+
+  EXPECT_TRUE(callback_result.isOK());
+  EXPECT_TRUE(snapshot_result.isOK());
+  EXPECT_EQ(callback_result.order_, snapshot_result.order_);
+}
+
+TEST(TraversalSnapshotTest, SnapshotImmutabilityAfterMutation) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addEdge(1, 2);
+
+  auto snapshot = makeSnapshotFromAdjacency(adj);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(2, 3);
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  auto frozen = alg.bfs(1, snapshot);
+  auto live = alg.bfs(1);
+
+  EXPECT_EQ(frozen.order_, std::vector<int>({1, 2}));
+  EXPECT_EQ(live.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(TraversalSnapshotTest, AdjacencyVsHybridSnapshotParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(2, 3);
+
+  std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>>
+      amap = adj.impl_captureTraversalAdjacency();
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  auto adj_snapshot = Algorithms::TraversalSnapshot<int, int>(
+      adj.impl_captureTraversalAdjacency());
+  auto hybrid_snapshot = Algorithms::TraversalSnapshot<int, int>(
+      hybrid_ptr->impl_captureTraversalAdjacency());
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      hybrid_ptr, [](const int &) { return true; },
+      [](const int &) {
+        return std::pair<std::vector<std::pair<int, int>>, PeakStatus>{};
+      });
+
+  auto adj_bfs = alg.bfs(1, adj_snapshot);
+  auto hybrid_bfs = alg.bfs(1, hybrid_snapshot);
+
+  EXPECT_TRUE(adj_bfs.isOK());
+  EXPECT_TRUE(hybrid_bfs.isOK());
+  EXPECT_EQ(adj_bfs.order_, hybrid_bfs.order_);
+}
+
+TEST(TraversalSnapshotTest, DisconnectedGraphViaSnapshot) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  for (int v : {1, 2, 3, 4, 5}) {
+    (void)adj.impl_addVertex(v);
+  }
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(2, 3);
+
+  auto snapshot = makeSnapshotFromAdjacency(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  auto result = alg.bfs(1, snapshot);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(TraversalSnapshotTest, CustomVertexSnapshotTraversal) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<CinderVertex, int> adj(runtime);
+  CinderVertex v1("A"), v2("B"), v3("C");
+  (void)adj.impl_addVertex(v1);
+  (void)adj.impl_addVertex(v2);
+  (void)adj.impl_addVertex(v3);
+  (void)adj.impl_addEdge(v1, v2);
+  (void)adj.impl_addEdge(v2, v3);
+
+  Algorithms::TraversalSnapshot<CinderVertex, int> snapshot(
+      adj.impl_captureTraversalAdjacency());
+
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<CinderVertex, int>>(), nullptr,
+      nullptr);
+
+  auto result = alg.bfs(v1, snapshot);
+  EXPECT_TRUE(result.isOK());
+  ASSERT_EQ(result.order_.size(), 3u);
+  EXPECT_EQ(result.order_[0].__id_, v1.__id_);
+  EXPECT_EQ(result.order_[1].__id_, v2.__id_);
+  EXPECT_EQ(result.order_[2].__id_, v3.__id_);
+}
+
+TEST(TraversalSnapshotTest, PeakStoreSnapshotOrchestration) {
+  CinderGraph<int, int> graph;
+  (void)graph.addVertex(1);
+  (void)graph.addVertex(2);
+  (void)graph.addEdge(1, 2, 0);
+
+  auto snapshot = graph.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Adjacency);
+  ASSERT_NE(snapshot, nullptr);
+  EXPECT_EQ(snapshot->vertexCount(), 2u);
+
+  (void)graph.addVertex(3);
+  (void)graph.addEdge(2, 3, 0);
+
+  auto frozen = graph.bfs(1, snapshot);
+  auto live = graph.bfs(1);
+
+  EXPECT_EQ(frozen.order_, std::vector<int>({1, 2}));
+  EXPECT_EQ(live.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(TraversalSnapshotTest, EmptyHybridSnapshotFallsBackToAdjacency) {
+  PeakStore::GraphInternalMetadata metadata("test_graph", true, true, false,
+                                            true);
+  PeakStore::PeakStore<int, int> store(metadata);
+
+  (void)store.addVertex(10);
+  (void)store.addVertex(20);
+  (void)store.addEdge(10, 20);
+
+  auto snapshot = store.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Hybrid);
+  ASSERT_NE(snapshot, nullptr);
+  EXPECT_TRUE(snapshot->hasVertex(10));
+  EXPECT_TRUE(snapshot->hasVertex(20));
+
+  auto neighbors = snapshot->getNeighbors(10);
+  ASSERT_TRUE(neighbors.second.isOK());
+  ASSERT_EQ(neighbors.first.size(), 1u);
+  EXPECT_EQ(neighbors.first[0].first, 20);
+}


### PR DESCRIPTION
- Closes #270 
- Incremental PR for #273 

## Rationale for this change

The traversal layer was previously tightly coupled to live storage access and lacked an immutable traversal-oriented abstraction for backend-independent traversal workflows.

The earlier traversal improvements PR introduced:
- a real BFS implementation
- backend-independent traversal access
- traversal parity/regression coverage

This PR builds incrementally on top of that foundation by introducing a lightweight immutable traversal snapshot layer without attempting a broad storage-engine rewrite.

The goal of this PR is to:
- improve traversal decoupling
- introduce immutable traversal-oriented graph views
- centralize snapshot orchestration through `PeakStore`
- prepare the architecture for future DFS/topological traversal support
- keep the implementation maintainable and reviewable

The implementation intentionally avoids:
- async traversal execution
- storage synchronization redesigns
- heavy graph-view frameworks
- major `HybridCSR_COO` rewrites

to keep the scope incremental and architecture-aligned.

## What changes are included in this PR?

### Traversal snapshot foundation
- introduced `TraversalSnapshot`
- added immutable backend-independent adjacency traversal views
- added snapshot traversal APIs:
  - `hasVertex()`
  - `getNeighbors()`
  - `vertexCount()`

### Snapshot orchestration
- centralized snapshot creation through `PeakStore`
- added:
  - adjacency-backed snapshot generation
  - hybrid-backed snapshot generation
- preserved existing traversal APIs and backward compatibility

### Storage integration
Added incremental snapshot capture support for:
- `AdjacencyList`
- `HybridCSR_COO`

without redesigning existing storage synchronization behavior.

### BFS integration
- added optional snapshot-backed BFS traversal support
- introduced shared BFS traversal core to avoid duplicated traversal logic
- preserved existing `bfs(src)` behavior and APIs

### Traversal consistency improvements
- immutable snapshot traversal behavior
- backend parity fallback behavior
- snapshot traversal independence from live graph mutations

### Testing
Added traversal snapshot coverage for:
- snapshot/callback BFS parity
- snapshot immutability after mutation
- adjacency vs hybrid parity
- disconnected graph traversal
- custom vertex traversal
- empty hybrid fallback behavior
- `PeakStore` snapshot orchestration behavior

## Are these changes tested?

Yes.

Validation completed:
- traversal snapshot tests added
- BFS parity tests passing
- full test suite passing (`45/45`)
- clang-format validation passing

## Are there any user-facing changes?

Yes.
New optional traversal snapshot APIs are now available through:
- `PeakStore`
- `CinderGraph`

The existing traversal APIs remain backward compatible.
This PR intentionally keeps the implementation incremental and does not yet introduce:
- full traversal synchronization policies
- async traversal execution
- snapshot invalidation systems
- DFS/topological-sort implementations

These can be built incrementally on top of the snapshot foundation introduced here.