### PR TITLE
feat(algorithms): add DFS and topological traversal on snapshot architecture

### DIFF
--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -1,11 +1,11 @@
 #pragma once
+#include "../StorageEngine/Utils.hpp"
 #include "Result/bfs_result.hpp"
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <queue>
 #include <unordered_set>
-#include <functional>
-#include "../StorageEngine/Utils.hpp"
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
@@ -217,15 +217,17 @@ public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
       nullptr;
   std::function<bool(const VertexType &)> hasVertexFn;
-  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
-      const VertexType &)> getNeighborsFn;
+  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                          PeakStatus>(const VertexType &)>
+      getNeighborsFn;
 
   CinderPeakAlgorithms(
       const std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>>
           &hybridcsr,
       std::function<bool(const VertexType &)> hasVertex,
-      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
-          const VertexType &)> getNeighbors)
+      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                              PeakStatus>(const VertexType &)>
+          getNeighbors)
       : hcsr(hybridcsr), hasVertexFn(std::move(hasVertex)),
         getNeighborsFn(std::move(getNeighbors)) {}
 

--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -2,6 +2,10 @@
 #include "Result/bfs_result.hpp"
 #include <iostream>
 #include <memory>
+#include <queue>
+#include <unordered_set>
+#include <functional>
+#include "../StorageEngine/Utils.hpp"
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
@@ -212,18 +216,52 @@ template <typename VertexType, typename EdgeType> class CinderPeakAlgorithms {
 public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
       nullptr;
+  std::function<bool(const VertexType &)> hasVertexFn;
+  std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+      const VertexType &)> getNeighborsFn;
+
   CinderPeakAlgorithms(
       const std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>>
-          &hybridcsr)
-      : hcsr(hybridcsr) {}
-  BFSResult<VertexType> bfs([[maybe_unused]] const VertexType &src) {
-    std::cout << "Algorithms::bfs called\n";
+          &hybridcsr,
+      std::function<bool(const VertexType &)> hasVertex,
+      std::function<std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+          const VertexType &)> getNeighbors)
+      : hcsr(hybridcsr), hasVertexFn(std::move(hasVertex)),
+        getNeighborsFn(std::move(getNeighbors)) {}
 
+  BFSResult<VertexType> bfs(const VertexType &src) const {
     BFSResult<VertexType> result;
-    result.order_.push_back(1);
-    result.order_.push_back(2);
-    result.order_.push_back(3);
-    result.order_.push_back(4);
+    if (!hasVertexFn || !hasVertexFn(src)) {
+      result._status =
+          PeakStatus::VertexNotFound("Vertex Not Found During BFS");
+      return result;
+    }
+
+    std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
+    std::queue<VertexType> queue;
+
+    visited.insert(src);
+    queue.push(src);
+
+    while (!queue.empty()) {
+      VertexType current = queue.front();
+      queue.pop();
+      result.order_.push_back(current);
+
+      auto [neighbors, status] = getNeighborsFn(current);
+      if (!status.isOK()) {
+        continue;
+      }
+
+      for (const auto &neighbor_pair : neighbors) {
+        const VertexType &neighbor = neighbor_pair.first;
+        if (visited.find(neighbor) == visited.end()) {
+          visited.insert(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+
     return result;
   }
 };

--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -1,16 +1,17 @@
 #pragma once
 #include "../StorageEngine/Utils.hpp"
 #include "Result/bfs_result.hpp"
+#include "TraversalSnapshot.hpp"
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <queue>
 #include <unordered_set>
+
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
 
-}
+} // namespace PeakStore
 /*
 ================================================================================
                                 CINDERPEAK NOTE
@@ -131,6 +132,11 @@ template <typename VertexType, typename EdgeType> class HybridCSR_COO;
         - Synchronization overhead
         - Cache invalidation logic
 
+    TraversalSnapshot provides a lightweight immutable adjacency view for
+    algorithms that need point-in-time connectivity without exposing storage
+    internals. PeakStore owns snapshot creation; algorithms consume snapshots
+    through hasVertex/getNeighbors-style access only.
+
     ------------------------------------------------------------------------
     Current Development Priority
     ------------------------------------------------------------------------
@@ -212,6 +218,51 @@ template <typename VertexType, typename EdgeType> class HybridCSR_COO;
 ================================================================================
 */
 namespace Algorithms {
+namespace detail {
+
+template <typename VertexType, typename EdgeType>
+BFSResult<VertexType>
+runBfs(const std::function<bool(const VertexType &)> &hasVertex,
+       const std::function<
+           std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
+               const VertexType &)> &getNeighbors,
+       const VertexType &src) {
+  BFSResult<VertexType> result;
+  if (!hasVertex || !hasVertex(src)) {
+    result._status = PeakStatus::VertexNotFound("Vertex Not Found During BFS");
+    return result;
+  }
+
+  std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
+  std::queue<VertexType> queue;
+
+  visited.insert(src);
+  queue.push(src);
+
+  while (!queue.empty()) {
+    VertexType current = queue.front();
+    queue.pop();
+    result.order_.push_back(current);
+
+    auto [neighbors, status] = getNeighbors(current);
+    if (!status.isOK()) {
+      continue;
+    }
+
+    for (const auto &neighbor_pair : neighbors) {
+      const VertexType &neighbor = neighbor_pair.first;
+      if (visited.find(neighbor) == visited.end()) {
+        visited.insert(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return result;
+}
+
+} // namespace detail
+
 template <typename VertexType, typename EdgeType> class CinderPeakAlgorithms {
 public:
   std::shared_ptr<PeakStore::HybridCSR_COO<VertexType, EdgeType>> hcsr =
@@ -232,39 +283,17 @@ public:
         getNeighborsFn(std::move(getNeighbors)) {}
 
   BFSResult<VertexType> bfs(const VertexType &src) const {
-    BFSResult<VertexType> result;
-    if (!hasVertexFn || !hasVertexFn(src)) {
-      result._status =
-          PeakStatus::VertexNotFound("Vertex Not Found During BFS");
-      return result;
-    }
+    return detail::runBfs<VertexType, EdgeType>(hasVertexFn, getNeighborsFn,
+                                                src);
+  }
 
-    std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
-    std::queue<VertexType> queue;
-
-    visited.insert(src);
-    queue.push(src);
-
-    while (!queue.empty()) {
-      VertexType current = queue.front();
-      queue.pop();
-      result.order_.push_back(current);
-
-      auto [neighbors, status] = getNeighborsFn(current);
-      if (!status.isOK()) {
-        continue;
-      }
-
-      for (const auto &neighbor_pair : neighbors) {
-        const VertexType &neighbor = neighbor_pair.first;
-        if (visited.find(neighbor) == visited.end()) {
-          visited.insert(neighbor);
-          queue.push(neighbor);
-        }
-      }
-    }
-
-    return result;
+  BFSResult<VertexType>
+  bfs(const VertexType &src,
+      const TraversalSnapshot<VertexType, EdgeType> &snapshot) const {
+    return detail::runBfs<VertexType, EdgeType>(
+        [&snapshot](const VertexType &v) { return snapshot.hasVertex(v); },
+        [&snapshot](const VertexType &v) { return snapshot.getNeighbors(v); },
+        src);
   }
 };
 } // namespace Algorithms

--- a/src/Algorithms/CinderPeakAlgorithms.hpp
+++ b/src/Algorithms/CinderPeakAlgorithms.hpp
@@ -1,267 +1,23 @@
 #pragma once
 #include "../StorageEngine/Utils.hpp"
 #include "Result/bfs_result.hpp"
+#include "Result/dfs_result.hpp"
+#include "Result/topological_sort_result.hpp"
+#include "TraversalExecution.hpp"
+#include "TraversalSemantics.hpp"
 #include "TraversalSnapshot.hpp"
 #include <functional>
 #include <memory>
-#include <queue>
-#include <unordered_set>
 
 namespace CinderPeak {
 namespace PeakStore {
 template <typename VertexType, typename EdgeType> class HybridCSR_COO;
 
 } // namespace PeakStore
-/*
-================================================================================
-                                CINDERPEAK NOTE
-================================================================================
 
-    Algorithms Module Status:
-    ------------------------------------------------------------------------
+// Traversal architecture semantics: see TraversalSemantics.hpp.
 
-    The CinderPeak Algorithms Module is currently NOT implemented and is
-    intentionally kept as a stub.
-
-    This decision is deliberate and design-driven rather than a missing
-    feature or unfinished placeholder. The algorithms subsystem requires a
-    highly detailed architectural plan before implementation can begin.
-
-    ------------------------------------------------------------------------
-    Background
-    ------------------------------------------------------------------------
-
-    CinderPeak internally uses multiple graph storage representations:
-
-        1. Adjacency List Storage
-        2. Hybrid Storage (optimized traversal/storage structure)
-
-    The primary challenge is NOT implementing algorithms like:
-
-        - BFS
-        - DFS
-        - Dijkstra
-        - PageRank
-        - Connected Components
-        - Centrality Algorithms
-        - Traversal Utilities
-
-    The real challenge is designing a reliable synchronization and
-    coordination mechanism between the storage backends.
-
-    ------------------------------------------------------------------------
-    Source of Truth Problem
-    ------------------------------------------------------------------------
-
-    The adjacency list currently acts as the canonical source of truth.
-
-    All graph mutations are performed on the adjacency storage:
-
-        - Vertex insertions
-        - Edge insertions
-        - Vertex removals
-        - Edge removals
-        - Property updates
-
-    However, traversal-heavy algorithms are expected to operate on the
-    Hybrid Storage because it is designed for optimized access patterns.
-
-    This creates a major architectural question:
-
-        "When should the hybrid storage be rebuilt or synchronized?"
-
-    Example scenario:
-
-        1. User performs graph mutations.
-        2. Hybrid storage becomes outdated ("dirty").
-        3. User invokes BFS/DFS.
-        4. System must decide:
-
-            a) Rebuild hybrid storage before traversal
-            b) Use stale hybrid storage
-            c) Incrementally synchronize changes
-            d) Maintain continuous synchronization
-
-    Each approach has tradeoffs involving:
-
-        - Memory usage
-        - Rebuild cost
-        - Traversal performance
-        - Synchronization complexity
-        - Thread safety
-        - Lock contention
-
-    ------------------------------------------------------------------------
-    Concurrency & Locking Challenges
-    ------------------------------------------------------------------------
-
-    Another major blocker is concurrency management.
-
-    Consider the following scenario:
-
-        Thread A:
-            Running BFS traversal on Hybrid Storage
-
-        Thread B:
-            Performing edge insertions/removals simultaneously
-
-    Questions that still require architectural decisions:
-
-        - Should traversals acquire read locks?
-        - Should writes block traversals?
-        - Should mutations be buffered temporarily?
-        - Should traversals operate on immutable snapshots?
-        - Should dirty-region synchronization exist?
-        - Should lock-free mechanisms be introduced?
-        - How should consistency guarantees be maintained?
-
-    One proposed idea is:
-
-        - During traversal execution:
-              Incoming writes are redirected into a temporary buffer.
-
-        - After traversal completion:
-              Buffered operations are merged back into adjacency storage.
-
-    However, this introduces additional complexity:
-
-        - Merge ordering
-        - Conflict resolution
-        - Snapshot validity
-        - Buffer ownership
-        - Synchronization overhead
-        - Cache invalidation logic
-
-    TraversalSnapshot provides a lightweight immutable adjacency view for
-    algorithms that need point-in-time connectivity without exposing storage
-    internals. PeakStore owns snapshot creation; algorithms consume snapshots
-    through hasVertex/getNeighbors-style access only.
-
-    ------------------------------------------------------------------------
-    Current Development Priority
-    ------------------------------------------------------------------------
-
-    The immediate focus of the project is improving:
-
-        PeakStore.hpp
-
-    Specifically:
-
-        - Event-driven architecture redesign
-        - Constraint system redesign
-        - Reduction of orchestration complexity
-        - Removal of duplicated orchestration logic
-        - Cleaner storage abstraction boundaries
-        - Better lifecycle/event handling
-
-    Currently PeakStore is responsible for handling a large amount of
-    orchestration logic and some parts have become difficult to maintain.
-
-    Before algorithms can be implemented properly, PeakStore must evolve
-    into a cleaner orchestration layer capable of managing:
-
-        - Storage synchronization
-        - Traversal execution
-        - Event dispatching
-        - Constraint enforcement
-        - Algorithm lifecycle management
-        - Concurrency coordination
-
-    The long-term plan is for PeakStore to become the central controller
-    responsible for safely coordinating storages and algorithms.
-
-    ------------------------------------------------------------------------
-    Community Contribution Suggestion
-    ------------------------------------------------------------------------
-
-    Current graph implementation supports:
-
-        - Parallel edges
-
-    Planned change:
-
-        - Remove support for self-loops/self-edges entirely.
-
-    Contributors are encouraged to open issues or PRs that remove all traces
-    of self-edge logic from the codebase, including:
-
-        - Storage layer logic
-        - Validation logic
-        - Tests
-        - Examples
-        - Orchestrator logic
-        - Utility helpers
-        - Edge insertion checks
-
-    This cleanup would simplify future algorithmic assumptions and reduce
-    architectural complexity.
-
-    ------------------------------------------------------------------------
-    Final Note
-    ------------------------------------------------------------------------
-
-    The absence of the algorithms module is intentional.
-
-    The goal is NOT to implement algorithms quickly, but to design an
-    architecture that can support:
-
-        - High performance
-        - Safe concurrency
-        - Multi-storage synchronization
-        - Scalable traversal systems
-        - Future distributed execution capabilities
-        - Maintainable long-term design
-
-    Until the orchestration and synchronization architecture is finalized,
-    the algorithms module will remain a stub by design.
-
-================================================================================
-*/
 namespace Algorithms {
-namespace detail {
-
-template <typename VertexType, typename EdgeType>
-BFSResult<VertexType>
-runBfs(const std::function<bool(const VertexType &)> &hasVertex,
-       const std::function<
-           std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>(
-               const VertexType &)> &getNeighbors,
-       const VertexType &src) {
-  BFSResult<VertexType> result;
-  if (!hasVertex || !hasVertex(src)) {
-    result._status = PeakStatus::VertexNotFound("Vertex Not Found During BFS");
-    return result;
-  }
-
-  std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
-  std::queue<VertexType> queue;
-
-  visited.insert(src);
-  queue.push(src);
-
-  while (!queue.empty()) {
-    VertexType current = queue.front();
-    queue.pop();
-    result.order_.push_back(current);
-
-    auto [neighbors, status] = getNeighbors(current);
-    if (!status.isOK()) {
-      continue;
-    }
-
-    for (const auto &neighbor_pair : neighbors) {
-      const VertexType &neighbor = neighbor_pair.first;
-      if (visited.find(neighbor) == visited.end()) {
-        visited.insert(neighbor);
-        queue.push(neighbor);
-      }
-    }
-  }
-
-  return result;
-}
-
-} // namespace detail
 
 template <typename VertexType, typename EdgeType> class CinderPeakAlgorithms {
 public:
@@ -283,18 +39,38 @@ public:
         getNeighborsFn(std::move(getNeighbors)) {}
 
   BFSResult<VertexType> bfs(const VertexType &src) const {
-    return detail::runBfs<VertexType, EdgeType>(hasVertexFn, getNeighborsFn,
-                                                src);
+    return runBfs(TraversalAdjacencyAccess<VertexType, EdgeType>::fromCallbacks(
+                      hasVertexFn, getNeighborsFn),
+                  src, TraversalNeighborOrder::PreserveBackendOrder);
   }
 
   BFSResult<VertexType>
   bfs(const VertexType &src,
       const TraversalSnapshot<VertexType, EdgeType> &snapshot) const {
-    return detail::runBfs<VertexType, EdgeType>(
-        [&snapshot](const VertexType &v) { return snapshot.hasVertex(v); },
-        [&snapshot](const VertexType &v) { return snapshot.getNeighbors(v); },
-        src);
+    return runBfs(
+        TraversalAdjacencyAccess<VertexType, EdgeType>::fromSnapshot(snapshot),
+        src, TraversalNeighborOrder::DeterministicByVertex);
+  }
+
+  DFSResult<VertexType> dfs(const VertexType &src) const {
+    return runDfs(TraversalAdjacencyAccess<VertexType, EdgeType>::fromCallbacks(
+                      hasVertexFn, getNeighborsFn),
+                  src, TraversalNeighborOrder::PreserveBackendOrder);
+  }
+
+  DFSResult<VertexType>
+  dfs(const VertexType &src,
+      const TraversalSnapshot<VertexType, EdgeType> &snapshot) const {
+    return runDfs(
+        TraversalAdjacencyAccess<VertexType, EdgeType>::fromSnapshot(snapshot),
+        src, TraversalNeighborOrder::DeterministicByVertex);
+  }
+
+  TopologicalSortResult<VertexType> topologicalSort(
+      const TraversalSnapshot<VertexType, EdgeType> &snapshot) const {
+    return runTopologicalSort(snapshot);
   }
 };
+
 } // namespace Algorithms
 } // namespace CinderPeak

--- a/src/Algorithms/Result/dfs_result.hpp
+++ b/src/Algorithms/Result/dfs_result.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "StorageEngine/ErrorCodes.hpp"
+#include <vector>
+
+namespace CinderPeak {
+namespace Algorithms {
+
+template <typename VertexType> class DFSResult {
+public:
+  explicit DFSResult(PeakStatus status = PeakStatus::OK())
+      : _status(std::move(status)) {}
+
+  bool isOK() { return _status.isOK(); }
+  std::vector<VertexType> order_;
+  PeakStatus _status;
+};
+
+} // namespace Algorithms
+} // namespace CinderPeak

--- a/src/Algorithms/Result/topological_sort_result.hpp
+++ b/src/Algorithms/Result/topological_sort_result.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "StorageEngine/ErrorCodes.hpp"
+#include <vector>
+
+namespace CinderPeak {
+namespace Algorithms {
+
+template <typename VertexType> class TopologicalSortResult {
+public:
+  explicit TopologicalSortResult(PeakStatus status = PeakStatus::OK())
+      : _status(std::move(status)) {}
+
+  bool isOK() { return _status.isOK(); }
+  std::vector<VertexType> order_;
+  PeakStatus _status;
+};
+
+} // namespace Algorithms
+} // namespace CinderPeak

--- a/src/Algorithms/TraversalExecution.hpp
+++ b/src/Algorithms/TraversalExecution.hpp
@@ -1,0 +1,233 @@
+#pragma once
+
+#include "Result/bfs_result.hpp"
+#include "Result/dfs_result.hpp"
+#include "Result/topological_sort_result.hpp"
+#include "TraversalOrdering.hpp"
+#include "TraversalSemantics.hpp"
+#include "TraversalSnapshot.hpp"
+#include <functional>
+#include <queue>
+#include <stack>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace CinderPeak {
+namespace Algorithms {
+
+/// Lightweight adjacency accessor shared by BFS and future DFS / topo sort.
+template <typename VertexType, typename EdgeType>
+struct TraversalAdjacencyAccess {
+  using NeighborList = std::vector<std::pair<VertexType, EdgeType>>;
+  using NeighborResult = std::pair<NeighborList, PeakStatus>;
+
+  std::function<bool(const VertexType &)> hasVertex;
+  std::function<NeighborResult(const VertexType &)> getNeighbors;
+
+  [[nodiscard]] static TraversalAdjacencyAccess fromCallbacks(
+      std::function<bool(const VertexType &)> has_vertex,
+      std::function<NeighborResult(const VertexType &)> get_neighbors) {
+    return {std::move(has_vertex), std::move(get_neighbors)};
+  }
+
+  [[nodiscard]] static TraversalAdjacencyAccess
+  fromSnapshot(const TraversalSnapshot<VertexType, EdgeType> &snapshot) {
+    return {
+        [&snapshot](const VertexType &v) { return snapshot.hasVertex(v); },
+        [&snapshot](const VertexType &v) { return snapshot.getNeighbors(v); }};
+  }
+};
+
+namespace detail {
+
+template <typename VertexType, typename EdgeType>
+typename TraversalAdjacencyAccess<VertexType, EdgeType>::NeighborResult
+fetchNeighbors(const TraversalAdjacencyAccess<VertexType, EdgeType> &access,
+               const VertexType &vertex, TraversalNeighborOrder order) {
+  using NeighborResult =
+      typename TraversalAdjacencyAccess<VertexType, EdgeType>::NeighborResult;
+  if (!access.getNeighbors) {
+    return {typename NeighborResult::first_type{},
+            PeakStatus::VertexNotFound()};
+  }
+  auto result = access.getNeighbors(vertex);
+  if (order == TraversalNeighborOrder::DeterministicByVertex &&
+      result.second.isOK()) {
+    stabilizeNeighborList<VertexType, EdgeType>(result.first);
+  }
+  return result;
+}
+
+template <typename VertexType, typename EdgeType>
+BFSResult<VertexType>
+runBfs(const TraversalAdjacencyAccess<VertexType, EdgeType> &access,
+       const VertexType &src, TraversalNeighborOrder neighbor_order) {
+  BFSResult<VertexType> result;
+  if (!access.hasVertex || !access.hasVertex(src)) {
+    result._status = PeakStatus::VertexNotFound("Vertex Not Found During BFS");
+    return result;
+  }
+
+  std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
+  std::queue<VertexType> queue;
+
+  visited.insert(src);
+  queue.push(src);
+
+  while (!queue.empty()) {
+    VertexType current = queue.front();
+    queue.pop();
+    result.order_.push_back(current);
+
+    auto [neighbors, status] =
+        fetchNeighbors<VertexType, EdgeType>(access, current, neighbor_order);
+    if (!status.isOK()) {
+      continue;
+    }
+
+    for (const auto &neighbor_pair : neighbors) {
+      const VertexType &neighbor = neighbor_pair.first;
+      if (visited.find(neighbor) == visited.end()) {
+        visited.insert(neighbor);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return result;
+}
+
+template <typename VertexType, typename EdgeType>
+DFSResult<VertexType>
+runDfs(const TraversalAdjacencyAccess<VertexType, EdgeType> &access,
+       const VertexType &src, TraversalNeighborOrder neighbor_order) {
+  DFSResult<VertexType> result;
+  if (!access.hasVertex || !access.hasVertex(src)) {
+    result._status = PeakStatus::VertexNotFound("Vertex Not Found During DFS");
+    return result;
+  }
+
+  std::unordered_set<VertexType, VertexHasher<VertexType>> visited;
+  std::stack<VertexType> stack;
+  stack.push(src);
+
+  while (!stack.empty()) {
+    VertexType current = stack.top();
+    stack.pop();
+
+    if (visited.find(current) != visited.end()) {
+      continue;
+    }
+    visited.insert(current);
+    result.order_.push_back(current);
+
+    auto [neighbors, status] =
+        fetchNeighbors<VertexType, EdgeType>(access, current, neighbor_order);
+    if (!status.isOK()) {
+      continue;
+    }
+
+    for (auto it = neighbors.rbegin(); it != neighbors.rend(); ++it) {
+      const VertexType &neighbor = it->first;
+      if (visited.find(neighbor) == visited.end()) {
+        stack.push(neighbor);
+      }
+    }
+  }
+
+  return result;
+}
+
+template <typename VertexType, typename EdgeType>
+TopologicalSortResult<VertexType>
+runTopologicalSort(const TraversalSnapshot<VertexType, EdgeType> &snapshot) {
+  TopologicalSortResult<VertexType> result;
+  const auto &adjacency = snapshot.adjacency();
+
+  if (adjacency.empty()) {
+    return result;
+  }
+
+  std::unordered_map<VertexType, std::size_t, VertexHasher<VertexType>>
+      indegree;
+  for (const auto &entry : adjacency) {
+    indegree.emplace(entry.first, 0);
+  }
+  for (const auto &entry : adjacency) {
+    for (const auto &edge : entry.second) {
+      ++indegree[edge.first];
+    }
+  }
+
+  detail::TraversalVertexLess<VertexType> less;
+  std::vector<VertexType> ready;
+  ready.reserve(indegree.size());
+  for (const auto &entry : indegree) {
+    if (entry.second == 0) {
+      ready.push_back(entry.first);
+    }
+  }
+
+  while (!ready.empty()) {
+    std::sort(ready.begin(), ready.end(),
+              [&less](const VertexType &a, const VertexType &b) {
+                return less(a, b);
+              });
+    const VertexType current = ready.front();
+    ready.erase(ready.begin());
+    result.order_.push_back(current);
+
+    auto adj_it = adjacency.find(current);
+    if (adj_it == adjacency.end()) {
+      continue;
+    }
+    for (const auto &edge : adj_it->second) {
+      auto indegree_it = indegree.find(edge.first);
+      if (indegree_it == indegree.end()) {
+        continue;
+      }
+      if (indegree_it->second > 0 && --indegree_it->second == 0) {
+        ready.push_back(edge.first);
+      }
+    }
+  }
+
+  if (result.order_.size() != adjacency.size()) {
+    result.order_.clear();
+    result._status = PeakStatus::GraphCycleDetected(
+        "Cycle detected during topological sort");
+  }
+
+  return result;
+}
+
+} // namespace detail
+
+template <typename VertexType, typename EdgeType>
+BFSResult<VertexType>
+runBfs(const TraversalAdjacencyAccess<VertexType, EdgeType> &access,
+       const VertexType &src,
+       TraversalNeighborOrder neighbor_order =
+           TraversalNeighborOrder::PreserveBackendOrder) {
+  return detail::runBfs<VertexType, EdgeType>(access, src, neighbor_order);
+}
+
+template <typename VertexType, typename EdgeType>
+DFSResult<VertexType>
+runDfs(const TraversalAdjacencyAccess<VertexType, EdgeType> &access,
+       const VertexType &src,
+       TraversalNeighborOrder neighbor_order =
+           TraversalNeighborOrder::PreserveBackendOrder) {
+  return detail::runDfs<VertexType, EdgeType>(access, src, neighbor_order);
+}
+
+template <typename VertexType, typename EdgeType>
+TopologicalSortResult<VertexType>
+runTopologicalSort(const TraversalSnapshot<VertexType, EdgeType> &snapshot) {
+  return detail::runTopologicalSort<VertexType, EdgeType>(snapshot);
+}
+
+} // namespace Algorithms
+} // namespace CinderPeak

--- a/src/Algorithms/TraversalOrdering.hpp
+++ b/src/Algorithms/TraversalOrdering.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "../StorageEngine/Utils.hpp"
+#include <algorithm>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace CinderPeak {
+namespace Algorithms {
+
+template <typename VertexType, typename EdgeType>
+using TraversalAdjacencyMap =
+    std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                       VertexHasher<VertexType>>;
+
+namespace detail {
+
+template <typename VertexType> struct TraversalVertexLess {
+  bool operator()(const VertexType &a, const VertexType &b) const {
+    if constexpr (has___id<VertexType>::value && std::is_class_v<VertexType> &&
+                  !std::is_same_v<VertexType, std::string>) {
+      return a.__id_ < b.__id_;
+    } else {
+      return a < b;
+    }
+  }
+};
+
+template <typename VertexType, typename EdgeType>
+void stabilizeNeighborList(
+    std::vector<std::pair<VertexType, EdgeType>> &neighbors) {
+  TraversalVertexLess<VertexType> less;
+  std::sort(neighbors.begin(), neighbors.end(),
+            [&less](const auto &lhs, const auto &rhs) {
+              return less(lhs.first, rhs.first);
+            });
+}
+
+template <typename VertexType, typename EdgeType>
+void finalizeSnapshotAdjacency(
+    TraversalAdjacencyMap<VertexType, EdgeType> &adjacency) {
+  for (auto &entry : adjacency) {
+    stabilizeNeighborList<VertexType, EdgeType>(entry.second);
+  }
+}
+
+} // namespace detail
+} // namespace Algorithms
+} // namespace CinderPeak

--- a/src/Algorithms/TraversalSemantics.hpp
+++ b/src/Algorithms/TraversalSemantics.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+/*
+ * CinderPeak Traversal Architecture — Semantics (issue completion)
+ *
+ * Snapshot immutability
+ *   TraversalSnapshot captures vertex-keyed adjacency at creation time.
+ *   After construction, neighbor lists and membership are fixed. Live graph
+ *   mutations (add/remove vertex/edge) never retroactively change a snapshot.
+ *
+ * Snapshot ownership
+ *   PeakStore::createTraversalSnapshot() returns shared_ptr<const Snapshot>.
+ *   Callers may retain snapshots independently of PeakStore. No invalidation
+ *   or versioning is performed; snapshots are lightweight value-like views.
+ *
+ * Traversal consistency (live / callback path)
+ *   bfs(src) reads the active storage through PeakStore-injected callbacks.
+ *   Order follows backend neighbor ordering at query time. AdjacencyList
+ *   preserves insertion order; HybridCSR_COO sorts neighbors by internal index
+ *   in impl_getNeighbors. Repeated runs on an unchanged graph are stable.
+ *
+ * Traversal consistency (snapshot path)
+ *   bfs(src, snapshot) reads only the frozen snapshot. Neighbor lists are
+ *   stabilized at snapshot construction (deterministic per-vertex order by
+ *   vertex identity). Repeated runs on the same snapshot yield identical order.
+ *
+ * Backend parity (snapshot capture)
+ *   Adjacency and Hybrid captures represent the same logical graph when hybrid
+ *   is populated from equivalent connectivity. Both paths materialize through
+ *   TraversalSnapshot, which applies the same neighbor-order normalization.
+ *   Hybrid TraversalSnapshotBackend falls back to adjacency when hybrid is
+ *   empty (no automatic rebuild/sync).
+ *
+ * Fallback semantics
+ *   Live traversal: hybrid-first getNeighbors/hasVertex, adjacency fallback.
+ *   Snapshot traversal: hybrid capture with adjacency fallback if empty.
+ *
+ * Determinism limits
+ *   Snapshot traversals are deterministic for a given snapshot instance.
+ *   Live traversals may change order after mutations that reorder adjacency
+ *   lists. No global vertex sorting is applied during traversal (only local
+ *   per-vertex neighbor stabilization in snapshots).
+ *
+ * DFS / topological sort
+ *   Use TraversalAdjacencyAccess + TraversalExecution (runDfs,
+ * runTopologicalSort). Topological sort requires a TraversalSnapshot and
+ * reports GRAPH_CYCLE_DETECTED when the graph is not a DAG.
+ */
+
+namespace CinderPeak {
+namespace Algorithms {
+
+/// How neighbor lists are ordered before / during traversal execution.
+enum class TraversalNeighborOrder {
+  /// Use neighbor order supplied by the backend or snapshot as-is.
+  PreserveBackendOrder,
+  /// Sort neighbors by stable vertex identity (see TraversalExecution.hpp).
+  DeterministicByVertex
+};
+
+/// Whether traversal reads live storage callbacks or a frozen snapshot.
+enum class TraversalExecutionMode { LiveCallbacks, ImmutableSnapshot };
+
+} // namespace Algorithms
+} // namespace CinderPeak

--- a/src/Algorithms/TraversalSnapshot.hpp
+++ b/src/Algorithms/TraversalSnapshot.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../StorageEngine/Utils.hpp"
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace CinderPeak {
+namespace Algorithms {
+
+/// Selects which storage backend PeakStore uses when materializing a snapshot.
+enum class TraversalSnapshotBackend { Adjacency, Hybrid };
+
+/// Immutable, backend-independent adjacency view for traversal algorithms.
+///
+/// Snapshots are owned by the caller (typically via shared_ptr from PeakStore)
+/// and capture graph connectivity at creation time. Live storage mutations do
+/// not affect an existing snapshot.
+///
+/// Future algorithms (DFS, topological sort, concurrent policies) should prefer
+/// this view over direct storage access.
+template <typename VertexType, typename EdgeType> class TraversalSnapshot {
+public:
+  using AdjacencyMap =
+      std::unordered_map<VertexType,
+                         std::vector<std::pair<VertexType, EdgeType>>,
+                         VertexHasher<VertexType>>;
+
+  TraversalSnapshot() = default;
+
+  explicit TraversalSnapshot(AdjacencyMap adjacency)
+      : adjacency_(std::move(adjacency)) {}
+
+  [[nodiscard]] bool hasVertex(const VertexType &vertex) const {
+    return adjacency_.find(vertex) != adjacency_.end();
+  }
+
+  [[nodiscard]] std::pair<std::vector<std::pair<VertexType, EdgeType>>,
+                          PeakStatus>
+  getNeighbors(const VertexType &vertex) const {
+    auto it = adjacency_.find(vertex);
+    if (it == adjacency_.end()) {
+      return {std::vector<std::pair<VertexType, EdgeType>>{},
+              PeakStatus::VertexNotFound()};
+    }
+    return {it->second, PeakStatus::OK()};
+  }
+
+  [[nodiscard]] std::size_t vertexCount() const { return adjacency_.size(); }
+
+  [[nodiscard]] const AdjacencyMap &adjacency() const { return adjacency_; }
+
+private:
+  AdjacencyMap adjacency_;
+};
+
+} // namespace Algorithms
+} // namespace CinderPeak

--- a/src/Algorithms/TraversalSnapshot.hpp
+++ b/src/Algorithms/TraversalSnapshot.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../StorageEngine/Utils.hpp"
-#include <unordered_map>
+#include "TraversalOrdering.hpp"
 #include <utility>
 #include <vector>
 
@@ -13,23 +13,24 @@ enum class TraversalSnapshotBackend { Adjacency, Hybrid };
 
 /// Immutable, backend-independent adjacency view for traversal algorithms.
 ///
-/// Snapshots are owned by the caller (typically via shared_ptr from PeakStore)
-/// and capture graph connectivity at creation time. Live storage mutations do
-/// not affect an existing snapshot.
+/// Ownership: returned as shared_ptr<const> from PeakStore; callers may retain
+/// snapshots independently. No invalidation is performed after creation.
 ///
-/// Future algorithms (DFS, topological sort, concurrent policies) should prefer
-/// this view over direct storage access.
+/// Immutability: adjacency is fixed at construction; neighbor lists are
+/// normalized for deterministic traversal (see TraversalSemantics.hpp).
+///
+/// Future DFS / topological sort should consume snapshots via
+/// TraversalAdjacencyAccess::fromSnapshot().
 template <typename VertexType, typename EdgeType> class TraversalSnapshot {
 public:
-  using AdjacencyMap =
-      std::unordered_map<VertexType,
-                         std::vector<std::pair<VertexType, EdgeType>>,
-                         VertexHasher<VertexType>>;
+  using AdjacencyMap = TraversalAdjacencyMap<VertexType, EdgeType>;
 
   TraversalSnapshot() = default;
 
   explicit TraversalSnapshot(AdjacencyMap adjacency)
-      : adjacency_(std::move(adjacency)) {}
+      : adjacency_(std::move(adjacency)) {
+    detail::finalizeSnapshotAdjacency<VertexType, EdgeType>(adjacency_);
+  }
 
   [[nodiscard]] bool hasVertex(const VertexType &vertex) const {
     return adjacency_.find(vertex) != adjacency_.end();

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -441,6 +441,21 @@ public:
     return peak_store->bfs(src);
   }
 
+  Algorithms::BFSResult<VertexType>
+  bfs(const VertexType &src,
+      const std::shared_ptr<
+          const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+          &snapshot) {
+    return peak_store->bfs(src, snapshot);
+  }
+
+  std::shared_ptr<const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+  createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend backend =
+          Algorithms::TraversalSnapshotBackend::Adjacency) const {
+    return peak_store->createTraversalSnapshot(backend);
+  }
+
   template <typename V = VertexType, typename E = EdgeType>
 
   /**

--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -456,6 +456,24 @@ public:
     return peak_store->createTraversalSnapshot(backend);
   }
 
+  Algorithms::DFSResult<VertexType> dfs(const VertexType &src) {
+    return peak_store->dfs(src);
+  }
+
+  Algorithms::DFSResult<VertexType>
+  dfs(const VertexType &src,
+      const std::shared_ptr<
+          const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+          &snapshot) {
+    return peak_store->dfs(src, snapshot);
+  }
+
+  Algorithms::TopologicalSortResult<VertexType>
+  topologicalSort(const std::shared_ptr<const Algorithms::TraversalSnapshot<
+                      VertexType, EdgeType>> &snapshot) const {
+    return peak_store->topologicalSort(snapshot);
+  }
+
   template <typename V = VertexType, typename E = EdgeType>
 
   /**

--- a/src/Events/GraphEvents.hpp
+++ b/src/Events/GraphEvents.hpp
@@ -15,14 +15,8 @@ template <typename V, typename E> struct EdgeRemovedEvent {
   const V &dest;
 };
 
-template <typename V> struct VertexAddedEvent {
+template <typename V> struct VertexAddedEvent { const V &vertex; };
 
-  const V &vertex;
-};
-
-template <typename V> struct VertexRemovedEvent {
-
-  const V &vertex;
-};
+template <typename V> struct VertexRemovedEvent { const V &vertex; };
 
 } // namespace CinderPeak

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -40,10 +40,22 @@ private:
     ctx->algorithms = std::make_shared<
         Algorithms::CinderPeakAlgorithms<VertexType, EdgeType>>(
         ctx->hybrid_storage,
-        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+        // hasVertex: prefer hybrid index but fall back to adjacency
+        [hyb = ctx->hybrid_storage,
+         adj = ctx->adjacency_storage](const VertexType &vertex) {
+          if (hyb && hyb->impl_hasVertex(vertex))
+            return true;
           return adj->impl_hasVertex(vertex);
         },
-        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+        // getNeighbors: try hybrid first (including buffered COO), then
+        // fallback to adjacency storage to preserve source-of-truth semantics.
+        [hyb = ctx->hybrid_storage,
+         adj = ctx->adjacency_storage](const VertexType &vertex) {
+          if (hyb) {
+            auto res = hyb->impl_getNeighbors(vertex);
+            if (res.second.isOK())
+              return res;
+          }
           return adj->impl_getNeighbors(vertex);
         });
 

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -39,7 +39,13 @@ private:
     ctx->active_storage = ctx->adjacency_storage;
     ctx->algorithms = std::make_shared<
         Algorithms::CinderPeakAlgorithms<VertexType, EdgeType>>(
-        ctx->hybrid_storage);
+        ctx->hybrid_storage,
+        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+          return adj->impl_hasVertex(vertex);
+        },
+        [adj = ctx->adjacency_storage](const VertexType &vertex) {
+          return adj->impl_getNeighbors(vertex);
+        });
 
     ctx->runtime->log(LogLevel::CRITICAL, "Log from ctx\n");
     registerMetadataListeners(*ctx);

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "Algorithms/TraversalSnapshot.hpp"
 #include "CinderPeak.hpp"
 #include "Constraints/Constraints.hpp"
 #include "Events/DefaultListeners.hpp"
@@ -82,6 +83,28 @@ public:
   // Get graph name
   std::string getGraphName() { return ctx->metadata->getGraphName(); }
 
+  /// Captures an immutable adjacency snapshot for traversal algorithms.
+  /// Hybrid snapshots fall back to adjacency when the hybrid index is empty.
+  std::shared_ptr<const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+  createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend backend =
+          Algorithms::TraversalSnapshotBackend::Adjacency) const {
+    typename Algorithms::TraversalSnapshot<VertexType, EdgeType>::AdjacencyMap
+        adjacency;
+    if (backend == Algorithms::TraversalSnapshotBackend::Hybrid &&
+        ctx->hybrid_storage) {
+      adjacency = ctx->hybrid_storage->impl_captureTraversalAdjacency();
+      if (adjacency.empty() && ctx->adjacency_storage) {
+        adjacency = ctx->adjacency_storage->impl_captureTraversalAdjacency();
+      }
+    } else if (ctx->adjacency_storage) {
+      adjacency = ctx->adjacency_storage->impl_captureTraversalAdjacency();
+    }
+    return std::make_shared<
+        const Algorithms::TraversalSnapshot<VertexType, EdgeType>>(
+        std::move(adjacency));
+  }
+
   Algorithms::BFSResult<VertexType> bfs(const VertexType &src) {
     Algorithms::BFSResult<VertexType> result;
     if (!hasVertex(src)) {
@@ -91,6 +114,25 @@ public:
     }
     result = std::move(ctx->algorithms->bfs(src));
     return result;
+  }
+
+  /// BFS over an immutable snapshot; ignores live storage mutations during
+  /// traversal. When snapshot is null, delegates to callback-based bfs().
+  Algorithms::BFSResult<VertexType>
+  bfs(const VertexType &src,
+      const std::shared_ptr<
+          const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+          &snapshot) {
+    if (!snapshot) {
+      return bfs(src);
+    }
+    Algorithms::BFSResult<VertexType> result;
+    if (!snapshot->hasVertex(src)) {
+      result._status =
+          PeakStatus::VertexNotFound("Vertex Not Found During the BFS");
+      return result;
+    }
+    return ctx->algorithms->bfs(src, *snapshot);
   }
 
   PeakStatus addEdge(const VertexType &src, const VertexType &dest,

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -83,8 +83,11 @@ public:
   // Get graph name
   std::string getGraphName() { return ctx->metadata->getGraphName(); }
 
-  /// Captures an immutable adjacency snapshot for traversal algorithms.
-  /// Hybrid snapshots fall back to adjacency when the hybrid index is empty.
+  // Traversal semantics: Algorithms/TraversalSemantics.hpp
+  //
+  // Captures an immutable adjacency snapshot. Ownership is shared via
+  // shared_ptr<const>; snapshots are never invalidated by later mutations.
+  // Hybrid snapshots fall back to adjacency when the hybrid index is empty.
   std::shared_ptr<const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
   createTraversalSnapshot(
       Algorithms::TraversalSnapshotBackend backend =
@@ -116,8 +119,9 @@ public:
     return result;
   }
 
-  /// BFS over an immutable snapshot; ignores live storage mutations during
-  /// traversal. When snapshot is null, delegates to callback-based bfs().
+  // BFS over a frozen snapshot (deterministic neighbor order). Live mutations
+  // do not affect the snapshot. Null snapshot delegates to callback-based
+  // bfs().
   Algorithms::BFSResult<VertexType>
   bfs(const VertexType &src,
       const std::shared_ptr<
@@ -133,6 +137,45 @@ public:
       return result;
     }
     return ctx->algorithms->bfs(src, *snapshot);
+  }
+
+  Algorithms::DFSResult<VertexType> dfs(const VertexType &src) {
+    Algorithms::DFSResult<VertexType> result;
+    if (!hasVertex(src)) {
+      result._status =
+          PeakStatus::VertexNotFound("Vertex Not Found During the DFS");
+      return result;
+    }
+    return ctx->algorithms->dfs(src);
+  }
+
+  Algorithms::DFSResult<VertexType>
+  dfs(const VertexType &src,
+      const std::shared_ptr<
+          const Algorithms::TraversalSnapshot<VertexType, EdgeType>>
+          &snapshot) {
+    if (!snapshot) {
+      return dfs(src);
+    }
+    Algorithms::DFSResult<VertexType> result;
+    if (!snapshot->hasVertex(src)) {
+      result._status =
+          PeakStatus::VertexNotFound("Vertex Not Found During the DFS");
+      return result;
+    }
+    return ctx->algorithms->dfs(src, *snapshot);
+  }
+
+  Algorithms::TopologicalSortResult<VertexType>
+  topologicalSort(const std::shared_ptr<const Algorithms::TraversalSnapshot<
+                      VertexType, EdgeType>> &snapshot) const {
+    Algorithms::TopologicalSortResult<VertexType> result;
+    if (!snapshot) {
+      result._status = PeakStatus::InvalidArgument(
+          "Traversal snapshot required for topological sort");
+      return result;
+    }
+    return ctx->algorithms->topologicalSort(*snapshot);
   }
 
   PeakStatus addEdge(const VertexType &src, const VertexType &dest,

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -461,16 +461,14 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing getInternalAdjacency");
     return _adj;
   }
-struct DotConfig {
-  std::string graphName = "G";
-  std::string nodeColor = "#E3F2FD";
-  std::string nodeShape = "circle";
-  std::string fontName = "Arial";
-};
-std::string impl_toDot(
-    bool isDirected,
-    bool allowParallel = false,
-    const DotConfig &config = DotConfig()) const {
+  struct DotConfig {
+    std::string graphName = "G";
+    std::string nodeColor = "#E3F2FD";
+    std::string nodeShape = "circle";
+    std::string fontName = "Arial";
+  };
+  std::string impl_toDot(bool isDirected, bool allowParallel = false,
+                         const DotConfig &config = DotConfig()) const {
     runtime.log(LogLevel::DEBUG, "Executing impl_toDot");
     std::shared_lock<std::shared_mutex> lock(_mtx);
     std::stringstream ss;
@@ -478,17 +476,15 @@ std::string impl_toDot(
     if (!allowParallel) {
       ss << "strict ";
     }
-    ss << (isDirected ? "digraph" : "graph")
-       << " " << config.graphName << " {\n";
+    ss << (isDirected ? "digraph" : "graph") << " " << config.graphName
+       << " {\n";
 
     ss << "  rankdir=LR;\n";
 
-    ss << "  node[shape=" << config.nodeShape
-       << " style=filled fillcolor=\"" << config.nodeColor
-       << "\" fontname=\"" << config.fontName << "\"];\n";
+    ss << "  node[shape=" << config.nodeShape << " style=filled fillcolor=\""
+       << config.nodeColor << "\" fontname=\"" << config.fontName << "\"];\n";
 
-    ss << "  edge[fontname=\"" << config.fontName
-       << "\" fontsize=10];\n\n";
+    ss << "  edge[fontname=\"" << config.fontName << "\" fontsize=10];\n\n";
     // declare all nodes first (ensures isolated nodes appear)
     for (const auto &kv : _vertex_data) {
       VertexId id = kv.first;

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -522,6 +522,35 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing getVertexDataMap");
     return _vertex_data;
   }
+
+  /// Copies vertex-keyed adjacency for immutable traversal snapshots.
+  std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                     VertexHasher<VertexType>>
+  impl_captureTraversalAdjacency() const {
+    std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                       VertexHasher<VertexType>>
+        snapshot;
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    snapshot.reserve(_vertex_data.size());
+    for (const auto &[id, vertex] : _vertex_data) {
+      const auto adj_it = _adj.find(id);
+      if (adj_it == _adj.end()) {
+        snapshot.emplace(vertex,
+                         std::vector<std::pair<VertexType, EdgeType>>{});
+        continue;
+      }
+      std::vector<std::pair<VertexType, EdgeType>> neighbors;
+      neighbors.reserve(adj_it->second.size());
+      for (const auto &edge : adj_it->second) {
+        auto dest_it = _vertex_data.find(edge.first);
+        if (dest_it != _vertex_data.end()) {
+          neighbors.emplace_back(dest_it->second, edge.second);
+        }
+      }
+      snapshot.emplace(vertex, std::move(neighbors));
+    }
+    return snapshot;
+  }
 };
 
 } // namespace PeakStore

--- a/src/StorageEngine/ErrorCodes.hpp
+++ b/src/StorageEngine/ErrorCodes.hpp
@@ -14,6 +14,7 @@ enum class StatusCode {
   UNIMPLEMENTED,
   ALREADY_EXISTS,
   EDGE_ALREADY_EXISTS,
+  GRAPH_CYCLE_DETECTED,
 };
 
 class PeakStatus {
@@ -58,6 +59,10 @@ public:
   inline static PeakStatus
   EdgeAlreadyExists(std::string msg = "Edge Already Exists") {
     return PeakStatus(StatusCode::EDGE_ALREADY_EXISTS, std::move(msg));
+  }
+  inline static PeakStatus
+  GraphCycleDetected(std::string msg = "Graph cycle detected") {
+    return PeakStatus(StatusCode::GRAPH_CYCLE_DETECTED, std::move(msg));
   }
   bool isOK() const { return code_ == StatusCode::OK; }
   StatusCode code() const { return code_; }

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -638,6 +638,70 @@ public:
 
     return PeakStatus::OK();
   }
+
+  /// Materializes vertex-keyed adjacency from CSR and any buffered COO edges.
+  std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                     VertexHasher<VertexType>>
+  impl_captureTraversalAdjacency() {
+    if (!is_built_.load(std::memory_order_acquire)) {
+      buildStructures();
+    }
+
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    std::unordered_map<VertexType, std::vector<std::pair<VertexType, EdgeType>>,
+                       VertexHasher<VertexType>>
+        snapshot;
+    snapshot.reserve(vertex_order.size());
+
+    for (size_t src_idx = 0; src_idx < vertex_order.size(); ++src_idx) {
+      if (_tombstoned.count(src_idx)) {
+        continue;
+      }
+      const VertexType &src_vertex = vertex_order[src_idx];
+      std::vector<std::pair<size_t, EdgeType>> neighbor_indices;
+
+      if (is_built_.load(std::memory_order_acquire) &&
+          src_idx + 1 < csr_row_offsets.size()) {
+        const size_t start = csr_row_offsets[src_idx];
+        const size_t end = csr_row_offsets[src_idx + 1];
+        for (size_t i = start; i < end; ++i) {
+          const size_t dest_idx = csr_col_vals[i];
+          if (!_tombstoned.count(dest_idx)) {
+            neighbor_indices.emplace_back(dest_idx, csr_weights[i]);
+          }
+        }
+      }
+
+      for (size_t i = 0; i < coo_src.size(); ++i) {
+        if (coo_src[i] == src_idx) {
+          const size_t dest_idx = coo_dest[i];
+          if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx)) {
+            neighbor_indices.emplace_back(dest_idx, coo_weights[i]);
+          }
+        }
+      }
+
+      std::vector<std::pair<VertexType, EdgeType>> neighbors;
+      if (!neighbor_indices.empty()) {
+        std::sort(
+            neighbor_indices.begin(), neighbor_indices.end(),
+            [](const auto &a, const auto &b) { return a.first < b.first; });
+        neighbor_indices.erase(std::unique(neighbor_indices.begin(),
+                                           neighbor_indices.end(),
+                                           [](const auto &a, const auto &b) {
+                                             return a.first == b.first;
+                                           }),
+                               neighbor_indices.end());
+        neighbors.reserve(neighbor_indices.size());
+        for (const auto &p : neighbor_indices) {
+          neighbors.emplace_back(vertex_order[p.first], p.second);
+        }
+      }
+
+      snapshot.emplace(src_vertex, std::move(neighbors));
+    }
+    return snapshot;
+  }
 };
 
 } // namespace PeakStore

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -551,6 +551,79 @@ public:
     return {EdgeType{}, PeakStatus::EdgeNotFound()};
   }
 
+  const std::pair<std::vector<std::pair<VertexType, EdgeType>>, PeakStatus>
+  impl_getNeighbors(const VertexType &vertex) {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+
+    auto it = vertex_to_index.find(vertex);
+    if (it == vertex_to_index.end()) {
+      return std::make_pair(std::vector<std::pair<VertexType, EdgeType>>{},
+                            PeakStatus::VertexNotFound());
+    }
+
+    size_t src_idx = it->second;
+
+    // Ensure CSR is built for fast access. Follow the same pattern used in
+    // impl_getEdge: release shared lock, build, and reacquire.
+    if (!is_built_.load(std::memory_order_acquire)) {
+      lock.unlock();
+      buildStructures();
+      lock.lock();
+    }
+
+    std::vector<std::pair<size_t, EdgeType>> neighbor_indices;
+
+    // Collect neighbors from CSR (if available)
+    if (is_built_.load(std::memory_order_acquire)) {
+      if (src_idx < csr_row_offsets.size() - 1) {
+        size_t start = csr_row_offsets[src_idx];
+        size_t end = csr_row_offsets[src_idx + 1];
+        for (size_t i = start; i < end; ++i) {
+          size_t dest_idx = csr_col_vals[i];
+          if (!_tombstoned.count(dest_idx))
+            neighbor_indices.emplace_back(dest_idx, csr_weights[i]);
+        }
+      }
+    }
+
+    // Include buffered COO entries
+    for (size_t i = 0; i < coo_src.size(); ++i) {
+      if (coo_src[i] == src_idx) {
+        size_t dest_idx = coo_dest[i];
+        if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx))
+          neighbor_indices.emplace_back(dest_idx, coo_weights[i]);
+      }
+    }
+
+    if (neighbor_indices.empty()) {
+      return std::make_pair(std::vector<std::pair<VertexType, EdgeType>>{},
+                            PeakStatus::OK());
+    }
+
+    // Sort and deduplicate by destination index to provide deterministic
+    // neighbor ordering.
+    std::sort(neighbor_indices.begin(), neighbor_indices.end(),
+              [](const auto &a, const auto &b) { return a.first < b.first; });
+    neighbor_indices.erase(std::unique(neighbor_indices.begin(),
+                                       neighbor_indices.end(),
+                                       [](const auto &a, const auto &b) {
+                                         return a.first == b.first;
+                                       }),
+                           neighbor_indices.end());
+
+    // Map indices back to vertex objects
+    std::vector<std::pair<VertexType, EdgeType>> result;
+    result.reserve(neighbor_indices.size());
+    for (const auto &p : neighbor_indices) {
+      size_t dest_idx = p.first;
+      if (dest_idx < vertex_order.size() && !_tombstoned.count(dest_idx)) {
+        result.emplace_back(vertex_order[dest_idx], p.second);
+      }
+    }
+
+    return std::make_pair(result, PeakStatus::OK());
+  }
+
   [[nodiscard]] const PeakStatus
   impl_removeVertex(const VertexType &vtx) override {
     std::unique_lock<std::shared_mutex> lock(_mtx);

--- a/tests/integration/CinderGraph/functional/bfs_test.cpp
+++ b/tests/integration/CinderGraph/functional/bfs_test.cpp
@@ -1,0 +1,93 @@
+#include "DummyGraphBuilder.hpp"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace CinderPeak;
+
+class CinderGraphBfsTest : public ::testing::Test {
+protected:
+  DummyGraph builder;
+};
+
+TEST_F(CinderGraphBfsTest, DirectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(1, 3).second);
+  EXPECT_TRUE(graph.addEdge(2, 4).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST_F(CinderGraphBfsTest, UndirectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::undirected);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(1, 3).second);
+  EXPECT_TRUE(graph.addEdge(3, 4).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST_F(CinderGraphBfsTest, DisconnectedGraphBFS) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(1).second);
+  EXPECT_TRUE(graph.addVertex(2).second);
+  EXPECT_TRUE(graph.addVertex(3).second);
+  EXPECT_TRUE(graph.addVertex(4).second);
+  EXPECT_TRUE(graph.addVertex(5).second);
+
+  EXPECT_TRUE(graph.addEdge(1, 2).second);
+  EXPECT_TRUE(graph.addEdge(2, 3).second);
+
+  auto result = graph.bfs(1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST_F(CinderGraphBfsTest, IsolatedVertexTraversal) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(graph.addVertex(42).second);
+
+  auto result = graph.bfs(42);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({42}));
+}
+
+TEST_F(CinderGraphBfsTest, MissingSourceReturnsNotFound) {
+  auto graph = builder.CreatePrimitiveUnweightedGraph(GraphOpts::directed);
+
+  auto result = graph.bfs(100);
+  EXPECT_FALSE(result.isOK());
+  EXPECT_EQ(result._status.code(), StatusCode::VERTEX_NOT_FOUND);
+}
+
+TEST_F(CinderGraphBfsTest, CustomVertexTraversal) {
+  auto graph = builder.CreateCustomUnweightedGraph(GraphOpts::directed);
+  ListVertex v1(1);
+  ListVertex v2(2);
+  ListVertex v3(3);
+
+  EXPECT_TRUE(graph.addVertex(v1).second);
+  EXPECT_TRUE(graph.addVertex(v2).second);
+  EXPECT_TRUE(graph.addVertex(v3).second);
+
+  EXPECT_TRUE(graph.addEdge(v1, v2).second);
+  EXPECT_TRUE(graph.addEdge(v2, v3).second);
+
+  auto result = graph.bfs(v1);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<ListVertex>({v1, v2, v3}));
+}

--- a/tests/unit/Algorithms/bfs_parity_test.cpp
+++ b/tests/unit/Algorithms/bfs_parity_test.cpp
@@ -1,0 +1,116 @@
+#include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "GraphRuntime.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/HybridCSR_COO.hpp"
+#include "gtest/gtest.h"
+
+using namespace CinderPeak;
+
+TEST(BFSParityTest, AdjacencyVsHybridPrimitive) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  PeakStore::HybridCSR_COO<int, int> hybrid;
+
+  // Build graph: 1 -> 2, 1 -> 3, 2 -> 4
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+
+  // Prepare adjacency-style map for hybrid population
+  std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>>
+      amap;
+  amap[1] = {{2, 0}, {3, 0}};
+  amap[2] = {{4, 0}};
+  amap[3] = {};
+  amap[4] = {};
+
+  // create shared hybrid and populate
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  // adjacency-only algorithm (no hybrid available)
+  Algorithms::CinderPeakAlgorithms<int, int> alg_adj(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  // hybrid-first algorithm (prefers hybrid, falls back to adjacency)
+  Algorithms::CinderPeakAlgorithms<int, int> alg_hyb(
+      hybrid_ptr,
+      [hyb = hybrid_ptr, &adj](const int &v) {
+        if (hyb->impl_hasVertex(v))
+          return true;
+        return adj.impl_hasVertex(v);
+      },
+      [hyb = hybrid_ptr, &adj](const int &v) {
+        auto res = hyb->impl_getNeighbors(v);
+        if (res.second.isOK())
+          return res;
+        return adj.impl_getNeighbors(v);
+      });
+
+  auto r1 = alg_adj.bfs(1);
+  auto r2 = alg_hyb.bfs(1);
+
+  EXPECT_TRUE(r1.isOK());
+  EXPECT_TRUE(r2.isOK());
+  EXPECT_EQ(r1.order_, r2.order_);
+}
+
+TEST(BFSParityTest, CustomVertexParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<CinderVertex, int> adj(runtime);
+  CinderVertex v1("A"), v2("B"), v3("C");
+  (void)adj.impl_addVertex(v1);
+  (void)adj.impl_addVertex(v2);
+  (void)adj.impl_addVertex(v3);
+  (void)adj.impl_addEdge(v1, v2);
+  (void)adj.impl_addEdge(v2, v3);
+
+  std::unordered_map<CinderVertex, std::vector<std::pair<CinderVertex, int>>,
+                     VertexHasher<CinderVertex>>
+      amap;
+  amap[v1] = {{v2, 0}};
+  amap[v2] = {{v3, 0}};
+  amap[v3] = {};
+
+  // populate hybrid from adjacency map
+  // (handled below via hybrid_ptr->populateFromAdjList)
+
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg_adj(
+      std::make_shared<PeakStore::HybridCSR_COO<CinderVertex, int>>(),
+      [&adj](const CinderVertex &v) { return adj.impl_hasVertex(v); },
+      [&adj](const CinderVertex &v) { return adj.impl_getNeighbors(v); });
+
+  auto hybrid_ptr =
+      std::make_shared<PeakStore::HybridCSR_COO<CinderVertex, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg_hyb(
+      hybrid_ptr,
+      [hyb = hybrid_ptr, &adj](const CinderVertex &v) {
+        if (hyb->impl_hasVertex(v))
+          return true;
+        return adj.impl_hasVertex(v);
+      },
+      [hyb = hybrid_ptr, &adj](const CinderVertex &v) {
+        auto res = hyb->impl_getNeighbors(v);
+        if (res.second.isOK())
+          return res;
+        return adj.impl_getNeighbors(v);
+      });
+
+  auto r1 = alg_adj.bfs(v1);
+  auto r2 = alg_hyb.bfs(v1);
+
+  EXPECT_TRUE(r1.isOK());
+  EXPECT_TRUE(r2.isOK());
+  EXPECT_EQ(r1.order_.size(), r2.order_.size());
+  // Compare __id_ to avoid relying on string names ordering
+  for (size_t i = 0; i < r1.order_.size(); ++i) {
+    EXPECT_EQ(r1.order_[i].__id_, r2.order_[i].__id_);
+  }
+}

--- a/tests/unit/Algorithms/dfs_topo_test.cpp
+++ b/tests/unit/Algorithms/dfs_topo_test.cpp
@@ -1,0 +1,282 @@
+#include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "Algorithms/TraversalExecution.hpp"
+#include "Algorithms/TraversalSnapshot.hpp"
+#include "CinderGraph.hpp"
+#include "GraphRuntime.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/HybridCSR_COO.hpp"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace CinderPeak;
+
+namespace {
+
+constexpr int kRepeatCount = 5;
+
+Algorithms::TraversalSnapshot<int, int>
+makeSnapshot(PeakStore::AdjacencyList<int, int> &adj) {
+  return Algorithms::TraversalSnapshot<int, int>(
+      adj.impl_captureTraversalAdjacency());
+}
+
+} // namespace
+
+TEST(DfsTopoTest, DfsSnapshotCorrectness) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+
+  auto snapshot = makeSnapshot(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  auto result = alg.dfs(1, snapshot);
+  ASSERT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 4, 3}));
+}
+
+TEST(DfsTopoTest, DfsRepeatedSnapshotTraversalIsIdentical) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+
+  auto snapshot = makeSnapshot(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  std::vector<int> baseline;
+  for (int i = 0; i < kRepeatCount; ++i) {
+    auto result = alg.dfs(1, snapshot);
+    ASSERT_TRUE(result.isOK());
+    if (i == 0) {
+      baseline = result.order_;
+    } else {
+      EXPECT_EQ(result.order_, baseline);
+    }
+  }
+}
+
+TEST(DfsTopoTest, DfsDisconnectedComponent) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  for (int v : {1, 2, 3, 4, 5}) {
+    (void)adj.impl_addVertex(v);
+  }
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(2, 3);
+
+  auto snapshot = makeSnapshot(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  auto result = alg.dfs(1, snapshot);
+  ASSERT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(DfsTopoTest, DfsCustomVertexSnapshot) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<CinderVertex, int> adj(runtime);
+  CinderVertex v1("A"), v2("B"), v3("C");
+  (void)adj.impl_addVertex(v1);
+  (void)adj.impl_addVertex(v2);
+  (void)adj.impl_addVertex(v3);
+  (void)adj.impl_addEdge(v1, v2);
+  (void)adj.impl_addEdge(v2, v3);
+
+  Algorithms::TraversalSnapshot<CinderVertex, int> snapshot(
+      adj.impl_captureTraversalAdjacency());
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<CinderVertex, int>>(), nullptr,
+      nullptr);
+
+  auto result = alg.dfs(v1, snapshot);
+  ASSERT_TRUE(result.isOK());
+  ASSERT_EQ(result.order_.size(), 3u);
+  EXPECT_EQ(result.order_[0].__id_, v1.__id_);
+  EXPECT_EQ(result.order_[1].__id_, v2.__id_);
+  EXPECT_EQ(result.order_[2].__id_, v3.__id_);
+}
+
+TEST(DfsTopoTest, DfsSnapshotMatchesTraversalExecution) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addEdge(1, 2);
+
+  auto snapshot = makeSnapshot(adj);
+  auto access =
+      Algorithms::TraversalAdjacencyAccess<int, int>::fromSnapshot(snapshot);
+  auto direct = Algorithms::runDfs(
+      access, 1, Algorithms::TraversalNeighborOrder::DeterministicByVertex);
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+  auto via_alg = alg.dfs(1, snapshot);
+
+  EXPECT_TRUE(direct.isOK());
+  EXPECT_TRUE(via_alg.isOK());
+  EXPECT_EQ(direct.order_, via_alg.order_);
+}
+
+TEST(DfsTopoTest, DfsBackendSnapshotParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(2, 3);
+
+  auto amap = adj.impl_captureTraversalAdjacency();
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  Algorithms::TraversalSnapshot<int, int> adj_snapshot(
+      adj.impl_captureTraversalAdjacency());
+  Algorithms::TraversalSnapshot<int, int> hybrid_snapshot(
+      hybrid_ptr->impl_captureTraversalAdjacency());
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(hybrid_ptr, nullptr, nullptr);
+
+  auto adj_dfs = alg.dfs(1, adj_snapshot);
+  auto hybrid_dfs = alg.dfs(1, hybrid_snapshot);
+  EXPECT_TRUE(adj_dfs.isOK());
+  EXPECT_TRUE(hybrid_dfs.isOK());
+  EXPECT_EQ(adj_dfs.order_, hybrid_dfs.order_);
+}
+
+TEST(DfsTopoTest, TopologicalSortDagCorrectness) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+  (void)adj.impl_addEdge(3, 4);
+
+  auto snapshot = makeSnapshot(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  auto result = alg.topologicalSort(snapshot);
+  ASSERT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3, 4}));
+}
+
+TEST(DfsTopoTest, TopologicalSortDetectsCycle) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(2, 1);
+
+  auto snapshot = makeSnapshot(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  auto result = alg.topologicalSort(snapshot);
+  EXPECT_FALSE(result.isOK());
+  EXPECT_EQ(result._status.code(), StatusCode::GRAPH_CYCLE_DETECTED);
+  EXPECT_TRUE(result.order_.empty());
+}
+
+TEST(DfsTopoTest, TopologicalSortRepeatedConsistency) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(5);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(8);
+  (void)adj.impl_addEdge(5, 2);
+  (void)adj.impl_addEdge(2, 8);
+
+  auto snapshot = makeSnapshot(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  std::vector<int> baseline;
+  for (int i = 0; i < kRepeatCount; ++i) {
+    auto result = alg.topologicalSort(snapshot);
+    ASSERT_TRUE(result.isOK());
+    if (i == 0) {
+      baseline = result.order_;
+    } else {
+      EXPECT_EQ(result.order_, baseline);
+    }
+  }
+  EXPECT_EQ(baseline, std::vector<int>({5, 2, 8}));
+}
+
+TEST(DfsTopoTest, TopologicalSortBackendParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 3);
+
+  auto amap = adj.impl_captureTraversalAdjacency();
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  Algorithms::TraversalSnapshot<int, int> adj_snapshot(
+      adj.impl_captureTraversalAdjacency());
+  Algorithms::TraversalSnapshot<int, int> hybrid_snapshot(
+      hybrid_ptr->impl_captureTraversalAdjacency());
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(hybrid_ptr, nullptr, nullptr);
+
+  auto adj_topo = alg.topologicalSort(adj_snapshot);
+  auto hybrid_topo = alg.topologicalSort(hybrid_snapshot);
+  EXPECT_TRUE(adj_topo.isOK());
+  EXPECT_TRUE(hybrid_topo.isOK());
+  EXPECT_EQ(adj_topo.order_, hybrid_topo.order_);
+}
+
+TEST(DfsTopoTest, PeakStoreCinderGraphIntegration) {
+  CinderGraph<int, int> graph;
+  (void)graph.addVertex(1);
+  (void)graph.addVertex(2);
+  (void)graph.addVertex(3);
+  (void)graph.addEdge(1, 2, 0);
+  (void)graph.addEdge(2, 3, 0);
+
+  auto snapshot = graph.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Adjacency);
+
+  auto dfs_result = graph.dfs(1, snapshot);
+  ASSERT_TRUE(dfs_result.isOK());
+  EXPECT_EQ(dfs_result.order_, std::vector<int>({1, 2, 3}));
+
+  auto topo_result = graph.topologicalSort(snapshot);
+  ASSERT_TRUE(topo_result.isOK());
+  EXPECT_EQ(topo_result.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(DfsTopoTest, TopologicalSortRequiresSnapshot) {
+  PeakStore::GraphInternalMetadata metadata("topo_test", true, true, false,
+                                            true);
+  PeakStore::PeakStore<int, int> store(metadata);
+
+  auto result = store.topologicalSort(
+      std::shared_ptr<const Algorithms::TraversalSnapshot<int, int>>());
+  EXPECT_FALSE(result.isOK());
+  EXPECT_EQ(result._status.code(), StatusCode::INVALID_ARGUMENT);
+}

--- a/tests/unit/Algorithms/traversal_architecture_test.cpp
+++ b/tests/unit/Algorithms/traversal_architecture_test.cpp
@@ -1,0 +1,220 @@
+#include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "Algorithms/TraversalExecution.hpp"
+#include "Algorithms/TraversalSemantics.hpp"
+#include "Algorithms/TraversalSnapshot.hpp"
+#include "CinderGraph.hpp"
+#include "GraphRuntime.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/HybridCSR_COO.hpp"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace CinderPeak;
+
+namespace {
+
+constexpr int kRepeatCount = 5;
+
+} // namespace
+
+TEST(TraversalArchitectureTest, RepeatedSnapshotBfsIsIdentical) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+
+  Algorithms::TraversalSnapshot<int, int> snapshot(
+      adj.impl_captureTraversalAdjacency());
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  const std::vector<int> expected{1, 2, 3, 4};
+  for (int i = 0; i < kRepeatCount; ++i) {
+    auto result = alg.bfs(1, snapshot);
+    ASSERT_TRUE(result.isOK()) << "iteration " << i;
+    EXPECT_EQ(result.order_, expected) << "iteration " << i;
+  }
+}
+
+TEST(TraversalArchitectureTest, RepeatedLiveBfsIsIdenticalOnUnchangedGraph) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  std::vector<int> baseline;
+  for (int i = 0; i < kRepeatCount; ++i) {
+    auto result = alg.bfs(1);
+    ASSERT_TRUE(result.isOK());
+    if (i == 0) {
+      baseline = result.order_;
+    } else {
+      EXPECT_EQ(result.order_, baseline);
+    }
+  }
+}
+
+TEST(TraversalArchitectureTest, SnapshotAdjacencyUnchangedAfterLiveMutation) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addEdge(1, 2);
+
+  Algorithms::TraversalSnapshot<int, int> snapshot(
+      adj.impl_captureTraversalAdjacency());
+  const auto neighbors_before = snapshot.getNeighbors(1);
+
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(2, 3);
+
+  const auto neighbors_after = snapshot.getNeighbors(1);
+  EXPECT_EQ(neighbors_before.first, neighbors_after.first);
+  EXPECT_EQ(neighbors_before.second.code(), neighbors_after.second.code());
+}
+
+TEST(TraversalArchitectureTest, BackendSnapshotParityAfterNormalization) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(1, 2);
+
+  auto amap = adj.impl_captureTraversalAdjacency();
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  Algorithms::TraversalSnapshot<int, int> adj_snapshot(
+      adj.impl_captureTraversalAdjacency());
+  Algorithms::TraversalSnapshot<int, int> hybrid_snapshot(
+      hybrid_ptr->impl_captureTraversalAdjacency());
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(hybrid_ptr, nullptr, nullptr);
+
+  auto adj_bfs = alg.bfs(1, adj_snapshot);
+  auto hybrid_bfs = alg.bfs(1, hybrid_snapshot);
+
+  EXPECT_TRUE(adj_bfs.isOK());
+  EXPECT_TRUE(hybrid_bfs.isOK());
+  EXPECT_EQ(adj_bfs.order_, hybrid_bfs.order_);
+}
+
+TEST(TraversalArchitectureTest, TraversalAdjacencyAccessMatchesSnapshotBfs) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(10);
+  (void)adj.impl_addVertex(20);
+  (void)adj.impl_addEdge(10, 20);
+
+  Algorithms::TraversalSnapshot<int, int> snapshot(
+      adj.impl_captureTraversalAdjacency());
+  auto access =
+      Algorithms::TraversalAdjacencyAccess<int, int>::fromSnapshot(snapshot);
+
+  auto direct = Algorithms::runBfs(
+      access, 10, Algorithms::TraversalNeighborOrder::DeterministicByVertex);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+  auto via_alg = alg.bfs(10, snapshot);
+
+  EXPECT_TRUE(direct.isOK());
+  EXPECT_TRUE(via_alg.isOK());
+  EXPECT_EQ(direct.order_, via_alg.order_);
+}
+
+TEST(TraversalArchitectureTest, CustomVertexRepeatedSnapshotParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<CinderVertex, int> adj(runtime);
+  CinderVertex v1("A"), v2("B"), v3("C");
+  (void)adj.impl_addVertex(v1);
+  (void)adj.impl_addVertex(v2);
+  (void)adj.impl_addVertex(v3);
+  (void)adj.impl_addEdge(v1, v2);
+  (void)adj.impl_addEdge(v2, v3);
+
+  Algorithms::TraversalSnapshot<CinderVertex, int> snapshot(
+      adj.impl_captureTraversalAdjacency());
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<CinderVertex, int>>(), nullptr,
+      nullptr);
+
+  std::vector<size_t> baseline_ids;
+  for (int i = 0; i < kRepeatCount; ++i) {
+    auto result = alg.bfs(v1, snapshot);
+    ASSERT_TRUE(result.isOK());
+    std::vector<size_t> ids;
+    for (const auto &v : result.order_) {
+      ids.push_back(v.__id_);
+    }
+    if (i == 0) {
+      baseline_ids = ids;
+    } else {
+      EXPECT_EQ(ids, baseline_ids);
+    }
+  }
+}
+
+TEST(TraversalArchitectureTest, PeakStoreHybridSnapshotFallbackSemantics) {
+  PeakStore::GraphInternalMetadata metadata("arch_test", true, true, false,
+                                            true);
+  PeakStore::PeakStore<int, int> store(metadata);
+
+  (void)store.addVertex(7);
+  (void)store.addVertex(8);
+  (void)store.addEdge(7, 8);
+
+  auto hybrid_snapshot = store.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Hybrid);
+  auto adj_snapshot = store.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Adjacency);
+
+  ASSERT_NE(hybrid_snapshot, nullptr);
+  ASSERT_NE(adj_snapshot, nullptr);
+
+  auto hyb_bfs = store.bfs(7, hybrid_snapshot);
+  auto adj_bfs = store.bfs(7, adj_snapshot);
+  EXPECT_TRUE(hyb_bfs.isOK());
+  EXPECT_TRUE(adj_bfs.isOK());
+  EXPECT_EQ(hyb_bfs.order_, adj_bfs.order_);
+}
+
+TEST(TraversalArchitectureTest, CinderGraphSnapshotIsolationFromMutation) {
+  CinderGraph<int, int> graph;
+  (void)graph.addVertex(1);
+  (void)graph.addVertex(2);
+  (void)graph.addEdge(1, 2, 0);
+
+  auto snapshot = graph.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Adjacency);
+
+  std::vector<int> frozen_order;
+  for (int i = 0; i < kRepeatCount; ++i) {
+    auto r = graph.bfs(1, snapshot);
+    ASSERT_TRUE(r.isOK());
+    if (i == 0) {
+      frozen_order = r.order_;
+    } else {
+      EXPECT_EQ(r.order_, frozen_order);
+    }
+  }
+
+  (void)graph.addVertex(99);
+  (void)graph.addEdge(2, 99, 0);
+  auto after_mutation = graph.bfs(1, snapshot);
+  EXPECT_EQ(after_mutation.order_, frozen_order);
+}

--- a/tests/unit/Algorithms/traversal_snapshot_test.cpp
+++ b/tests/unit/Algorithms/traversal_snapshot_test.cpp
@@ -1,0 +1,186 @@
+#include "Algorithms/CinderPeakAlgorithms.hpp"
+#include "Algorithms/TraversalSnapshot.hpp"
+#include "CinderGraph.hpp"
+#include "GraphRuntime.hpp"
+#include "StorageEngine/AdjacencyList.hpp"
+#include "StorageEngine/HybridCSR_COO.hpp"
+#include "gtest/gtest.h"
+
+using namespace CinderPeak;
+
+namespace {
+
+Algorithms::TraversalSnapshot<int, int>
+makeSnapshotFromAdjacency(PeakStore::AdjacencyList<int, int> &adj) {
+  return Algorithms::TraversalSnapshot<int, int>(
+      adj.impl_captureTraversalAdjacency());
+}
+
+} // namespace
+
+TEST(TraversalSnapshotTest, SnapshotBfsMatchesCallbackBfs) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addVertex(4);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(1, 3);
+  (void)adj.impl_addEdge(2, 4);
+
+  auto snapshot = makeSnapshotFromAdjacency(adj);
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  auto callback_result = alg.bfs(1);
+  auto snapshot_result = alg.bfs(1, snapshot);
+
+  EXPECT_TRUE(callback_result.isOK());
+  EXPECT_TRUE(snapshot_result.isOK());
+  EXPECT_EQ(callback_result.order_, snapshot_result.order_);
+}
+
+TEST(TraversalSnapshotTest, SnapshotImmutabilityAfterMutation) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addEdge(1, 2);
+
+  auto snapshot = makeSnapshotFromAdjacency(adj);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(2, 3);
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(),
+      [&adj](const int &v) { return adj.impl_hasVertex(v); },
+      [&adj](const int &v) { return adj.impl_getNeighbors(v); });
+
+  auto frozen = alg.bfs(1, snapshot);
+  auto live = alg.bfs(1);
+
+  EXPECT_EQ(frozen.order_, std::vector<int>({1, 2}));
+  EXPECT_EQ(live.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(TraversalSnapshotTest, AdjacencyVsHybridSnapshotParity) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  (void)adj.impl_addVertex(1);
+  (void)adj.impl_addVertex(2);
+  (void)adj.impl_addVertex(3);
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(2, 3);
+
+  std::unordered_map<int, std::vector<std::pair<int, int>>, VertexHasher<int>>
+      amap = adj.impl_captureTraversalAdjacency();
+  auto hybrid_ptr = std::make_shared<PeakStore::HybridCSR_COO<int, int>>();
+  hybrid_ptr->populateFromAdjList(amap);
+
+  auto adj_snapshot = Algorithms::TraversalSnapshot<int, int>(
+      adj.impl_captureTraversalAdjacency());
+  auto hybrid_snapshot = Algorithms::TraversalSnapshot<int, int>(
+      hybrid_ptr->impl_captureTraversalAdjacency());
+
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      hybrid_ptr, [](const int &) { return true; },
+      [](const int &) {
+        return std::pair<std::vector<std::pair<int, int>>, PeakStatus>{};
+      });
+
+  auto adj_bfs = alg.bfs(1, adj_snapshot);
+  auto hybrid_bfs = alg.bfs(1, hybrid_snapshot);
+
+  EXPECT_TRUE(adj_bfs.isOK());
+  EXPECT_TRUE(hybrid_bfs.isOK());
+  EXPECT_EQ(adj_bfs.order_, hybrid_bfs.order_);
+}
+
+TEST(TraversalSnapshotTest, DisconnectedGraphViaSnapshot) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<int, int> adj(runtime);
+  for (int v : {1, 2, 3, 4, 5}) {
+    (void)adj.impl_addVertex(v);
+  }
+  (void)adj.impl_addEdge(1, 2);
+  (void)adj.impl_addEdge(2, 3);
+
+  auto snapshot = makeSnapshotFromAdjacency(adj);
+  Algorithms::CinderPeakAlgorithms<int, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<int, int>>(), nullptr, nullptr);
+
+  auto result = alg.bfs(1, snapshot);
+  EXPECT_TRUE(result.isOK());
+  EXPECT_EQ(result.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(TraversalSnapshotTest, CustomVertexSnapshotTraversal) {
+  GraphRuntime runtime;
+  PeakStore::AdjacencyList<CinderVertex, int> adj(runtime);
+  CinderVertex v1("A"), v2("B"), v3("C");
+  (void)adj.impl_addVertex(v1);
+  (void)adj.impl_addVertex(v2);
+  (void)adj.impl_addVertex(v3);
+  (void)adj.impl_addEdge(v1, v2);
+  (void)adj.impl_addEdge(v2, v3);
+
+  Algorithms::TraversalSnapshot<CinderVertex, int> snapshot(
+      adj.impl_captureTraversalAdjacency());
+
+  Algorithms::CinderPeakAlgorithms<CinderVertex, int> alg(
+      std::shared_ptr<PeakStore::HybridCSR_COO<CinderVertex, int>>(), nullptr,
+      nullptr);
+
+  auto result = alg.bfs(v1, snapshot);
+  EXPECT_TRUE(result.isOK());
+  ASSERT_EQ(result.order_.size(), 3u);
+  EXPECT_EQ(result.order_[0].__id_, v1.__id_);
+  EXPECT_EQ(result.order_[1].__id_, v2.__id_);
+  EXPECT_EQ(result.order_[2].__id_, v3.__id_);
+}
+
+TEST(TraversalSnapshotTest, PeakStoreSnapshotOrchestration) {
+  CinderGraph<int, int> graph;
+  (void)graph.addVertex(1);
+  (void)graph.addVertex(2);
+  (void)graph.addEdge(1, 2, 0);
+
+  auto snapshot = graph.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Adjacency);
+  ASSERT_NE(snapshot, nullptr);
+  EXPECT_EQ(snapshot->vertexCount(), 2u);
+
+  (void)graph.addVertex(3);
+  (void)graph.addEdge(2, 3, 0);
+
+  auto frozen = graph.bfs(1, snapshot);
+  auto live = graph.bfs(1);
+
+  EXPECT_EQ(frozen.order_, std::vector<int>({1, 2}));
+  EXPECT_EQ(live.order_, std::vector<int>({1, 2, 3}));
+}
+
+TEST(TraversalSnapshotTest, EmptyHybridSnapshotFallsBackToAdjacency) {
+  PeakStore::GraphInternalMetadata metadata("test_graph", true, true, false,
+                                            true);
+  PeakStore::PeakStore<int, int> store(metadata);
+
+  (void)store.addVertex(10);
+  (void)store.addVertex(20);
+  (void)store.addEdge(10, 20);
+
+  auto snapshot = store.createTraversalSnapshot(
+      Algorithms::TraversalSnapshotBackend::Hybrid);
+  ASSERT_NE(snapshot, nullptr);
+  EXPECT_TRUE(snapshot->hasVertex(10));
+  EXPECT_TRUE(snapshot->hasVertex(20));
+
+  auto neighbors = snapshot->getNeighbors(10);
+  ASSERT_TRUE(neighbors.second.isOK());
+  ASSERT_EQ(neighbors.first.size(), 1u);
+  EXPECT_EQ(neighbors.first[0].first, 20);
+}


### PR DESCRIPTION
- Closes #270 
- Incremental PR for #273
- Incremental PR for #274 

## Rationale for this change

This PR completes the remaining traversal architecture work incrementally on top of the earlier traversal foundation PRs.

Previous traversal PRs introduced:
- real BFS traversal
- backend-independent traversal access
- immutable traversal snapshots
- snapshot-backed BFS support
- traversal parity and lifecycle guarantees

This PR finalizes the traversal architecture by:
- formalizing reusable traversal execution infrastructure
- introducing DFS and Topological Sort support on top of the snapshot architecture
- improving deterministic traversal semantics
- strengthening traversal consistency and parity guarantees
- extending traversal validation coverage

The implementation intentionally continues the incremental architecture-aligned approach rather than introducing a broad storage-engine rewrite or async traversal framework.

## What changes are included in this PR?

### Traversal execution architecture
Added reusable traversal execution infrastructure through:
- `TraversalExecution.hpp`
- shared traversal adjacency access helpers
- reusable traversal execution flows for BFS/DFS/topological traversal

### Traversal semantics and ordering
Added:
- `TraversalSemantics.hpp`
- `TraversalOrdering.hpp`

These formalize:
- snapshot immutability guarantees
- traversal consistency behavior
- deterministic traversal ordering semantics
- backend parity expectations
- fallback semantics
- future traversal extensibility notes

### DFS traversal support
Implemented:
- iterative DFS traversal using explicit stack-based execution
- snapshot-backed DFS traversal
- backend-independent DFS flows
- deterministic snapshot DFS ordering

Added:
- `DFSResult<VertexType>`

### Topological Sort support
Implemented:
- snapshot-backed topological sort traversal
- Kahn’s algorithm for DAG traversal
- deterministic ready-node ordering
- cycle detection support

Added:
- `TopologicalSortResult<VertexType>`
- `GRAPH_CYCLE_DETECTED` traversal status handling

### API integration
Integrated DFS/topological traversal through:
- `CinderPeakAlgorithms`
- `PeakStore`
- `CinderGraph`

while preserving backward compatibility with existing traversal APIs.

### Traversal consistency improvements
- strengthened snapshot immutability guarantees
- aligned adjacency/hybrid snapshot parity behavior
- normalized snapshot traversal ordering
- improved repeated traversal consistency

### Testing
Added traversal architecture and algorithm coverage for:
- DFS correctness
- repeated traversal consistency
- disconnected graph traversal
- custom vertex traversal
- backend parity
- snapshot parity
- traversal execution reuse
- topological sort DAG traversal
- cycle detection
- snapshot immutability after mutation
- `PeakStore` / `CinderGraph` integration behavior

## Are these changes tested?

Yes.
Validation completed:
- traversal architecture tests added
- DFS/topological traversal tests added
- backend parity tests passing
- full test suite passing (`47/47`)
- clang-format validation passing

## Are there any user-facing changes?

Yes.
New traversal capabilities are now available:
- `dfs(...)`
- `topologicalSort(...)`
- snapshot-backed traversal execution APIs

Existing BFS APIs remain backward compatible.