### PR TITLE
Corrected `updateEdge` return value and propagate storage operation failures

### DIFF
--- a/src/CinderGraph.hpp
+++ b/src/CinderGraph.hpp
@@ -364,14 +364,14 @@ public:
       -> std::enable_if_t<CinderPeak::Traits::is_weighted_v<E>,
                           UpdateEdgeResult> {
     peak_store->log(LogLevel::INFO, "API: Entering updateEdge");
-    auto [status, updatedEdge] = peak_store->updateEdge(src, dest, newWeight);
+    auto [status, previousEdge] = peak_store->updateEdge(src, dest, newWeight);
     if (!status.isOK()) {
       peak_store->log(LogLevel::WARNING, "API: Error in updateEdge");
       Exceptions::handle_exception_map(status);
-      return {newWeight, false};
+      return {EdgeType(), false};
     }
     peak_store->log(LogLevel::INFO, "API: updateEdge completed successfully");
-    return {newWeight, true};
+    return {previousEdge, true};
   }
 
   /**

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -104,10 +104,16 @@ public:
       return status;
     ctx->events.edgeAdded.emit({src, dest, weight});
     if (!op.directed) {
+      PeakStatus rev_status;
       if (op.weighted) {
-        ctx->active_storage->impl_addEdge(dest, src, weight);
+        rev_status = ctx->active_storage->impl_addEdge(dest, src, weight);
       } else {
-        ctx->active_storage->impl_addEdge(dest, src);
+        rev_status = ctx->active_storage->impl_addEdge(dest, src);
+      }
+      if (!rev_status.isOK()) {
+        // Propagate reverse-insert failure to caller so API reflects partial
+        // application rather than silently reporting full success.
+        return rev_status;
       }
       ctx->events.edgeAdded.emit({dest, src, weight});
     }
@@ -125,9 +131,13 @@ public:
           ctx->create_options->hasOption(GraphCreationOptions::Directed);
       if (!isDirected && src != dest) {
         auto rev_result = ctx->active_storage->impl_removeEdge(dest, src);
-        if (rev_result.second.isOK()) {
-          GraphEvents<VertexType, EdgeType>::onEdgeRemove(*ctx, dest, src);
+        if (!rev_result.second.isOK()) {
+          // If reverse removal fails, propagate that failure to caller so the
+          // API can surface the partial failure instead of silently
+          // returning success.
+          return rev_result;
         }
+        GraphEvents<VertexType, EdgeType>::onEdgeRemove(*ctx, dest, src);
       }
     }
     return result;
@@ -139,21 +149,27 @@ public:
     ctx->log(LogLevel::INFO, "Called adjacency:updateEdge() for " +
                                  weightedEdgeStr(src, dest, newWeight));
 
+    auto [currentWeight, currentStatus] =
+        ctx->active_storage->impl_getEdge(src, dest);
+    if (!currentStatus.isOK()) {
+      return {currentStatus, EdgeType()};
+    }
+
     PeakStatus resp =
         ctx->active_storage->impl_updateEdge(src, dest, newWeight);
     if (!resp.isOK()) {
-      return {resp, newWeight};
+      return {resp, EdgeType()};
     }
 
     if (ctx->create_options->hasOption(GraphCreationOptions::Undirected)) {
       PeakStatus resp2 =
           ctx->active_storage->impl_updateEdge(dest, src, newWeight);
       if (!resp2.isOK()) {
-        return {resp2, newWeight};
+        return {resp2, EdgeType()};
       }
     }
 
-    return {PeakStatus::OK(), newWeight};
+    return {PeakStatus::OK(), currentWeight};
   }
 
   std::pair<EdgeType, PeakStatus> getEdge(const VertexType &src,

--- a/tests/integration/CinderGraph/functional/updateEdge_test.cpp
+++ b/tests/integration/CinderGraph/functional/updateEdge_test.cpp
@@ -22,7 +22,7 @@ TEST_F(CinderGraphFunctionalTest, UpdateEdgePrimitive) {
 
   auto [new_weight, status1] = intGraph.updateEdge(1, 2, 50);
   EXPECT_TRUE(status1);
-  EXPECT_EQ(new_weight, 50);
+  EXPECT_EQ(new_weight, 25);
 
   EXPECT_FALSE(intGraph.updateEdge(2, 3, 100).second); // edge doesn't exist
 }
@@ -41,7 +41,7 @@ TEST_F(CinderGraphFunctionalTest, UpdateEdgeString) {
 
   auto [new_weight, status1] = stringGraph.updateEdge("A", "B", 84);
   EXPECT_TRUE(status1);
-  EXPECT_EQ(new_weight, 84);
+  EXPECT_EQ(new_weight, 42);
 
   EXPECT_FALSE(
       stringGraph.updateEdge("B", "C", 100).second); // edge doesn't exist
@@ -64,7 +64,7 @@ TEST_F(CinderGraphFunctionalTest, UpdateCustomEdge) {
 
   auto [new_weight, status1] = customGraph.updateEdge(v1, v2, e2);
   EXPECT_TRUE(status1);
-  EXPECT_EQ(new_weight.edge_weight, 7.0f);
+  EXPECT_EQ(new_weight.edge_weight, 3.5f);
 
   EXPECT_FALSE(customGraph.updateEdge(v2, v1, e1).second); // edge doesn't exist
 }

--- a/tests/integration/CinderGraph/scenarios/UpdateAndQueryFlow_test.cpp
+++ b/tests/integration/CinderGraph/scenarios/UpdateAndQueryFlow_test.cpp
@@ -23,7 +23,7 @@ TEST_F(UpdateAndQueryFlowTest, AddUpdateQuery) {
 
   auto [newWeight, updated] = intGraph.updateEdge(1, 2, 10);
   EXPECT_TRUE(updated);
-  EXPECT_EQ(newWeight, 10);
+  EXPECT_EQ(newWeight, 5);
 
   auto weight2 = intGraph.getEdge(1, 2);
   EXPECT_TRUE(weight2.has_value());
@@ -38,15 +38,18 @@ TEST_F(UpdateAndQueryFlowTest, MultipleUpdates) {
   EXPECT_TRUE(intGraph.addEdge(10, 20, 1).second);
 
   int weights[] = {2, 5, 10, 25, 50};
+  int previousWeight = 1;
 
   for (int w : weights) {
     auto [updatedWeight, success] = intGraph.updateEdge(10, 20, w);
     EXPECT_TRUE(success);
-    EXPECT_EQ(updatedWeight, w);
+    EXPECT_EQ(updatedWeight, previousWeight);
 
     auto currentWeight = intGraph.getEdge(10, 20);
     EXPECT_TRUE(currentWeight.has_value());
     EXPECT_EQ(*currentWeight, w);
+
+    previousWeight = w;
   }
 
   auto finalWeight = intGraph.getEdge(10, 20);


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #313 .

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
1. The API documentation specifies that `updateEdge` should return the previous edge weight, but it was incorrectly returning the newly updated weight.
2. Operations like `addEdge` and `removeEdge` were silently neglecting reverse-operation failures from the storage layer.
3. This silent failure could lead to an inconsistent graph state where the API reports success despite partial underlying failures.
## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1) In CinderGraph.hpp and PeakStore.hpp modified `updateEdge` to return `previousEdge`, added validation in `addEdge` and `removeEdge`
2) In `updateEdge_test.cpp` and `UpdateAndQueryFlow_test.cpp` updated `EXPECT_EQ` assertions to match the previous weights rather than the newly applied weights.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes, existing functional and scenario integration tests were updated.
The tests now explicitly verify that `updateEdge` returns the correct historical weight and that statuses validate successfully.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Yes. The return payload of updateEdge has changed from the new weight to the previous weight.
Client applications relying on the returned weight will need to adjust their logic.
Edge addition and removal operations will now actively surface error statuses instead of failing silently.