### PR TITLE
fix: add missing optsU declaration in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ struct MyEdge : CinderPeak::CinderEdge {
 int main() {
   // --- Complex Graph (custom vertex + weighted edge) ---
 
+  GraphCreationOptions optsU({GraphCreationOptions::Undirected});
+
   CinderGraph<MyVertex, MyEdge> customGraph(optsU);
 
   MyVertex v1(1);


### PR DESCRIPTION
## Which issue does this PR close?

<!--
In the README.md example code, `optsU` was used to create a `CinderGraph` 
but was never declared, which would cause a compilation error if anyone 
tried to run the example.
-->

- Closes #.

## Rationale for this change

<!--
The README example code used `optsU` without declaring it, which would 
cause a compilation error if anyone tried to run the example. This fix 
adds the missing declaration to make the example code valid and runnable.
-->

## What changes are included in this PR?

<!--
  Added missing `GraphCreationOptions optsU({GraphCreationOptions::Undirected});` 
  declaration in README.md before its usage in the custom graph section
-->

## Are these changes tested?

<!--
This is a documentation fix to the README example code. No tests are 
required as no source code was modified.
-->

## Are there any user-facing changes?

<!--
Yes, the README example code is now correct and will compile successfully 
if copied and run by users.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
