### PR TITLE
fix(warnings): resolve [[nodiscard]] compiler warnings in HybridCSR_C…

### DIFF
--- a/tests/unit/HybridCSR_COO/HybridStorageShardMT.cpp
+++ b/tests/unit/HybridCSR_COO/HybridStorageShardMT.cpp
@@ -46,10 +46,10 @@ protected:
 
 TEST_F(HybridStorageShardTestMT, ConcurrentReads) {
   for (int i = 0; i < 100; ++i) {
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
   }
   for (int i = 0; i < 100; ++i) {
-    graph->impl_addEdge(i, (i + 1) % 100, i * 10);
+    (void)graph->impl_addEdge(i, (i + 1) % 100, i * 10);
   }
 
   std::atomic<bool> stop_flag{false};
@@ -71,13 +71,13 @@ TEST_F(HybridStorageShardTestMT, ConcurrentReads) {
 
 TEST_F(HybridStorageShardTestMT, MixedReadWrite) {
   for (int i = 0; i < 50; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   std::atomic<bool> stop_flag{false};
   auto writer = [&]() {
     int counter = 0;
     while (!stop_flag.load()) {
-      graph->impl_addEdge(counter % 50, (counter + 1) % 50, counter);
+      (void)graph->impl_addEdge(counter % 50, (counter + 1) % 50, counter);
       counter++;
     }
   };
@@ -101,14 +101,14 @@ TEST_F(HybridStorageShardTestMT, MixedReadWrite) {
 TEST_F(HybridStorageShardTestMT, StressTestMultipleThreads) {
   const int NUM_THREADS = 8;
   for (int i = 0; i < 500; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   auto worker = [&](int id) {
     for (int i = 0; i < 2000; ++i) {
       int src = (i + id) % 500;
       int dst = (i * 13 + id) % 500;
       if (src != dst)
-        graph->impl_addEdge(src, dst, src + dst);
+        (void)graph->impl_addEdge(src, dst, src + dst);
     }
   };
 
@@ -125,7 +125,7 @@ TEST_F(HybridStorageShardTestMT, StressTestMultipleThreads) {
 
 TEST_F(HybridStorageShardTestMT, ProperRaceDetection) {
   for (int i = 0; i < 10; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   std::atomic<bool> stop_flag{false};
   std::atomic<int> write_counter{0};
@@ -133,7 +133,7 @@ TEST_F(HybridStorageShardTestMT, ProperRaceDetection) {
   auto writer = [&]() {
     while (!stop_flag.load()) {
       int val = write_counter.fetch_add(1);
-      graph->impl_addEdge(0, 1, val);
+      (void)graph->impl_addEdge(0, 1, val);
     }
   };
 
@@ -162,17 +162,17 @@ TEST_F(HybridStorageShardTestMT, ProperRaceDetection) {
 
 TEST_F(HybridStorageShardTestMT, PerformanceRegression) {
   for (int i = 0; i < 2000; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   auto edges = generateTestEdges(2000, 5000);
   for (auto &[src, dst, w] : edges)
-    graph->impl_addEdge(src, dst, w);
+    (void)graph->impl_addEdge(src, dst, w);
 
   auto start = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < 10000; ++i) {
     int src = i % 2000;
     int dst = (i * 17) % 2000;
-    graph->impl_doesEdgeExist(src, dst);
+    (void)graph->impl_doesEdgeExist(src, dst);
   }
   auto end = std::chrono::high_resolution_clock::now();
   auto duration_ms =
@@ -190,12 +190,12 @@ TEST_F(HybridStorageShardTestMT, ConcurrentVertexAdditionAndRemoval) {
   std::atomic<int> vertex_counter{50};
 
   for (int i = 0; i < 50; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   auto adder = [&]() {
     for (int i = 0; i < NUM_OPERATIONS; ++i) {
       int v = vertex_counter.fetch_add(1);
-      graph->impl_addVertex(v);
+      (void)graph->impl_addVertex(v);
     }
   };
 
@@ -206,7 +206,7 @@ TEST_F(HybridStorageShardTestMT, ConcurrentVertexAdditionAndRemoval) {
 
     for (int i = 0; i < NUM_OPERATIONS; ++i) {
       int v = dis(gen);
-      graph->impl_removeVertex(v);
+      (void)graph->impl_removeVertex(v);
     }
   };
 
@@ -249,9 +249,9 @@ TEST_F(HybridStorageShardTestMT, EdgeUpdateRaceConditions) {
   const int NUM_UPDATES = 1000;
 
   for (int i = 0; i < 10; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
-  graph->impl_addEdge(0, 1, 100);
+  (void)graph->impl_addEdge(0, 1, 100);
 
   std::vector<std::thread> threads;
   std::atomic<int> update_count{0};
@@ -296,7 +296,7 @@ TEST_F(HybridStorageShardTestMT, MixedOperationsStressTest) {
   const int NUM_VERTICES = 100;
 
   for (int i = 0; i < NUM_VERTICES; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   std::atomic<bool> stop_flag{false};
   std::atomic<int> operations_count{0};
@@ -319,19 +319,19 @@ TEST_F(HybridStorageShardTestMT, MixedOperationsStressTest) {
 
       switch (op) {
       case 0:
-        graph->impl_addEdge(src, dst, weight_dis(gen));
+        (void)graph->impl_addEdge(src, dst, weight_dis(gen));
         break;
       case 1:
-        graph->impl_doesEdgeExist(src, dst);
+        (void)graph->impl_doesEdgeExist(src, dst);
         break;
       case 2:
-        graph->impl_getEdge(src, dst);
+        (void)graph->impl_getEdge(src, dst);
         break;
       case 3:
-        graph->impl_updateEdge(src, dst, weight_dis(gen));
+        (void)graph->impl_updateEdge(src, dst, weight_dis(gen));
         break;
       case 4:
-        graph->impl_hasVertex(src);
+        (void)graph->impl_hasVertex(src);
         break;
       }
 
@@ -354,10 +354,10 @@ TEST_F(HybridStorageShardTestMT, BuildDuringConcurrentAccess) {
   const int NUM_THREADS = 4;
 
   for (int i = 0; i < 1000; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   for (int i = 0; i < 5000; ++i)
-    graph->impl_addEdge(i % 1000, (i + 1) % 1000, i);
+    (void)graph->impl_addEdge(i % 1000, (i + 1) % 1000, i);
 
   std::atomic<bool> stop_flag{false};
 
@@ -369,7 +369,7 @@ TEST_F(HybridStorageShardTestMT, BuildDuringConcurrentAccess) {
     while (!stop_flag.load()) {
       int src = dis(gen);
       int dst = dis(gen);
-      graph->impl_getEdge(src, dst);
+      (void)graph->impl_getEdge(src, dst);
     }
   };
 
@@ -384,9 +384,9 @@ TEST_F(HybridStorageShardTestMT, BuildDuringConcurrentAccess) {
       int dst = vertex_dis(gen);
 
       if (src != dst) {
-        graph->impl_addVertex(src);
-        graph->impl_addVertex(dst);
-        graph->impl_addEdge(src, dst, weight_dis(gen));
+        (void)graph->impl_addVertex(src);
+        (void)graph->impl_addVertex(dst);
+        (void)graph->impl_addEdge(src, dst, weight_dis(gen));
       }
     }
   };
@@ -412,10 +412,10 @@ TEST_F(HybridStorageShardTestMT, ClearEdgesUnderLoad) {
   const int NUM_THREADS = 4;
 
   for (int i = 0; i < 100; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   for (int i = 0; i < 500; ++i)
-    graph->impl_addEdge(i % 100, (i + 1) % 100, i);
+    (void)graph->impl_addEdge(i % 100, (i + 1) % 100, i);
 
   std::atomic<bool> stop_flag{false};
 
@@ -427,14 +427,14 @@ TEST_F(HybridStorageShardTestMT, ClearEdgesUnderLoad) {
     while (!stop_flag.load()) {
       int src = dis(gen);
       int dst = dis(gen);
-      graph->impl_getEdge(src, dst);
+      (void)graph->impl_getEdge(src, dst);
     }
   };
 
   auto clear_edges = [&]() {
     for (int i = 0; i < 5; ++i) {
       std::this_thread::sleep_for(std::chrono::milliseconds(50));
-      graph->impl_clearEdges();
+      (void)graph->impl_clearEdges();
     }
   };
 
@@ -458,9 +458,9 @@ TEST_F(HybridStorageShardTestMT, StringTypeConcurrency) {
   const int NUM_THREADS = 4;
   const int NUM_OPERATIONS = 1000;
 
-  string_graph->impl_addVertex("vertex0");
-  string_graph->impl_addVertex("vertex1");
-  string_graph->impl_addVertex("vertex2");
+  (void)string_graph->impl_addVertex("vertex0");
+  (void)string_graph->impl_addVertex("vertex1");
+  (void)string_graph->impl_addVertex("vertex2");
 
   std::atomic<bool> stop_flag{false};
   std::atomic<int> operations_count{0};
@@ -485,7 +485,7 @@ TEST_F(HybridStorageShardTestMT, StringTypeConcurrency) {
         int src_idx = vertex_dis(gen);
         int dst_idx = vertex_dis(gen);
         if (src_idx != dst_idx) {
-          string_graph->impl_addEdge(vertices[src_idx], vertices[dst_idx],
+          (void)string_graph->impl_addEdge(vertices[src_idx], vertices[dst_idx],
                                      weight_dis(gen));
         }
         break;
@@ -493,14 +493,14 @@ TEST_F(HybridStorageShardTestMT, StringTypeConcurrency) {
       case 1: {
         int src_idx = vertex_dis(gen);
         int dst_idx = vertex_dis(gen);
-        string_graph->impl_getEdge(vertices[src_idx], vertices[dst_idx]);
+        (void)string_graph->impl_getEdge(vertices[src_idx], vertices[dst_idx]);
         break;
       }
       case 2:
-        string_graph->impl_addVertex(new_vertices[new_vertex_dis(gen)]);
+        (void)string_graph->impl_addVertex(new_vertices[new_vertex_dis(gen)]);
         break;
       case 3:
-        string_graph->impl_hasVertex(vertices[vertex_dis(gen)]);
+        (void)string_graph->impl_hasVertex(vertices[vertex_dis(gen)]);
         break;
       }
 
@@ -525,7 +525,7 @@ TEST_F(HybridStorageShardTestMT, MemoryConsistencyAfterConcurrentOperations) {
   const int NUM_VERTICES = 20;
 
   for (int i = 0; i < NUM_VERTICES; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   auto worker = [&](int thread_id) {
     std::random_device rd;
@@ -544,10 +544,10 @@ TEST_F(HybridStorageShardTestMT, MemoryConsistencyAfterConcurrentOperations) {
 
       switch (op_dis(gen)) {
       case 0:
-        graph->impl_addEdge(src, dst, weight_dis(gen));
+        (void)graph->impl_addEdge(src, dst, weight_dis(gen));
         break;
       case 1:
-        graph->impl_updateEdge(src, dst, weight_dis(gen));
+        (void)graph->impl_updateEdge(src, dst, weight_dis(gen));
         break;
       }
     }
@@ -572,9 +572,9 @@ TEST_F(HybridStorageShardTestMT, HighContentionOnSingleVertex) {
   const int NUM_THREADS = 8;
   const int NUM_OPERATIONS = 2000;
 
-  graph->impl_addVertex(0);
-  graph->impl_addVertex(1);
-  graph->impl_addEdge(0, 1, 100);
+  (void)graph->impl_addVertex(0);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addEdge(0, 1, 100);
 
   std::atomic<bool> stop_flag{false};
   std::atomic<int> success_count{0};
@@ -595,13 +595,13 @@ TEST_F(HybridStorageShardTestMT, HighContentionOnSingleVertex) {
         }
         break;
       case 1:
-        graph->impl_getEdge(0, 1);
+        (void)graph->impl_getEdge(0, 1);
         break;
       case 2:
-        graph->impl_doesEdgeExist(0, 1);
+        (void)graph->impl_doesEdgeExist(0, 1);
         break;
       case 3:
-        graph->impl_addEdge(0, 1, weight_dis(gen));
+        (void)graph->impl_addEdge(0, 1, weight_dis(gen));
         break;
       }
     }
@@ -627,7 +627,7 @@ TEST_F(HybridStorageShardTestMT, LongRunningStressTest) {
   const int DURATION_MS = 5000;
 
   for (int i = 0; i < 100; ++i)
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
 
   std::atomic<bool> stop_flag{false};
   std::atomic<int> operations_count{0};
@@ -652,19 +652,19 @@ TEST_F(HybridStorageShardTestMT, LongRunningStressTest) {
 
       switch (op) {
       case 0:
-        graph->impl_addEdge(src, dst, weight_dis(gen));
+        (void)graph->impl_addEdge(src, dst, weight_dis(gen));
         break;
       case 1:
-        graph->impl_getEdge(src, dst);
+        (void)graph->impl_getEdge(src, dst);
         break;
       case 2:
-        graph->impl_updateEdge(src, dst, weight_dis(gen));
+        (void)graph->impl_updateEdge(src, dst, weight_dis(gen));
         break;
       case 3:
-        graph->impl_hasVertex(src);
+        (void)graph->impl_hasVertex(src);
         break;
       case 4:
-        graph->impl_doesEdgeExist(src, dst);
+        (void)graph->impl_doesEdgeExist(src, dst);
         break;
       }
 

--- a/tests/unit/HybridCSR_COO/HybridStorageShardMT.cpp
+++ b/tests/unit/HybridCSR_COO/HybridStorageShardMT.cpp
@@ -486,7 +486,7 @@ TEST_F(HybridStorageShardTestMT, StringTypeConcurrency) {
         int dst_idx = vertex_dis(gen);
         if (src_idx != dst_idx) {
           (void)string_graph->impl_addEdge(vertices[src_idx], vertices[dst_idx],
-                                     weight_dis(gen));
+                                           weight_dis(gen));
         }
         break;
       }

--- a/tests/unit/HybridCSR_COO/Orchestrator_test.cpp
+++ b/tests/unit/HybridCSR_COO/Orchestrator_test.cpp
@@ -38,9 +38,9 @@ TEST_F(HybridStorageOrchestratorTest, RebuildFromAdjList) {
 }
 
 TEST_F(HybridStorageOrchestratorTest, MergeBuffer) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 100);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 100);
 
   graph->orchestrator_mergeBuffer();
 
@@ -50,9 +50,9 @@ TEST_F(HybridStorageOrchestratorTest, MergeBuffer) {
 }
 
 TEST_F(HybridStorageOrchestratorTest, ClearAll) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 50);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 50);
 
   graph->orchestrator_clearAll();
 
@@ -63,9 +63,9 @@ TEST_F(HybridStorageOrchestratorTest, ClearAll) {
 }
 
 TEST_F(HybridStorageOrchestratorTest, BuildIfNeeded) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 50); // In COO
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 50); // In COO
 
   graph->orchestrator_buildIfNeeded();
 
@@ -76,13 +76,13 @@ TEST_F(HybridStorageOrchestratorTest, BuildIfNeeded) {
 
 TEST_F(HybridStorageOrchestratorTest, SetCOOThreshold) {
   graph->setCOOThreshold(10);
-  graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(1);
   SUCCEED();
 }
 
 TEST_F(HybridStorageOrchestratorTest, ConcurrentMergeAndAdd) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
 
   std::atomic<bool> done{false};
 
@@ -100,7 +100,7 @@ TEST_F(HybridStorageOrchestratorTest, ConcurrentMergeAndAdd) {
   for (int i = 0; i < NUM_THREADS; ++i) {
     writers.emplace_back([&, i]() {
       for (int j = 0; j < NUM_OPS; ++j) {
-        graph->impl_addEdge(1, 2, j + (i * 1000));
+        (void)graph->impl_addEdge(1, 2, j + (i * 1000));
       }
     });
   }

--- a/tests/unit/HybridCSR_COO/addEdge_test.cpp
+++ b/tests/unit/HybridCSR_COO/addEdge_test.cpp
@@ -43,7 +43,7 @@ protected:
 TEST_F(HybridStorageShardTest, AddEdge_Basic) {
   std::vector<int> vertices = {1, 2, 3, 4, 5};
   for (int v : vertices) {
-    graph->impl_addVertex(v);
+    (void)graph->impl_addVertex(v);
   }
   EXPECT_TRUE(graph->impl_addEdge(1, 2, 10).isOK())
       << "Failed to add edge (1,2)";
@@ -65,7 +65,7 @@ TEST_F(HybridStorageShardTest, AddEdge_Basic) {
 
 // Test adding edges with non-existent vertices
 TEST_F(HybridStorageShardTest, AddEdge_NonExistentVertices) {
-  graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(1);
   EXPECT_FALSE(graph->impl_addEdge(99, 1, 10).isOK())
       << "Added edge with non-existent source";
   EXPECT_FALSE(graph->impl_addEdge(1, 99, 10).isOK())
@@ -76,8 +76,8 @@ TEST_F(HybridStorageShardTest, AddEdge_NonExistentVertices) {
 
 // Test adding edges with negative weights
 TEST_F(HybridStorageShardTest, AddEdge_NegativeWeights) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
   EXPECT_TRUE(graph->impl_addEdge(1, 2, -100).isOK())
       << "Failed to add edge with negative weight";
   auto [weight, status] = graph->impl_getEdge(1, 2);
@@ -87,8 +87,8 @@ TEST_F(HybridStorageShardTest, AddEdge_NegativeWeights) {
 
 // Test adding edges with zero weights
 TEST_F(HybridStorageShardTest, AddEdge_ZeroWeights) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
   EXPECT_TRUE(graph->impl_addEdge(1, 2, 0).isOK())
       << "Failed to add edge with zero weight";
   auto [weight, status] = graph->impl_getEdge(1, 2);
@@ -98,14 +98,14 @@ TEST_F(HybridStorageShardTest, AddEdge_ZeroWeights) {
 
 // Test COO buffer priority (multiple edges)
 TEST_F(HybridStorageShardTest, AddEdge_COOBufferPriority) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 100);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 100);
   for (int i = 3; i < 1027; ++i) {
-    graph->impl_addVertex(i);
-    graph->impl_addEdge(1, i, i);
+    (void)graph->impl_addVertex(i);
+    (void)graph->impl_addEdge(1, i, i);
   }
-  graph->impl_addEdge(1, 2, 999);
+  (void)graph->impl_addEdge(1, 2, 999);
   auto [weight, status] = graph->impl_getEdge(1, 2);
   EXPECT_TRUE(status.isOK()) << "Edge (1,2) not found";
   EXPECT_EQ(weight, 999) << "Incorrect weight after COO buffer priority";
@@ -113,11 +113,11 @@ TEST_F(HybridStorageShardTest, AddEdge_COOBufferPriority) {
 
 // Test COO buffer overwrite
 TEST_F(HybridStorageShardTest, AddEdge_COOBufferOverwrite) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 10);
-  graph->impl_addEdge(1, 2, 20);
-  graph->impl_addEdge(1, 2, 30);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 10);
+  (void)graph->impl_addEdge(1, 2, 20);
+  (void)graph->impl_addEdge(1, 2, 30);
   auto [weight, status] = graph->impl_getEdge(1, 2);
   EXPECT_TRUE(status.isOK()) << "Edge (1,2) not found";
   EXPECT_EQ(weight, 30) << "Incorrect weight after overwrite";
@@ -125,9 +125,9 @@ TEST_F(HybridStorageShardTest, AddEdge_COOBufferOverwrite) {
 
 // Test adding edges with string vertices
 TEST_F(HybridStorageShardTest, AddEdge_String) {
-  string_graph->impl_addVertex("prasad");
-  string_graph->impl_addVertex("omkar");
-  string_graph->impl_addVertex("tejas");
+  (void)string_graph->impl_addVertex("prasad");
+  (void)string_graph->impl_addVertex("omkar");
+  (void)string_graph->impl_addVertex("tejas");
   EXPECT_TRUE(string_graph->impl_addEdge("prasad", "omkar", 1.5).isOK())
       << "Failed to add string edge";
   EXPECT_TRUE(string_graph->impl_addEdge("omkar", "tejas", 2.7).isOK())
@@ -141,8 +141,8 @@ TEST_F(HybridStorageShardTest, AddEdge_String) {
 
 // Test concurrent edge addition
 TEST_F(HybridStorageShardTest, AddEdge_Concurrent) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
   std::vector<std::thread> threads;
   const int NUM_THREADS = 5;
   for (int i = 0; i < NUM_THREADS; ++i) {

--- a/tests/unit/HybridCSR_COO/clearEdges_test.cpp
+++ b/tests/unit/HybridCSR_COO/clearEdges_test.cpp
@@ -23,7 +23,7 @@ protected:
 TEST_F(HybridStorageShardTest, ClearEdges_Basic) {
   std::vector<int> vertices = {1, 2, 3, 4, 5};
   for (int v : vertices) {
-    graph->impl_addVertex(v);
+    (void)graph->impl_addVertex(v);
   }
   EXPECT_TRUE(graph->impl_addEdge(1, 2).isOK()) << "Failed to add edge (1,2)";
   EXPECT_TRUE(graph->impl_addEdge(2, 3).isOK()) << "Failed to add edge (2,3)";
@@ -54,9 +54,9 @@ TEST_F(HybridStorageShardTest, ClearEdges_EmptyGraph) {
 
 // Test clearing edges in string graph
 TEST_F(HybridStorageShardTest, ClearEdges_String) {
-  string_graph->impl_addVertex("prasad");
-  string_graph->impl_addVertex("omkar");
-  string_graph->impl_addEdge("prasad", "omkar", 1.5);
+  (void)string_graph->impl_addVertex("prasad");
+  (void)string_graph->impl_addVertex("omkar");
+  (void)string_graph->impl_addEdge("prasad", "omkar", 1.5);
   EXPECT_TRUE(string_graph->impl_clearEdges().isOK())
       << "Failed to clear string edges";
   EXPECT_FALSE(string_graph->impl_doesEdgeExist("prasad", "omkar"))

--- a/tests/unit/HybridCSR_COO/doesEdgeExist_test.cpp
+++ b/tests/unit/HybridCSR_COO/doesEdgeExist_test.cpp
@@ -32,14 +32,14 @@ TEST_F(HybridStorageShardTest, DoesEdgeExist_EmptyGraph) {
 // Test advanced edge existence checks
 TEST_F(HybridStorageShardTest, DoesEdgeExist_Advanced) {
   for (int i = 1; i <= 5; ++i) {
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
   }
-  graph->impl_addEdge(1, 2, 12);
-  graph->impl_addEdge(1, 3, 13);
-  graph->impl_addEdge(1, 4, 14);
-  graph->impl_addEdge(2, 3, 23);
-  graph->impl_addEdge(3, 4, 34);
-  graph->impl_addEdge(4, 5, 45);
+  (void)graph->impl_addEdge(1, 2, 12);
+  (void)graph->impl_addEdge(1, 3, 13);
+  (void)graph->impl_addEdge(1, 4, 14);
+  (void)graph->impl_addEdge(2, 3, 23);
+  (void)graph->impl_addEdge(3, 4, 34);
+  (void)graph->impl_addEdge(4, 5, 45);
   EXPECT_TRUE(graph->impl_doesEdgeExist(1, 2)) << "Edge (1,2) not found";
   EXPECT_TRUE(graph->impl_doesEdgeExist(1, 3)) << "Edge (1,3) not found";
   EXPECT_TRUE(graph->impl_doesEdgeExist(4, 5)) << "Edge (4,5) not found";
@@ -57,9 +57,9 @@ TEST_F(HybridStorageShardTest, DoesEdgeExist_Advanced) {
 
 // Test concurrent edge existence checks
 TEST_F(HybridStorageShardTest, DoesEdgeExist_Concurrent) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 10);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 10);
   std::vector<std::thread> threads;
   const int NUM_THREADS = 10;
   for (int i = 0; i < NUM_THREADS; ++i) {

--- a/tests/unit/HybridCSR_COO/getEdge_test.cpp
+++ b/tests/unit/HybridCSR_COO/getEdge_test.cpp
@@ -30,14 +30,14 @@ TEST_F(HybridStorageShardTest, GetEdge_EmptyGraph) {
 // Test advanced edge retrieval
 TEST_F(HybridStorageShardTest, GetEdge_Advanced) {
   for (int i = 1; i <= 5; ++i) {
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
   }
-  graph->impl_addEdge(1, 2, 12);
-  graph->impl_addEdge(1, 3, 13);
-  graph->impl_addEdge(1, 4, 14);
-  graph->impl_addEdge(2, 3, 23);
-  graph->impl_addEdge(3, 4, 34);
-  graph->impl_addEdge(4, 5, 45);
+  (void)graph->impl_addEdge(1, 2, 12);
+  (void)graph->impl_addEdge(1, 3, 13);
+  (void)graph->impl_addEdge(1, 4, 14);
+  (void)graph->impl_addEdge(2, 3, 23);
+  (void)graph->impl_addEdge(3, 4, 34);
+  (void)graph->impl_addEdge(4, 5, 45);
   auto [w1, s1] = graph->impl_getEdge(1, 2);
   EXPECT_TRUE(s1.isOK()) << "Edge (1,2) not found";
   EXPECT_EQ(w1, 12) << "Incorrect weight for edge (1,2)";

--- a/tests/unit/HybridCSR_COO/hasVertex_test.cpp
+++ b/tests/unit/HybridCSR_COO/hasVertex_test.cpp
@@ -27,8 +27,8 @@ protected:
 };
 
 TEST_F(HybridStorageShardTest, HasVertices) {
-  graph->impl_addVertex(40);
-  graph->impl_addVertex(49);
+  (void)graph->impl_addVertex(40);
+  (void)graph->impl_addVertex(49);
   EXPECT_TRUE(graph->impl_hasVertex(40));
   EXPECT_TRUE(graph->impl_hasVertex(49));
   EXPECT_FALSE(graph->impl_hasVertex(404));
@@ -48,7 +48,7 @@ TEST_F(HybridStorageShardTest, HasVertices_MultipleAdditions) {
   std::vector<int> vertices = {1, 5, 10, 15, 20, 25, 30};
 
   for (int v : vertices) {
-    testGraph->impl_addVertex(v);
+    (void)testGraph->impl_addVertex(v);
   }
 
   for (int v : vertices) {
@@ -62,13 +62,13 @@ TEST_F(HybridStorageShardTest, HasVertices_MultipleAdditions) {
 
 TEST_F(HybridStorageShardTest, HasVertices_Deleted) {
   auto testGraph = std::make_unique<HybridCSR_COO<int, int>>();
-  testGraph->impl_addVertex(100);
-  testGraph->impl_addVertex(200);
-  testGraph->impl_addVertex(300);
+  (void)testGraph->impl_addVertex(100);
+  (void)testGraph->impl_addVertex(200);
+  (void)testGraph->impl_addVertex(300);
 
   EXPECT_TRUE(testGraph->impl_hasVertex(200));
 
-  testGraph->impl_removeVertex(200);
+  (void)testGraph->impl_removeVertex(200);
   EXPECT_FALSE(testGraph->impl_hasVertex(200));
   EXPECT_TRUE(testGraph->impl_hasVertex(100));
   EXPECT_TRUE(testGraph->impl_hasVertex(300));
@@ -77,13 +77,13 @@ TEST_F(HybridStorageShardTest, HasVertices_Deleted) {
 TEST_F(HybridStorageShardTest, HasVertices_Mix) {
   auto testGraph = std::make_unique<HybridCSR_COO<int, int>>();
 
-  testGraph->impl_addVertex(75);
+  (void)testGraph->impl_addVertex(75);
   EXPECT_TRUE(testGraph->impl_hasVertex(75));
 
-  testGraph->impl_removeVertex(75);
+  (void)testGraph->impl_removeVertex(75);
   EXPECT_FALSE(testGraph->impl_hasVertex(75));
 
-  testGraph->impl_addVertex(75);
+  (void)testGraph->impl_addVertex(75);
   EXPECT_TRUE(testGraph->impl_hasVertex(75));
 }
 
@@ -92,11 +92,11 @@ TEST_F(HybridStorageShardTest, HasVertices_DeleteAll) {
   std::vector<int> vertices = {1, 2, 3, 4, 5};
 
   for (int v : vertices) {
-    testGraph->impl_addVertex(v);
+    (void)testGraph->impl_addVertex(v);
   }
 
   for (int v : vertices) {
-    testGraph->impl_removeVertex(v);
+    (void)testGraph->impl_removeVertex(v);
   }
 
   for (int v : vertices) {
@@ -105,17 +105,17 @@ TEST_F(HybridStorageShardTest, HasVertices_DeleteAll) {
 }
 
 TEST_F(HybridStorageShardTest, HasVertices_String) {
-  string_graph->impl_addVertex("A");
-  string_graph->impl_addVertex("B");
-  string_graph->impl_addVertex("C");
+  (void)string_graph->impl_addVertex("A");
+  (void)string_graph->impl_addVertex("B");
+  (void)string_graph->impl_addVertex("C");
   EXPECT_TRUE(string_graph->impl_hasVertex("A"));
   EXPECT_TRUE(string_graph->impl_hasVertex("B"));
   EXPECT_TRUE(string_graph->impl_hasVertex("C"));
   EXPECT_FALSE(string_graph->impl_hasVertex("D"));
   EXPECT_FALSE(string_graph->impl_hasVertex(""));
 
-  string_graph->impl_addVertex("apple");
-  string_graph->impl_addVertex("banana");
+  (void)string_graph->impl_addVertex("apple");
+  (void)string_graph->impl_addVertex("banana");
 
   EXPECT_TRUE(string_graph->impl_hasVertex("apple"));
   EXPECT_TRUE(string_graph->impl_hasVertex("banana"));
@@ -127,7 +127,7 @@ TEST_F(HybridStorageShardTest, HasVertices_LargeGraph) {
   const int numVertices = 100000;
 
   for (int i = 0; i < numVertices; i++) {
-    testGraph->impl_addVertex(i);
+    (void)testGraph->impl_addVertex(i);
   }
 
   for (int i = 0; i < numVertices; i += 100) {
@@ -145,7 +145,7 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentReads) {
   const int numVertices = 1000;
 
   for (int i = 0; i < numVertices; i++) {
-    testGraph->impl_addVertex(i);
+    (void)testGraph->impl_addVertex(i);
   }
 
   const int numThreads = 8;
@@ -180,7 +180,7 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentAddAndRead) {
     threads.emplace_back([&testGraph, &addCount, numOperations, t]() {
       for (int i = 0; i < numOperations; i++) {
         int vertex = t * numOperations + i;
-        testGraph->impl_addVertex(vertex);
+        (void)testGraph->impl_addVertex(vertex);
         addCount++;
       }
     });
@@ -190,7 +190,7 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentAddAndRead) {
     threads.emplace_back([&testGraph, numOperations, t]() {
       for (int i = 0; i < numOperations; i++) {
         int vertex = t * numOperations + i;
-        testGraph->impl_hasVertex(vertex);
+        (void)testGraph->impl_hasVertex(vertex);
       }
     });
   }
@@ -207,7 +207,7 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentDeleteAndRead) {
   const int numVertices = 1000;
 
   for (int i = 0; i < numVertices; i++) {
-    testGraph->impl_addVertex(i);
+    (void)testGraph->impl_addVertex(i);
   }
 
   const int numThreads = 4;
@@ -216,7 +216,7 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentDeleteAndRead) {
   for (int t = 0; t < numThreads / 2; t++) {
     threads.emplace_back([&testGraph, numVertices, t, numThreads]() {
       for (int i = t; i < numVertices; i += numThreads / 2) {
-        testGraph->impl_removeVertex(i);
+        (void)testGraph->impl_removeVertex(i);
       }
     });
   }
@@ -224,7 +224,7 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentDeleteAndRead) {
   for (int t = 0; t < numThreads / 2; t++) {
     threads.emplace_back([&testGraph, numVertices]() {
       for (int i = 0; i < numVertices; i++) {
-        testGraph->impl_hasVertex(i);
+        (void)testGraph->impl_hasVertex(i);
       }
     });
   }
@@ -248,7 +248,7 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentMix) {
   std::atomic<int> readCount{0};
 
   for (int i = 0; i < 100; i++) {
-    testGraph->impl_addVertex(i);
+    (void)testGraph->impl_addVertex(i);
   }
 
   for (int t = 0; t < numThreads; t++) {
@@ -261,9 +261,9 @@ TEST_F(HybridStorageShardTest, HasVertices_ConcurrentMix) {
         int op = i % 3;
 
         if (op == 0) {
-          testGraph->impl_addVertex(vertex);
+          (void)testGraph->impl_addVertex(vertex);
         } else if (op == 1) {
-          testGraph->impl_removeVertex(vertex);
+          (void)testGraph->impl_removeVertex(vertex);
         } else {
           if (testGraph->impl_hasVertex(vertex)) {
             readCount++;
@@ -295,19 +295,19 @@ TEST_F(HybridStorageShardTest, HasVertices_StressTestConcurrent) {
           for (int i = 0; i < numOperationsPerThread; i++) {
             int vertex = baseVertex + i;
 
-            testGraph->impl_addVertex(vertex);
+            (void)testGraph->impl_addVertex(vertex);
 
             if (!testGraph->impl_hasVertex(vertex)) {
               allTestsPassed = false;
             }
 
-            testGraph->impl_removeVertex(vertex);
+            (void)testGraph->impl_removeVertex(vertex);
 
             if (testGraph->impl_hasVertex(vertex)) {
               allTestsPassed = false;
             }
 
-            testGraph->impl_addVertex(vertex);
+            (void)testGraph->impl_addVertex(vertex);
 
             if (!testGraph->impl_hasVertex(vertex)) {
               allTestsPassed = false;
@@ -343,9 +343,9 @@ TEST_F(HybridStorageShardTest, HasVertices_RaceConditionDetection) {
         [&testGraph, &trueCount, &falseCount, targetVertex, t]() {
           for (int i = 0; i < 100; i++) {
             if (t % 2 == 0) {
-              testGraph->impl_addVertex(targetVertex);
+              (void)testGraph->impl_addVertex(targetVertex);
             } else {
-              testGraph->impl_removeVertex(targetVertex);
+              (void)testGraph->impl_removeVertex(targetVertex);
             }
 
             if (testGraph->impl_hasVertex(targetVertex)) {

--- a/tests/unit/HybridCSR_COO/performance_test.cpp
+++ b/tests/unit/HybridCSR_COO/performance_test.cpp
@@ -52,7 +52,7 @@ TEST_F(HybridCSRCOOPerformanceTest, VertexInsertionPerformance) {
   const int NUM_VERTICES = 50000;
   auto insertion_func = [&]() {
     for (int i = 0; i < NUM_VERTICES; ++i) {
-      graph->impl_addVertex(i);
+      (void)graph->impl_addVertex(i);
     }
   };
   measureTime(insertion_func, "50K Vertex Insertion");
@@ -71,12 +71,12 @@ TEST_F(HybridCSRCOOPerformanceTest, EdgeInsertionPerformance) {
   const int NUM_VERTICES = 5000;
   const int NUM_EDGES = 25000;
   for (int i = 0; i < NUM_VERTICES; ++i) {
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
   }
   auto edges = generateTestEdges(NUM_VERTICES, NUM_EDGES);
   auto insertion_func = [&]() {
     for (const auto &[src, dest, weight] : edges) {
-      graph->impl_addEdge(src, dest, weight);
+      (void)graph->impl_addEdge(src, dest, weight);
     }
   };
   measureTime(insertion_func, "25K Edge Insertion");
@@ -96,11 +96,11 @@ TEST_F(HybridCSRCOOPerformanceTest, EdgeRetrievalPerformance) {
   const int NUM_EDGES = 10000;
   const int NUM_QUERIES = 50000;
   for (int i = 0; i < NUM_VERTICES; ++i) {
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
   }
   auto edges = generateTestEdges(NUM_VERTICES, NUM_EDGES);
   for (const auto &[src, dest, weight] : edges) {
-    graph->impl_addEdge(src, dest, weight);
+    (void)graph->impl_addEdge(src, dest, weight);
   }
   std::vector<std::pair<int, int>> queries;
   std::mt19937 gen(123);
@@ -133,11 +133,11 @@ TEST_F(HybridCSRCOOPerformanceTest, MixedOperationsPerformance) {
   const int INITIAL_EDGES = 5000;
   const int OPERATIONS = 10000;
   for (int i = 0; i < NUM_VERTICES; ++i) {
-    graph->impl_addVertex(i);
+    (void)graph->impl_addVertex(i);
   }
   auto initial_edges = generateTestEdges(NUM_VERTICES, INITIAL_EDGES);
   for (const auto &[src, dest, weight] : initial_edges) {
-    graph->impl_addEdge(src, dest, weight);
+    (void)graph->impl_addEdge(src, dest, weight);
   }
   auto mixed_func = [&]() {
     std::mt19937 gen(456);
@@ -149,13 +149,13 @@ TEST_F(HybridCSRCOOPerformanceTest, MixedOperationsPerformance) {
       int src = vertex_dis(gen);
       int dest = vertex_dis(gen);
       if (op == 0 && src != dest) {
-        graph->impl_addEdge(src, dest, src * 1000 + dest + i);
+        (void)graph->impl_addEdge(src, dest, src * 1000 + dest + i);
         adds++;
       } else if (op == 1) {
         auto [weight, status] = graph->impl_getEdge(src, dest);
         queries++;
       } else {
-        graph->impl_doesEdgeExist(src, dest);
+        (void)graph->impl_doesEdgeExist(src, dest);
         checks++;
       }
     }

--- a/tests/unit/HybridCSR_COO/removeEdge_test.cpp
+++ b/tests/unit/HybridCSR_COO/removeEdge_test.cpp
@@ -23,9 +23,9 @@ protected:
 
 // Test removing edges with weights
 TEST_F(HybridStorageShardTest, RemoveEdge_WithWeight) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addVertex(3);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(3);
   EXPECT_TRUE(graph->impl_addEdge(1, 2, 5).isOK())
       << "Failed to add edge (1,2)";
   EXPECT_TRUE(graph->impl_addEdge(2, 3, 10).isOK())
@@ -50,9 +50,9 @@ TEST_F(HybridStorageShardTest, RemoveEdge_WithWeight) {
 
 // Test removing edges without weights
 TEST_F(HybridStorageShardTest, RemoveEdge_WithoutWeight) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addVertex(3);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(3);
   EXPECT_TRUE(graph->impl_addEdge(1, 2).isOK()) << "Failed to add edge (1,2)";
   EXPECT_TRUE(graph->impl_addEdge(2, 3).isOK()) << "Failed to add edge (2,3)";
   auto edge1 = graph->impl_getEdge(1, 2);
@@ -73,9 +73,9 @@ TEST_F(HybridStorageShardTest, RemoveEdge_WithoutWeight) {
 
 // Test removing edges in string graph
 TEST_F(HybridStorageShardTest, RemoveEdge_String) {
-  string_graph->impl_addVertex("prasad");
-  string_graph->impl_addVertex("omkar");
-  string_graph->impl_addEdge("prasad", "omkar", 1.5);
+  (void)string_graph->impl_addVertex("prasad");
+  (void)string_graph->impl_addVertex("omkar");
+  (void)string_graph->impl_addEdge("prasad", "omkar", 1.5);
   auto result = string_graph->impl_removeEdge("prasad", "omkar");
   EXPECT_TRUE(result.second.isOK()) << "Failed to remove string edge";
   EXPECT_DOUBLE_EQ(result.first, 1.5) << "Incorrect weight returned";
@@ -85,9 +85,9 @@ TEST_F(HybridStorageShardTest, RemoveEdge_String) {
 
 // Test concurrent edge removal
 TEST_F(HybridStorageShardTest, RemoveEdge_Concurrent) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 10);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 10);
   std::vector<std::thread> threads;
   const int NUM_THREADS = 5;
   std::atomic<int> success_count{0};

--- a/tests/unit/HybridCSR_COO/removeVertex_test.cpp
+++ b/tests/unit/HybridCSR_COO/removeVertex_test.cpp
@@ -22,9 +22,9 @@ protected:
 
 // Test removing a valid vertex with edges
 TEST_F(HybridStorageShardTest, RemoveVertex_Valid) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 10);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 10);
   auto status = graph->impl_removeVertex(1);
   EXPECT_TRUE(status.isOK()) << "Failed to remove vertex 1";
   EXPECT_FALSE(graph->impl_hasVertex(1)) << "Vertex 1 still exists";
@@ -40,12 +40,12 @@ TEST_F(HybridStorageShardTest, RemoveVertex_NonExistent) {
 
 // Test removing a vertex with multiple edges
 TEST_F(HybridStorageShardTest, RemoveVertex_WithMultipleEdges) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addVertex(3);
-  graph->impl_addEdge(1, 2, 10);
-  graph->impl_addEdge(1, 3, 20);
-  graph->impl_addEdge(2, 1, 15);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(3);
+  (void)graph->impl_addEdge(1, 2, 10);
+  (void)graph->impl_addEdge(1, 3, 20);
+  (void)graph->impl_addEdge(2, 1, 15);
   auto status = graph->impl_removeVertex(1);
   EXPECT_TRUE(status.isOK()) << "Failed to remove vertex 1";
   EXPECT_FALSE(graph->impl_hasVertex(1)) << "Vertex 1 still exists";
@@ -56,9 +56,9 @@ TEST_F(HybridStorageShardTest, RemoveVertex_WithMultipleEdges) {
 
 // Test removing a string vertex
 TEST_F(HybridStorageShardTest, RemoveVertex_String) {
-  string_graph->impl_addVertex("prasad");
-  string_graph->impl_addVertex("omkar");
-  string_graph->impl_addEdge("prasad", "omkar", 1.5);
+  (void)string_graph->impl_addVertex("prasad");
+  (void)string_graph->impl_addVertex("omkar");
+  (void)string_graph->impl_addEdge("prasad", "omkar", 1.5);
   auto status = string_graph->impl_removeVertex("prasad");
   EXPECT_TRUE(status.isOK()) << "Failed to remove string vertex";
   EXPECT_FALSE(string_graph->impl_hasVertex("prasad"))
@@ -69,8 +69,8 @@ TEST_F(HybridStorageShardTest, RemoveVertex_String) {
 
 // Test concurrent vertex removal
 TEST_F(HybridStorageShardTest, RemoveVertex_Concurrent) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
   std::vector<std::thread> threads;
   threads.emplace_back([this]() {
     auto status = graph->impl_removeVertex(1);

--- a/tests/unit/HybridCSR_COO/updateEdge_test.cpp
+++ b/tests/unit/HybridCSR_COO/updateEdge_test.cpp
@@ -24,7 +24,7 @@ protected:
 TEST_F(HybridStorageShardTest, UpdateEdge_Basic) {
   std::vector<int> vertices = {1, 2, 3, 4, 5};
   for (int v : vertices) {
-    graph->impl_addVertex(v);
+    (void)graph->impl_addVertex(v);
   }
   EXPECT_TRUE(graph->impl_addEdge(1, 2, 10).isOK())
       << "Failed to add edge (1,2)";
@@ -48,16 +48,16 @@ TEST_F(HybridStorageShardTest, UpdateEdge_Basic) {
 
 // Test updating non-existent edge
 TEST_F(HybridStorageShardTest, UpdateEdge_NonExistent) {
-  graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(1);
   EXPECT_FALSE(graph->impl_updateEdge(1, 2, 10).isOK())
       << "Updated non-existent edge";
 }
 
 // Test updating edge in string graph
 TEST_F(HybridStorageShardTest, UpdateEdge_String) {
-  string_graph->impl_addVertex("prasad");
-  string_graph->impl_addVertex("omkar");
-  string_graph->impl_addEdge("prasad", "omkar", 1.5);
+  (void)string_graph->impl_addVertex("prasad");
+  (void)string_graph->impl_addVertex("omkar");
+  (void)string_graph->impl_addEdge("prasad", "omkar", 1.5);
   EXPECT_TRUE(string_graph->impl_updateEdge("prasad", "omkar", 2.0).isOK())
       << "Failed to update string edge";
   auto [weight, status] = string_graph->impl_getEdge("prasad", "omkar");
@@ -67,9 +67,9 @@ TEST_F(HybridStorageShardTest, UpdateEdge_String) {
 
 // Test concurrent edge updates
 TEST_F(HybridStorageShardTest, UpdateEdge_Concurrent) {
-  graph->impl_addVertex(1);
-  graph->impl_addVertex(2);
-  graph->impl_addEdge(1, 2, 10);
+  (void)graph->impl_addVertex(1);
+  (void)graph->impl_addVertex(2);
+  (void)graph->impl_addEdge(1, 2, 10);
   std::vector<std::thread> threads;
   const int NUM_THREADS = 5;
   for (int i = 0; i < NUM_THREADS; ++i) {


### PR DESCRIPTION
Which issue does this PR close?
Closes #312 

Rationale for this change
The MSVC compiler was throwing C4834 (discarded return value) warnings during the build process because the PeakStatus return type is marked with [[nodiscard]]. In the unit tests, many setup operations and simulated concurrent threading tasks intentionally ignore this return value, which cluttered the build output with warnings.

What changes are included in this PR?
Added explicit (void) casts to unhandled impl_ function calls (e.g., impl_addVertex, impl_addEdge, impl_getEdge) across the tests/unit/HybridCSR_COO/ directory.

This explicitly signals to the compiler that the discarded return value is intentional, silencing the C4834 warnings while preserving the original test logic.

Note on Scope: I intentionally ignored the C4324 structure padding warnings (originating from HybridCSR_COO.hpp) and a C4834 warning cascading from PeakStore.hpp, as those require changes to the core storage engine files and should likely be handled in a separate, scoped PR.

Are these changes tested?
Yes. I verified locally using MSVC (cmake --build .) that all C4834 warnings specific to the HybridCSR_COO test suite are now completely resolved.

Are there any user-facing changes?
No. These changes are strictly internal to the unit test implementations and do not affect the public API or user experience.