### PR TITLE
fix(warnings): resolve MSVC compiler warnings in PeakLogger and Concepts

### DIFF
--- a/src/Concepts.hpp
+++ b/src/Concepts.hpp
@@ -132,8 +132,9 @@ constexpr bool is_unweighted_integral_vertex_v =
 template <typename T> constexpr bool isTypePrimitive() {
   if constexpr (is_primitive_or_string_v<T>) {
     return true;
+  } else {
+    return false;
   }
-  return false;
 }
 
 /**
@@ -146,8 +147,9 @@ template <typename T> constexpr bool isTypePrimitive() {
 template <typename T> constexpr bool isGraphWeighted() {
   if constexpr (is_weighted_v<T>) {
     return true;
+  } else {
+    return false;
   }
-  return false;
 }
 
 #define STATIC_ASSERT_WEIGHTED(E)                                              \

--- a/src/Concepts.hpp
+++ b/src/Concepts.hpp
@@ -12,210 +12,160 @@
  * Provides helper traits for validating graph vertex/edge types,
  * weighted/unweighted configurations, and compile-time constraints.
  */
-namespace CinderPeak::Traits
-{
+namespace CinderPeak::Traits {
 
-  /**
-   * @brief Checks whether an edge type represents an unweighted graph edge.
-   *
-   * @tparam T Edge type to evaluate.
-   */
-  template <typename T>
-  struct is_unweighted : std::is_same<T, Unweighted>
-  {
-  };
+/**
+ * @brief Checks whether an edge type represents an unweighted graph edge.
+ *
+ * @tparam T Edge type to evaluate.
+ */
+template <typename T> struct is_unweighted : std::is_same<T, Unweighted> {};
 
-  template <typename T>
-  constexpr bool is_unweighted_v = is_unweighted<T>::value;
+template <typename T> constexpr bool is_unweighted_v = is_unweighted<T>::value;
 
-  /**
-   * @brief Checks whether an edge type represents a weighted graph edge.
-   *
-   * @tparam T Edge type to evaluate.
-   */
-  template <typename T>
-  struct is_weighted : std::integral_constant<bool, !is_unweighted_v<T>>
-  {
-  };
+/**
+ * @brief Checks whether an edge type represents a weighted graph edge.
+ *
+ * @tparam T Edge type to evaluate.
+ */
+template <typename T>
+struct is_weighted : std::integral_constant<bool, !is_unweighted_v<T>> {};
 
-  template <typename T>
-  constexpr bool is_weighted_v = is_weighted<T>::value;
+template <typename T> constexpr bool is_weighted_v = is_weighted<T>::value;
 
-  // True if EdgeType is numeric
-  template <typename T>
-  struct is_numeric_edge : std::is_arithmetic<T>
-  {
-  };
+// True if EdgeType is numeric
+template <typename T> struct is_numeric_edge : std::is_arithmetic<T> {};
 
-  template <typename T>
-  constexpr bool is_numeric_edge_v = is_numeric_edge<T>::value;
+template <typename T>
+constexpr bool is_numeric_edge_v = is_numeric_edge<T>::value;
 
-  // True if EdgeType is a pointer
-  template <typename T>
-  struct is_pointer_edge : std::is_pointer<T>
-  {
-  };
+// True if EdgeType is a pointer
+template <typename T> struct is_pointer_edge : std::is_pointer<T> {};
 
-  template <typename T>
-  constexpr bool is_pointer_edge_v = is_pointer_edge<T>::value;
+template <typename T>
+constexpr bool is_pointer_edge_v = is_pointer_edge<T>::value;
 
-  // True if EdgeType is optional
-  template <typename T>
-  struct is_optional_edge : std::false_type
-  {
-  };
+// True if EdgeType is optional
+template <typename T> struct is_optional_edge : std::false_type {};
 
-  template <typename T>
-  struct is_optional_edge<std::optional<T>> : std::true_type
-  {
-  };
+template <typename T>
+struct is_optional_edge<std::optional<T>> : std::true_type {};
 
-  template <typename T>
-  constexpr bool is_optional_edge_v = is_optional_edge<T>::value;
+template <typename T>
+constexpr bool is_optional_edge_v = is_optional_edge<T>::value;
 
-  // True if VertexType is primitive or string
-  template <typename T>
-  struct is_primitive_or_string
-      : std::disjunction<std::is_arithmetic<T>, std::is_same<T, std::string>>
-  {
-  };
+// True if VertexType is primitive or string
+template <typename T>
+struct is_primitive_or_string
+    : std::disjunction<std::is_arithmetic<T>, std::is_same<T, std::string>> {};
 
-  template <typename T>
-  constexpr bool is_primitive_or_string_v = is_primitive_or_string<T>::value;
+template <typename T>
+constexpr bool is_primitive_or_string_v = is_primitive_or_string<T>::value;
 
-  // True if VertexType is enum
-  template <typename T>
-  struct is_enum_vertex : std::is_enum<T>
-  {
-  };
+// True if VertexType is enum
+template <typename T> struct is_enum_vertex : std::is_enum<T> {};
 
-  template <typename T>
-  constexpr bool is_enum_vertex_v = is_enum_vertex<T>::value;
+template <typename T>
+constexpr bool is_enum_vertex_v = is_enum_vertex<T>::value;
 
-  // True if VertexType is comparable (supports <)
-  template <typename T, typename = void>
-  struct is_comparable_vertex : std::false_type
-  {
-  };
+// True if VertexType is comparable (supports <)
+template <typename T, typename = void>
+struct is_comparable_vertex : std::false_type {};
 
-  template <typename T>
-  struct is_comparable_vertex<
-      T, std::void_t<decltype(std::declval<T>() < std::declval<T>())>>
-      : std::true_type
-  {
-  };
+template <typename T>
+struct is_comparable_vertex<
+    T, std::void_t<decltype(std::declval<T>() < std::declval<T>())>>
+    : std::true_type {};
 
-  template <typename T>
-  constexpr bool is_comparable_vertex_v = is_comparable_vertex<T>::value;
+template <typename T>
+constexpr bool is_comparable_vertex_v = is_comparable_vertex<T>::value;
 
-  /**
-   * @brief Checks whether a type supports std::hash.
-   *
-   * Used to validate compatibility with unordered containers.
-   *
-   * @tparam T Type to evaluate.
-   */
-  template <typename T, typename = void>
-  struct is_hashable : std::false_type
-  {
-  };
+/**
+ * @brief Checks whether a type supports std::hash.
+ *
+ * Used to validate compatibility with unordered containers.
+ *
+ * @tparam T Type to evaluate.
+ */
+template <typename T, typename = void> struct is_hashable : std::false_type {};
 
-  template <typename T>
-  struct is_hashable<T, std::void_t<decltype(std::hash<T>{}(std::declval<T>()))>>
-      : std::true_type
-  {
-  };
+template <typename T>
+struct is_hashable<T, std::void_t<decltype(std::hash<T>{}(std::declval<T>()))>>
+    : std::true_type {};
 
-  template <typename T>
-  constexpr bool is_hashable_v = is_hashable<T>::value;
+template <typename T> constexpr bool is_hashable_v = is_hashable<T>::value;
 
-  // Primitive, enum, or string
-  template <typename T>
-  struct is_primitive_enum_or_string
-      : std::disjunction<is_primitive_or_string<T>, is_enum_vertex<T>>
-  {
-  };
+// Primitive, enum, or string
+template <typename T>
+struct is_primitive_enum_or_string
+    : std::disjunction<is_primitive_or_string<T>, is_enum_vertex<T>> {};
 
-  template <typename T>
-  constexpr bool is_primitive_enum_or_string_v =
-      is_primitive_enum_or_string<T>::value;
+template <typename T>
+constexpr bool is_primitive_enum_or_string_v =
+    is_primitive_enum_or_string<T>::value;
 
-  // Weighted numeric edge
-  template <typename T>
-  struct is_weighted_numeric_edge
-      : std::integral_constant<bool, is_weighted_v<T> && is_numeric_edge_v<T>>
-  {
-  };
+// Weighted numeric edge
+template <typename T>
+struct is_weighted_numeric_edge
+    : std::integral_constant<bool, is_weighted_v<T> && is_numeric_edge_v<T>> {};
 
-  template <typename T>
-  constexpr bool is_weighted_numeric_edge_v = is_weighted_numeric_edge<T>::value;
+template <typename T>
+constexpr bool is_weighted_numeric_edge_v = is_weighted_numeric_edge<T>::value;
 
-  // Unweighted + integral vertex
-  template <typename V, typename E>
-  struct is_unweighted_integral_vertex
-      : std::integral_constant<bool, is_unweighted_v<E> &&
-                                         std::is_integral<V>::value>
-  {
-  };
+// Unweighted + integral vertex
+template <typename V, typename E>
+struct is_unweighted_integral_vertex
+    : std::integral_constant<bool, is_unweighted_v<E> &&
+                                       std::is_integral<V>::value> {};
 
-  template <typename V, typename E>
-  constexpr bool is_unweighted_integral_vertex_v =
-      is_unweighted_integral_vertex<V, E>::value;
+template <typename V, typename E>
+constexpr bool is_unweighted_integral_vertex_v =
+    is_unweighted_integral_vertex<V, E>::value;
 
-  /**
-   * @brief Runtime helper for checking primitive-compatible graph types.
-   *
-   * @tparam T Type to evaluate.
-   *
-   * @return true if the type is primitive or std::string.
-   */
-  template <typename T>
-  constexpr bool isTypePrimitive()
-  {
-    if constexpr (is_primitive_or_string_v<T>)
-    {
-      return true;
-    }
-    else
-    {
-      return false;
-    }
+/**
+ * @brief Runtime helper for checking primitive-compatible graph types.
+ *
+ * @tparam T Type to evaluate.
+ *
+ * @return true if the type is primitive or std::string.
+ */
+template <typename T> constexpr bool isTypePrimitive() {
+  if constexpr (is_primitive_or_string_v<T>) {
+    return true;
+  } else {
+    return false;
   }
+}
 
-  /**
-   * @brief Runtime helper for checking weighted graph configurations.
-   *
-   * @tparam T Edge type to evaluate.
-   *
-   * @return true if the graph uses weighted edges.
-   */
-  template <typename T>
-  constexpr bool isGraphWeighted()
-  {
-    if constexpr (is_weighted_v<T>)
-    {
-      return true;
-    }
-    else
-    {
-      return false;
-    }
+/**
+ * @brief Runtime helper for checking weighted graph configurations.
+ *
+ * @tparam T Edge type to evaluate.
+ *
+ * @return true if the graph uses weighted edges.
+ */
+template <typename T> constexpr bool isGraphWeighted() {
+  if constexpr (is_weighted_v<T>) {
+    return true;
+  } else {
+    return false;
   }
+}
 
-#define STATIC_ASSERT_WEIGHTED(E)                     \
-  static_assert(CinderPeak::Traits::is_weighted_v<E>, \
+#define STATIC_ASSERT_WEIGHTED(E)                                              \
+  static_assert(CinderPeak::Traits::is_weighted_v<E>,                          \
                 "EdgeType must be weighted (not Unweighted).")
 
-#define STATIC_ASSERT_UNWEIGHTED(E)                     \
-  static_assert(CinderPeak::Traits::is_unweighted_v<E>, \
+#define STATIC_ASSERT_UNWEIGHTED(E)                                            \
+  static_assert(CinderPeak::Traits::is_unweighted_v<E>,                        \
                 "EdgeType must be Unweighted.")
 
-#define STATIC_ASSERT_NUMERIC_EDGE(E)                     \
-  static_assert(CinderPeak::Traits::is_numeric_edge_v<E>, \
+#define STATIC_ASSERT_NUMERIC_EDGE(E)                                          \
+  static_assert(CinderPeak::Traits::is_numeric_edge_v<E>,                      \
                 "EdgeType must be numeric for this algorithm.")
 
-#define STATIC_ASSERT_COMPARABLE_VERTEX(V)                     \
-  static_assert(CinderPeak::Traits::is_comparable_vertex_v<V>, \
+#define STATIC_ASSERT_COMPARABLE_VERTEX(V)                                     \
+  static_assert(CinderPeak::Traits::is_comparable_vertex_v<V>,                 \
                 "VertexType must support operator< for this algorithm.")
 
 } // namespace CinderPeak::Traits

--- a/src/Concepts.hpp
+++ b/src/Concepts.hpp
@@ -12,160 +12,210 @@
  * Provides helper traits for validating graph vertex/edge types,
  * weighted/unweighted configurations, and compile-time constraints.
  */
-namespace CinderPeak::Traits {
+namespace CinderPeak::Traits
+{
 
-/**
- * @brief Checks whether an edge type represents an unweighted graph edge.
- *
- * @tparam T Edge type to evaluate.
- */
-template <typename T> struct is_unweighted : std::is_same<T, Unweighted> {};
+  /**
+   * @brief Checks whether an edge type represents an unweighted graph edge.
+   *
+   * @tparam T Edge type to evaluate.
+   */
+  template <typename T>
+  struct is_unweighted : std::is_same<T, Unweighted>
+  {
+  };
 
-template <typename T> constexpr bool is_unweighted_v = is_unweighted<T>::value;
+  template <typename T>
+  constexpr bool is_unweighted_v = is_unweighted<T>::value;
 
-/**
- * @brief Checks whether an edge type represents a weighted graph edge.
- *
- * @tparam T Edge type to evaluate.
- */
-template <typename T>
-struct is_weighted : std::integral_constant<bool, !is_unweighted_v<T>> {};
+  /**
+   * @brief Checks whether an edge type represents a weighted graph edge.
+   *
+   * @tparam T Edge type to evaluate.
+   */
+  template <typename T>
+  struct is_weighted : std::integral_constant<bool, !is_unweighted_v<T>>
+  {
+  };
 
-template <typename T> constexpr bool is_weighted_v = is_weighted<T>::value;
+  template <typename T>
+  constexpr bool is_weighted_v = is_weighted<T>::value;
 
-// True if EdgeType is numeric
-template <typename T> struct is_numeric_edge : std::is_arithmetic<T> {};
+  // True if EdgeType is numeric
+  template <typename T>
+  struct is_numeric_edge : std::is_arithmetic<T>
+  {
+  };
 
-template <typename T>
-constexpr bool is_numeric_edge_v = is_numeric_edge<T>::value;
+  template <typename T>
+  constexpr bool is_numeric_edge_v = is_numeric_edge<T>::value;
 
-// True if EdgeType is a pointer
-template <typename T> struct is_pointer_edge : std::is_pointer<T> {};
+  // True if EdgeType is a pointer
+  template <typename T>
+  struct is_pointer_edge : std::is_pointer<T>
+  {
+  };
 
-template <typename T>
-constexpr bool is_pointer_edge_v = is_pointer_edge<T>::value;
+  template <typename T>
+  constexpr bool is_pointer_edge_v = is_pointer_edge<T>::value;
 
-// True if EdgeType is optional
-template <typename T> struct is_optional_edge : std::false_type {};
+  // True if EdgeType is optional
+  template <typename T>
+  struct is_optional_edge : std::false_type
+  {
+  };
 
-template <typename T>
-struct is_optional_edge<std::optional<T>> : std::true_type {};
+  template <typename T>
+  struct is_optional_edge<std::optional<T>> : std::true_type
+  {
+  };
 
-template <typename T>
-constexpr bool is_optional_edge_v = is_optional_edge<T>::value;
+  template <typename T>
+  constexpr bool is_optional_edge_v = is_optional_edge<T>::value;
 
-// True if VertexType is primitive or string
-template <typename T>
-struct is_primitive_or_string
-    : std::disjunction<std::is_arithmetic<T>, std::is_same<T, std::string>> {};
+  // True if VertexType is primitive or string
+  template <typename T>
+  struct is_primitive_or_string
+      : std::disjunction<std::is_arithmetic<T>, std::is_same<T, std::string>>
+  {
+  };
 
-template <typename T>
-constexpr bool is_primitive_or_string_v = is_primitive_or_string<T>::value;
+  template <typename T>
+  constexpr bool is_primitive_or_string_v = is_primitive_or_string<T>::value;
 
-// True if VertexType is enum
-template <typename T> struct is_enum_vertex : std::is_enum<T> {};
+  // True if VertexType is enum
+  template <typename T>
+  struct is_enum_vertex : std::is_enum<T>
+  {
+  };
 
-template <typename T>
-constexpr bool is_enum_vertex_v = is_enum_vertex<T>::value;
+  template <typename T>
+  constexpr bool is_enum_vertex_v = is_enum_vertex<T>::value;
 
-// True if VertexType is comparable (supports <)
-template <typename T, typename = void>
-struct is_comparable_vertex : std::false_type {};
+  // True if VertexType is comparable (supports <)
+  template <typename T, typename = void>
+  struct is_comparable_vertex : std::false_type
+  {
+  };
 
-template <typename T>
-struct is_comparable_vertex<
-    T, std::void_t<decltype(std::declval<T>() < std::declval<T>())>>
-    : std::true_type {};
+  template <typename T>
+  struct is_comparable_vertex<
+      T, std::void_t<decltype(std::declval<T>() < std::declval<T>())>>
+      : std::true_type
+  {
+  };
 
-template <typename T>
-constexpr bool is_comparable_vertex_v = is_comparable_vertex<T>::value;
+  template <typename T>
+  constexpr bool is_comparable_vertex_v = is_comparable_vertex<T>::value;
 
-/**
- * @brief Checks whether a type supports std::hash.
- *
- * Used to validate compatibility with unordered containers.
- *
- * @tparam T Type to evaluate.
- */
-template <typename T, typename = void> struct is_hashable : std::false_type {};
+  /**
+   * @brief Checks whether a type supports std::hash.
+   *
+   * Used to validate compatibility with unordered containers.
+   *
+   * @tparam T Type to evaluate.
+   */
+  template <typename T, typename = void>
+  struct is_hashable : std::false_type
+  {
+  };
 
-template <typename T>
-struct is_hashable<T, std::void_t<decltype(std::hash<T>{}(std::declval<T>()))>>
-    : std::true_type {};
+  template <typename T>
+  struct is_hashable<T, std::void_t<decltype(std::hash<T>{}(std::declval<T>()))>>
+      : std::true_type
+  {
+  };
 
-template <typename T> constexpr bool is_hashable_v = is_hashable<T>::value;
+  template <typename T>
+  constexpr bool is_hashable_v = is_hashable<T>::value;
 
-// Primitive, enum, or string
-template <typename T>
-struct is_primitive_enum_or_string
-    : std::disjunction<is_primitive_or_string<T>, is_enum_vertex<T>> {};
+  // Primitive, enum, or string
+  template <typename T>
+  struct is_primitive_enum_or_string
+      : std::disjunction<is_primitive_or_string<T>, is_enum_vertex<T>>
+  {
+  };
 
-template <typename T>
-constexpr bool is_primitive_enum_or_string_v =
-    is_primitive_enum_or_string<T>::value;
+  template <typename T>
+  constexpr bool is_primitive_enum_or_string_v =
+      is_primitive_enum_or_string<T>::value;
 
-// Weighted numeric edge
-template <typename T>
-struct is_weighted_numeric_edge
-    : std::integral_constant<bool, is_weighted_v<T> && is_numeric_edge_v<T>> {};
+  // Weighted numeric edge
+  template <typename T>
+  struct is_weighted_numeric_edge
+      : std::integral_constant<bool, is_weighted_v<T> && is_numeric_edge_v<T>>
+  {
+  };
 
-template <typename T>
-constexpr bool is_weighted_numeric_edge_v = is_weighted_numeric_edge<T>::value;
+  template <typename T>
+  constexpr bool is_weighted_numeric_edge_v = is_weighted_numeric_edge<T>::value;
 
-// Unweighted + integral vertex
-template <typename V, typename E>
-struct is_unweighted_integral_vertex
-    : std::integral_constant<bool, is_unweighted_v<E> &&
-                                       std::is_integral<V>::value> {};
+  // Unweighted + integral vertex
+  template <typename V, typename E>
+  struct is_unweighted_integral_vertex
+      : std::integral_constant<bool, is_unweighted_v<E> &&
+                                         std::is_integral<V>::value>
+  {
+  };
 
-template <typename V, typename E>
-constexpr bool is_unweighted_integral_vertex_v =
-    is_unweighted_integral_vertex<V, E>::value;
+  template <typename V, typename E>
+  constexpr bool is_unweighted_integral_vertex_v =
+      is_unweighted_integral_vertex<V, E>::value;
 
-/**
- * @brief Runtime helper for checking primitive-compatible graph types.
- *
- * @tparam T Type to evaluate.
- *
- * @return true if the type is primitive or std::string.
- */
-template <typename T> constexpr bool isTypePrimitive() {
-  if constexpr (is_primitive_or_string_v<T>) {
-    return true;
-  } else {
-    return false;
+  /**
+   * @brief Runtime helper for checking primitive-compatible graph types.
+   *
+   * @tparam T Type to evaluate.
+   *
+   * @return true if the type is primitive or std::string.
+   */
+  template <typename T>
+  constexpr bool isTypePrimitive()
+  {
+    if constexpr (is_primitive_or_string_v<T>)
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
   }
-}
 
-/**
- * @brief Runtime helper for checking weighted graph configurations.
- *
- * @tparam T Edge type to evaluate.
- *
- * @return true if the graph uses weighted edges.
- */
-template <typename T> constexpr bool isGraphWeighted() {
-  if constexpr (is_weighted_v<T>) {
-    return true;
-  } else {
-    return false;
+  /**
+   * @brief Runtime helper for checking weighted graph configurations.
+   *
+   * @tparam T Edge type to evaluate.
+   *
+   * @return true if the graph uses weighted edges.
+   */
+  template <typename T>
+  constexpr bool isGraphWeighted()
+  {
+    if constexpr (is_weighted_v<T>)
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
   }
-}
 
-#define STATIC_ASSERT_WEIGHTED(E)                                              \
-  static_assert(CinderPeak::Traits::is_weighted_v<E>,                          \
+#define STATIC_ASSERT_WEIGHTED(E)                     \
+  static_assert(CinderPeak::Traits::is_weighted_v<E>, \
                 "EdgeType must be weighted (not Unweighted).")
 
-#define STATIC_ASSERT_UNWEIGHTED(E)                                            \
-  static_assert(CinderPeak::Traits::is_unweighted_v<E>,                        \
+#define STATIC_ASSERT_UNWEIGHTED(E)                     \
+  static_assert(CinderPeak::Traits::is_unweighted_v<E>, \
                 "EdgeType must be Unweighted.")
 
-#define STATIC_ASSERT_NUMERIC_EDGE(E)                                          \
-  static_assert(CinderPeak::Traits::is_numeric_edge_v<E>,                      \
+#define STATIC_ASSERT_NUMERIC_EDGE(E)                     \
+  static_assert(CinderPeak::Traits::is_numeric_edge_v<E>, \
                 "EdgeType must be numeric for this algorithm.")
 
-#define STATIC_ASSERT_COMPARABLE_VERTEX(V)                                     \
-  static_assert(CinderPeak::Traits::is_comparable_vertex_v<V>,                 \
+#define STATIC_ASSERT_COMPARABLE_VERTEX(V)                     \
+  static_assert(CinderPeak::Traits::is_comparable_vertex_v<V>, \
                 "VertexType must support operator< for this algorithm.")
 
 } // namespace CinderPeak::Traits

--- a/src/PeakLogger.hpp
+++ b/src/PeakLogger.hpp
@@ -24,44 +24,29 @@
 #define COLOR_BOLD_ERROR "\033[1;31m"
 #define COLOR_BOLD_CRIT "\033[1;91m"
 
-enum LogLevel
-{
-  TRACE,
-  DEBUG,
-  INFO,
-  WARNING,
-  ERROR,
-  CRITICAL
-};
+enum LogLevel { TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL };
 
-class Logger
-{
+class Logger {
 public:
-  static void shutdown()
-  {
+  static void shutdown() {
     std::lock_guard<std::mutex> lock(logMutex);
-    if (logFile.is_open())
-    {
+    if (logFile.is_open()) {
       logFile.close();
     }
   }
 
   static void log(const LogLevel &level, const std::string &msg,
                   bool consoleEnabled, bool fileEnabled,
-                  const std::string &logFileP)
-  {
-    if (!consoleEnabled && !fileEnabled)
-    {
+                  const std::string &logFileP) {
+    if (!consoleEnabled && !fileEnabled) {
       return;
     }
 
-    if (consoleEnabled)
-    {
+    if (consoleEnabled) {
       logToConsole(level, msg);
     }
 
-    if (fileEnabled)
-    {
+    if (fileEnabled) {
       ensureFileOpen(logFileP);
       logToFile(level, msg);
     }
@@ -71,10 +56,8 @@ private:
   inline static std::mutex logMutex;
   inline static std::ofstream logFile;
 
-  static const char *levelToString(LogLevel level)
-  {
-    switch (level)
-    {
+  static const char *levelToString(LogLevel level) {
+    switch (level) {
     case LogLevel::TRACE:
       return "TRACE";
     case LogLevel::DEBUG:
@@ -92,10 +75,8 @@ private:
     }
   }
 
-  static const char *levelToColor(LogLevel level)
-  {
-    switch (level)
-    {
+  static const char *levelToColor(LogLevel level) {
+    switch (level) {
     case LogLevel::TRACE:
       return COLOR_TRACE;
     case LogLevel::DEBUG:
@@ -113,9 +94,9 @@ private:
     }
   }
 
-  // Cross-platform, thread-safe helper to eliminate C4996 'localtime' unsafe warning
-  static std::tm getLocalTime(const std::time_t &time_res)
-  {
+  // Cross-platform, thread-safe helper to eliminate C4996 'localtime' unsafe
+  // warning
+  static std::tm getLocalTime(const std::time_t &time_res) {
     std::tm timeinfo;
 #if defined(_MSC_VER)
     // MSVC secure alternative
@@ -125,20 +106,16 @@ private:
     localtime_r(&time_res, &timeinfo);
 #else
     // Fallback if compilation environment is ambiguous
-    if (auto *fallback = std::localtime(&time_res))
-    {
+    if (auto *fallback = std::localtime(&time_res)) {
       timeinfo = *fallback;
-    }
-    else
-    {
+    } else {
       std::memset(&timeinfo, 0, sizeof(std::tm));
     }
 #endif
     return timeinfo;
   }
 
-  static std::string getTimestamp()
-  {
+  static std::string getTimestamp() {
     auto now = std::chrono::system_clock::now();
     auto t_c = std::chrono::system_clock::to_time_t(now);
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -153,16 +130,13 @@ private:
     return oss.str();
   }
 
-  static void ensureFileOpen(const std::string &path)
-  {
-    if (!logFile.is_open())
-    {
+  static void ensureFileOpen(const std::string &path) {
+    if (!logFile.is_open()) {
       logFile.open(path, std::ios::app);
     }
   }
 
-  static void logToConsole(LogLevel level, const std::string &msg)
-  {
+  static void logToConsole(LogLevel level, const std::string &msg) {
     std::lock_guard<std::mutex> lock(logMutex);
 
     std::string timestamp = getTimestamp();
@@ -174,8 +148,7 @@ private:
               << COLOR_RESET << " " << msg << std::endl;
   }
 
-  static void logToFile(LogLevel level, const std::string &msg)
-  {
+  static void logToFile(LogLevel level, const std::string &msg) {
     if (!logFile.is_open())
       return;
 

--- a/src/PeakLogger.hpp
+++ b/src/PeakLogger.hpp
@@ -1,13 +1,13 @@
 #pragma once
 #include <chrono>
+#include <cstring>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <mutex>
 #include <sstream>
 #include <string>
-#include <ctime>
-#include <cstring>
 
 #define COLOR_RESET "\033[0m"
 #define COLOR_WHITE "\033[37m"
@@ -24,29 +24,44 @@
 #define COLOR_BOLD_ERROR "\033[1;31m"
 #define COLOR_BOLD_CRIT "\033[1;91m"
 
-enum LogLevel { TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL };
+enum LogLevel
+{
+  TRACE,
+  DEBUG,
+  INFO,
+  WARNING,
+  ERROR,
+  CRITICAL
+};
 
-class Logger {
+class Logger
+{
 public:
-  static void shutdown() {
+  static void shutdown()
+  {
     std::lock_guard<std::mutex> lock(logMutex);
-    if (logFile.is_open()) {
+    if (logFile.is_open())
+    {
       logFile.close();
     }
   }
+
   static void log(const LogLevel &level, const std::string &msg,
                   bool consoleEnabled, bool fileEnabled,
-                  const std::string &logFileP) {
-
-    if (!consoleEnabled && !fileEnabled) {
+                  const std::string &logFileP)
+  {
+    if (!consoleEnabled && !fileEnabled)
+    {
       return;
     }
 
-    if (consoleEnabled) {
+    if (consoleEnabled)
+    {
       logToConsole(level, msg);
     }
 
-    if (fileEnabled) {
+    if (fileEnabled)
+    {
       ensureFileOpen(logFileP);
       logToFile(level, msg);
     }
@@ -56,8 +71,10 @@ private:
   inline static std::mutex logMutex;
   inline static std::ofstream logFile;
 
-  static const char *levelToString(LogLevel level) {
-    switch (level) {
+  static const char *levelToString(LogLevel level)
+  {
+    switch (level)
+    {
     case LogLevel::TRACE:
       return "TRACE";
     case LogLevel::DEBUG:
@@ -75,8 +92,10 @@ private:
     }
   }
 
-  static const char *levelToColor(LogLevel level) {
-    switch (level) {
+  static const char *levelToColor(LogLevel level)
+  {
+    switch (level)
+    {
     case LogLevel::TRACE:
       return COLOR_TRACE;
     case LogLevel::DEBUG:
@@ -95,7 +114,8 @@ private:
   }
 
   // Cross-platform, thread-safe helper to eliminate C4996 'localtime' unsafe warning
-  static std::tm getLocalTime(const std::time_t &time_res) {
+  static std::tm getLocalTime(const std::time_t &time_res)
+  {
     std::tm timeinfo;
 #if defined(_MSC_VER)
     // MSVC secure alternative
@@ -105,16 +125,20 @@ private:
     localtime_r(&time_res, &timeinfo);
 #else
     // Fallback if compilation environment is ambiguous
-    if (auto* fallback = std::localtime(&time_res)) {
+    if (auto *fallback = std::localtime(&time_res))
+    {
       timeinfo = *fallback;
-    } else {
+    }
+    else
+    {
       std::memset(&timeinfo, 0, sizeof(std::tm));
     }
 #endif
     return timeinfo;
   }
 
-  static std::string getTimestamp() {
+  static std::string getTimestamp()
+  {
     auto now = std::chrono::system_clock::now();
     auto t_c = std::chrono::system_clock::to_time_t(now);
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -124,18 +148,21 @@ private:
     std::tm timeinfo = getLocalTime(t_c);
 
     std::ostringstream oss;
-    oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S") << '.'
-        << std::setw(3) << std::setfill('0') << ms.count();
+    oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S") << '.' << std::setw(3)
+        << std::setfill('0') << ms.count();
     return oss.str();
   }
 
-  static void ensureFileOpen(const std::string &path) {
-    if (!logFile.is_open()) {
+  static void ensureFileOpen(const std::string &path)
+  {
+    if (!logFile.is_open())
+    {
       logFile.open(path, std::ios::app);
     }
   }
 
-  static void logToConsole(LogLevel level, const std::string &msg) {
+  static void logToConsole(LogLevel level, const std::string &msg)
+  {
     std::lock_guard<std::mutex> lock(logMutex);
 
     std::string timestamp = getTimestamp();
@@ -147,7 +174,8 @@ private:
               << COLOR_RESET << " " << msg << std::endl;
   }
 
-  static void logToFile(LogLevel level, const std::string &msg) {
+  static void logToFile(LogLevel level, const std::string &msg)
+  {
     if (!logFile.is_open())
       return;
 
@@ -157,10 +185,6 @@ private:
     const char *levelStr = levelToString(level);
 
     logFile << "[" << timestamp << "] [" << levelStr << "] " << msg;
-    // if (!file.empty() && line != -1 &&
-    //     (level == LogLevel::CRITICAL || level == LogLevel::ERROR)) {
-    //   logFile << " (" << file << ":" << line << ")";
-    // } TODO: Remove it in future
     logFile << std::endl;
   }
 };

--- a/src/PeakLogger.hpp
+++ b/src/PeakLogger.hpp
@@ -6,6 +6,8 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <ctime>
+#include <cstring>
 
 #define COLOR_RESET "\033[0m"
 #define COLOR_WHITE "\033[37m"
@@ -92,6 +94,26 @@ private:
     }
   }
 
+  // Cross-platform, thread-safe helper to eliminate C4996 'localtime' unsafe warning
+  static std::tm getLocalTime(const std::time_t &time_res) {
+    std::tm timeinfo;
+#if defined(_MSC_VER)
+    // MSVC secure alternative
+    localtime_s(&timeinfo, &time_res);
+#elif defined(__unix__) || defined(__APPLE__) || defined(__linux__)
+    // POSIX thread-safe alternative
+    localtime_r(&time_res, &timeinfo);
+#else
+    // Fallback if compilation environment is ambiguous
+    if (auto* fallback = std::localtime(&time_res)) {
+      timeinfo = *fallback;
+    } else {
+      std::memset(&timeinfo, 0, sizeof(std::tm));
+    }
+#endif
+    return timeinfo;
+  }
+
   static std::string getTimestamp() {
     auto now = std::chrono::system_clock::now();
     auto t_c = std::chrono::system_clock::to_time_t(now);
@@ -99,8 +121,10 @@ private:
                   now.time_since_epoch()) %
               1000;
 
+    std::tm timeinfo = getLocalTime(t_c);
+
     std::ostringstream oss;
-    oss << std::put_time(std::localtime(&t_c), "%Y-%m-%d %H:%M:%S") << '.'
+    oss << std::put_time(&timeinfo, "%Y-%m-%d %H:%M:%S") << '.'
         << std::setw(3) << std::setfill('0') << ms.count();
     return oss.str();
   }

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -40,7 +40,6 @@ private:
     ctx->algorithms = std::make_shared<
         Algorithms::CinderPeakAlgorithms<VertexType, EdgeType>>(
         ctx->hybrid_storage);
-
     ctx->runtime->log(LogLevel::CRITICAL, "Log from ctx\n");
     registerMetadataListeners(*ctx);
   }


### PR DESCRIPTION
- Fixed C4996 'localtime' unsafe warning by adding cross-platform secure fallback using localtime_s/localtime_r.
- Fixed C4702 unreachable code warning by introducing an explicit else-branch to the template if constexpr logic.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #243 

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This change addresses outstanding Windows MSVC compiler warnings (C4996 and C4702) to ensure a cleaner and warning-free build process for Windows developers using MSVC.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- **src/PeakLogger.hpp**: Introduced a cross-platform, thread-safe `getLocalTime` helper wrapper that calls `localtime_s` on MSVC and `localtime_r` on POSIX systems, resolving the unsafe C4996 warning. Also cleaned up an old commented-out dead code block at the bottom of the file.
- **src/Concepts.hpp**: Resolved the C4702 unreachable code warning by explicitly wrapping the template `if constexpr` conditionals inside `isTypePrimitive()` and `isGraphWeighted()` with clear `else` branches.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
No new tests were added, as these changes purely resolve compiler configuration warnings without changing the underlying behavior or logic. The files have been verified locally to compile cleanly.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No user-facing or public API changes are introduced.
