### PR TITLE
Fixed incorrect impl_doesEdgeExist log messages in AdjacencyList

### DIFF
--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -297,7 +297,7 @@ public:
       if (p.first == destId)
         return true;
     }
-    runtime.log(LogLevel::INFO, "Edge found.");
+    runtime.log(LogLevel::INFO, "Edge not found.");
     return false;
   }
 
@@ -321,11 +321,11 @@ public:
     const auto &neighbors = _adj.at(srcId);
     for (const auto &p : neighbors) {
       if (p.first == destId && p.second == weight) {
-        runtime.log(LogLevel::INFO, "Edge not exist.");
+        runtime.log(LogLevel::INFO, "Edge exists.");
         return true;
       }
     }
-    runtime.log(LogLevel::INFO, "Edge not exist.");
+    runtime.log(LogLevel::INFO, "Edge not found.");
 
     return false;
   }


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #306 

## Rationale for this change

The boolean overloads of `impl_doesEdgeExist` contained inconsistent log messages that did not match the actual return values. This could cause confusion while debugging or interpreting runtime logs.

## What changes are included in this PR?

* Updated the unweighted `impl_doesEdgeExist` overload to log a non-existence message when returning `false`.
* Updated the weighted `impl_doesEdgeExist` overload to log an existence message when returning `true`.
* Improved log message consistency to accurately reflect the result of the edge lookup.

## Are these changes tested?

Yes. The changes were verified by reviewing the control flow of both overloads and ensuring that the emitted log messages now correspond to the actual return values in each execution path.

## Are there any user-facing changes?

No. This change only affects internal logging behavior and does not modify the public API or graph functionality.
