### PR TITLE
Fix #309: Data Race in AdjacencyList Getters via Safe Returns and Vis…

### DIFF
--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -454,12 +454,21 @@ public:
     return PeakStatus::OK();
   }
 
-  const std::unordered_map<
+  std::unordered_map<
       CinderPeak::VertexId,
-      std::vector<std::pair<CinderPeak::VertexId, EdgeType>>> &
+      std::vector<std::pair<CinderPeak::VertexId, EdgeType>>>
   getInternalAdjacency() const {
     runtime.log(LogLevel::DEBUG, "Executing getInternalAdjacency");
+    std::shared_lock<std::shared_mutex> lock(_mtx);
     return _adj;
+  }
+
+  template <typename Func>
+  void forEachAdjacency(Func&& func) const {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    for (const auto& pair : _adj) {
+      func(pair.first, pair.second);
+    }
   }
   struct DotConfig {
     std::string graphName = "G";
@@ -517,10 +526,19 @@ public:
     return ss.str();
   }
 
-  const std::unordered_map<CinderPeak::VertexId, VertexType> &
+  std::unordered_map<CinderPeak::VertexId, VertexType>
   getVertexDataMap() const {
     runtime.log(LogLevel::DEBUG, "Executing getVertexDataMap");
+    std::shared_lock<std::shared_mutex> lock(_mtx);
     return _vertex_data;
+  }
+
+  template <typename Func>
+  void forEachVertexData(Func&& func) const {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    for (const auto& pair : _vertex_data) {
+      func(pair.first, pair.second);
+    }
   }
 };
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #309.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In `src/StorageEngine/AdjacencyList.hpp`, the `getInternalAdjacency()` and `getVertexDataMap()` methods were returning unprotected const references to the internal `std::unordered_map` data structures. This allowed read-write data races because external callers could iterate over the maps while a concurrent mutation (e.g. `addVertex`) forced the map to rehash, leading to segmentation faults.

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR addresses the issue by offering a dual-approach solution to accommodate both safety and performance:
1. **Safe Copy Returns:** Removed the dangling references (`&`) from the return signatures of `getInternalAdjacency()` and `getVertexDataMap()`. These methods now safely acquire a `std::shared_lock` and return the map by value, providing a safe fallback for existing callers.
2. **Thread-Safe Visitors:** Introduced two new high-performance lambda visitor methods (`forEachAdjacency` and `forEachVertexData`). These methods internally acquire the `std::shared_lock` and execute a passed function over each element, allowing zero-copy thread-safe iteration across the graph's internal data structures.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes. The underlying read-write crash test simulating concurrent `addVertex()` (Thread 1) and map reads (Thread 2) now resolves successfully without triggering segmentation faults or ThreadSanitizer warnings because the state is properly protected by `std::shared_lock`.

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes, there is a minor API change. Callers previously receiving a `const reference` to the internal maps from `getInternalAdjacency()` and `getVertexDataMap()` will now receive a standard copy of the map. In the vast majority of C++ contexts (e.g. `const auto& x = store.getVertexDataMap()`), the lifetime of the returned temporary is automatically extended and will compile successfully without dangling, making this backward compatible.

For users wishing to avoid the memory overhead of copying the graph, they can migrate to the newly added `forEachAdjacency()` and `forEachVertexData()` methods.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
