### PR TITLE
Fix: Remove obsolete TODO logs and resolve spelling/grammar warnings in StorageEngine 

### DIFF
--- a/src/PeakLogger.hpp
+++ b/src/PeakLogger.hpp
@@ -133,10 +133,6 @@ private:
     const char *levelStr = levelToString(level);
 
     logFile << "[" << timestamp << "] [" << levelStr << "] " << msg;
-    // if (!file.empty() && line != -1 &&
-    //     (level == LogLevel::CRITICAL || level == LogLevel::ERROR)) {
-    //   logFile << " (" << file << ":" << line << ")";
-    // } TODO: Remove it in future
     logFile << std::endl;
   }
 };

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -68,14 +68,14 @@ public:
         if constexpr (CinderPeak::Traits::is_primitive_or_string_v<
                           VertexType>) {
           runtime.log(LogLevel::WARNING,
-                      "Failed to add Vertex: Vertex Already Exist. " +
+                      "Failed to add Vertex: Vertex Already Exists. " +
                           vertexStr(v));
           return PeakStatus::VertexAlreadyExists(
               "Primitive Vertex Already Exists");
         } else {
           runtime.log(LogLevel::WARNING,
-                      "Failed to add Non Premitive Vertex: Non Premitive "
-                      "Vertex Already Exist. " +
+                      "Failed to add Non Primitive Vertex: Non Primitive "
+                      "Vertex Already Exists. " +
                           vertexStr(v));
           return PeakStatus::VertexAlreadyExists(
               "Non Primitive Vertex Already Exists");
@@ -91,8 +91,6 @@ public:
 
     // perform string construction and logging outside of the lock to avoid
     // blocking critical sections
-    // TODO: this is a test log for output check so remove it in future.
-    runtime.log(LogLevel::INFO, "Vertex added.");
     return PeakStatus::OK();
   }
 
@@ -105,7 +103,7 @@ public:
     for (const auto &v : vertices) {
       if (_vertex_lookup.find(v) != _vertex_lookup.end()) {
         final_status = PeakStatus::VertexAlreadyExists();
-        runtime.log(LogLevel::WARNING, "Vertex already Exist.");
+        runtime.log(LogLevel::WARNING, "Vertex already Exists.");
         continue;
       }
       VertexId id = _next_vertex_id.fetch_add(1, std::memory_order_relaxed);


### PR DESCRIPTION
## Description
This PR addresses the lingering `TODO` comments, obsolete testing artifacts, and minor warning typos in the `StorageEngine` and `Logger` modules. These cleanups improve the overall code hygiene and ensure that logs reflect only the relevant system state.

### What was changed:
* **`src/StorageEngine/AdjacencyList.hpp`**: 
  * Removed the `TODO: this is a test log...` comment and the accompanying `runtime.log(LogLevel::INFO, "Vertex added.");` from the `impl_addVertex` method.
  * Fixed spelling and grammatical errors in the warning logs (changed `"Premitive"` to `"Primitive"` and `"Exist"` to `"Exists"`).
* **`src/PeakLogger.hpp`**: 
  * Removed the commented-out file/line logging block and its associated `TODO: Remove it in future` marker.



### Issue(s) Resolved
* Fixes #302


### Type of change
- [x] Bug fix / Code Cleanup (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the contribution guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] The changes made are greater than 5 lines of code.
