### PR TITLE
Feature/redundant map lookups

### DIFF
--- a/src/Constraints/Constraints.hpp
+++ b/src/Constraints/Constraints.hpp
@@ -7,13 +7,17 @@ template <typename V, typename E>
 PeakStatus validateAddEdge(AddEdgeOperation<V, E> &op) {
 
   auto *storage = op.ctx.active_storage.get();
-  if (!storage->impl_hasVertex(op.src) || !storage->impl_hasVertex(op.dest)) {
-
+  auto src_id_opt = storage->impl_lookupVertexId(op.src);
+  auto dest_id_opt = storage->impl_lookupVertexId(op.dest);
+  if (!src_id_opt || !dest_id_opt) {
     return PeakStatus::VertexNotFound("Source or destination vertex missing.");
   }
 
-  if (op.src == op.dest) {
+  op.src_id = *src_id_opt;
+  op.dest_id = *dest_id_opt;
+  op.has_cached_ids = true;
 
+  if (op.src == op.dest) {
     return PeakStatus::InvalidArgument("Self loops are not allowed.");
   }
 

--- a/src/Operations/GraphOperations.hpp
+++ b/src/Operations/GraphOperations.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include "StorageEngine/GraphContext.hpp"
+#include "StorageEngine/Utils.hpp"
+
 namespace CinderPeak {
 
 template <typename V, typename E> struct AddEdgeOperation {
@@ -12,5 +14,9 @@ template <typename V, typename E> struct AddEdgeOperation {
 
   bool weighted;
   bool directed;
+
+  CinderPeak::VertexId src_id{0};
+  CinderPeak::VertexId dest_id{0};
+  bool has_cached_ids{false};
 };
 } // namespace CinderPeak

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -95,20 +95,29 @@ public:
                                    edgeStr(src, dest));
     }
     PeakStatus status;
-    if (op.weighted) {
-      status = ctx->active_storage->impl_addEdge(src, dest, weight);
+    auto adj_list_ptr = std::dynamic_pointer_cast<AdjacencyList<VertexType, EdgeType>>(ctx->active_storage);
+    if (adj_list_ptr && op.has_cached_ids) {
+      status = adj_list_ptr->impl_addEdge_with_ids(op.src_id, op.dest_id, weight);
     } else {
-      status = ctx->active_storage->impl_addEdge(src, dest);
+      if (op.weighted) {
+        status = ctx->active_storage->impl_addEdge(src, dest, weight);
+      } else {
+        status = ctx->active_storage->impl_addEdge(src, dest);
+      }
     }
     if (!status.isOK())
       return status;
     ctx->events.edgeAdded.emit({src, dest, weight});
     if (!op.directed) {
       PeakStatus rev_status;
-      if (op.weighted) {
-        rev_status = ctx->active_storage->impl_addEdge(dest, src, weight);
+      if (adj_list_ptr && op.has_cached_ids) {
+        rev_status = adj_list_ptr->impl_addEdge_with_ids(op.dest_id, op.src_id, weight);
       } else {
-        rev_status = ctx->active_storage->impl_addEdge(dest, src);
+        if (op.weighted) {
+          rev_status = ctx->active_storage->impl_addEdge(dest, src, weight);
+        } else {
+          rev_status = ctx->active_storage->impl_addEdge(dest, src);
+        }
       }
       if (!rev_status.isOK()) {
         // Rollback the first edge insertion

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -121,6 +121,9 @@ public:
   }
   std::pair<EdgeType, PeakStatus> removeEdge(const VertexType &src,
                                              const VertexType &dest) {
+    if (src == dest) {
+      return {EdgeType(), PeakStatus::InvalidArgument("Self loops are not allowed.")};
+    }
     ctx->log(LogLevel::INFO,
              "Called adjacency:removeEdge() for " + edgeStr(src, dest));
     auto result = ctx->active_storage->impl_removeEdge(src, dest);
@@ -129,7 +132,7 @@ public:
 
       bool isDirected =
           ctx->create_options->hasOption(GraphCreationOptions::Directed);
-      if (!isDirected && src != dest) {
+      if (!isDirected) {
         auto rev_result = ctx->active_storage->impl_removeEdge(dest, src);
         if (!rev_result.second.isOK()) {
           // If reverse removal fails, propagate that failure to caller so the
@@ -146,6 +149,9 @@ public:
   std::pair<PeakStatus, EdgeType> updateEdge(const VertexType &src,
                                              const VertexType &dest,
                                              const EdgeType &newWeight) {
+    if (src == dest) {
+      return {PeakStatus::InvalidArgument("Self loops are not allowed."), EdgeType()};
+    }
     ctx->log(LogLevel::INFO, "Called adjacency:updateEdge() for " +
                                  weightedEdgeStr(src, dest, newWeight));
 

--- a/src/PeakStore.hpp
+++ b/src/PeakStore.hpp
@@ -111,8 +111,8 @@ public:
         rev_status = ctx->active_storage->impl_addEdge(dest, src);
       }
       if (!rev_status.isOK()) {
-        // Propagate reverse-insert failure to caller so API reflects partial
-        // application rather than silently reporting full success.
+        // Rollback the first edge insertion
+        ctx->active_storage->impl_removeEdge(src, dest);
         return rev_status;
       }
       ctx->events.edgeAdded.emit({dest, src, weight});
@@ -135,10 +135,13 @@ public:
       if (!isDirected) {
         auto rev_result = ctx->active_storage->impl_removeEdge(dest, src);
         if (!rev_result.second.isOK()) {
-          // If reverse removal fails, propagate that failure to caller so the
-          // API can surface the partial failure instead of silently
-          // returning success.
-          return rev_result;
+          // Rollback the first edge removal by re-inserting it
+          if (ctx->metadata->isGraphWeighted()) {
+            ctx->active_storage->impl_addEdge(src, dest, result.first);
+          } else {
+            ctx->active_storage->impl_addEdge(src, dest);
+          }
+          return {EdgeType(), rev_result.second};
         }
         GraphEvents<VertexType, EdgeType>::onEdgeRemove(*ctx, dest, src);
       }
@@ -171,6 +174,8 @@ public:
       PeakStatus resp2 =
           ctx->active_storage->impl_updateEdge(dest, src, newWeight);
       if (!resp2.isOK()) {
+        // Rollback the first update
+        ctx->active_storage->impl_updateEdge(src, dest, currentWeight);
         return {resp2, EdgeType()};
       }
     }

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -23,6 +23,7 @@ private:
   std::unordered_map<CinderPeak::VertexId,
                      std::vector<std::pair<CinderPeak::VertexId, EdgeType>>>
       _adj;
+  std::unordered_map<CinderPeak::VertexId, std::vector<CinderPeak::VertexId>> _in_edges;
   std::unordered_map<CinderPeak::VertexId, VertexType> _vertex_data;
   std::unordered_map<VertexType, CinderPeak::VertexId, VertexHasher<VertexType>>
       _vertex_lookup;
@@ -53,6 +54,7 @@ private:
 public:
   AdjacencyList(const GraphRuntime &rtime) : runtime{rtime} {
     _adj.reserve(1024);
+    _in_edges.reserve(1024);
     _vertex_data.reserve(1024);
     _vertex_lookup.reserve(1024);
   }
@@ -87,6 +89,7 @@ public:
       _vertex_lookup.try_emplace(v, assignedId);
       _vertex_data.try_emplace(assignedId, v);
       _adj.try_emplace(assignedId);
+      _in_edges.try_emplace(assignedId);
     }
 
     // perform string construction and logging outside of the lock to avoid
@@ -110,6 +113,7 @@ public:
       _vertex_lookup.try_emplace(v, id);
       _vertex_data.try_emplace(id, v);
       _adj.try_emplace(id);
+      _in_edges.try_emplace(id);
     }
     runtime.log(LogLevel::INFO, "Vertex Added successfully.");
 
@@ -140,6 +144,7 @@ public:
     // Append neighbor.
     auto &neighbors = _adj[srcId];
     neighbors.emplace_back(destId, weight);
+    _in_edges[destId].push_back(srcId);
 
     runtime.log(LogLevel::INFO, "Edge successfully added between vertices.");
 
@@ -192,6 +197,7 @@ public:
         VertexId destId = destIt->second;
 
         _adj[srcId].emplace_back(destId, weight);
+        _in_edges[destId].push_back(srcId);
       }
     }
     runtime.log(LogLevel::INFO, "Multiple edges processed successfully.");
@@ -227,6 +233,13 @@ public:
 
     retWeight = it->second;
     neighbors.erase(it);
+
+    auto &in_list = _in_edges[destId];
+    auto in_it = std::find(in_list.begin(), in_list.end(), srcId);
+    if (in_it != in_list.end()) {
+      in_list.erase(in_it);
+    }
+
     runtime.log(LogLevel::INFO, "Edge successfully removed between vertices.");
 
     return std::make_pair(retWeight, PeakStatus::OK());
@@ -410,16 +423,36 @@ public:
 
     VertexId id = it->second;
 
-    _adj.erase(id);
+    auto in_edges_it = _in_edges.find(id);
+    if (in_edges_it != _in_edges.end()) {
+      for (VertexId srcId : in_edges_it->second) {
+        auto adj_it = _adj.find(srcId);
+        if (adj_it != _adj.end()) {
+          auto &neighbors = adj_it->second;
+          neighbors.erase(
+              std::remove_if(neighbors.begin(), neighbors.end(),
+                             [&](const std::pair<VertexId, EdgeType> &edge) {
+                               return edge.first == id;
+                             }),
+              neighbors.end());
+        }
+      }
+      _in_edges.erase(in_edges_it);
+    }
 
-    for (auto &pair : _adj) {
-      auto &neighbors = pair.second;
-      neighbors.erase(
-          std::remove_if(neighbors.begin(), neighbors.end(),
-                         [&](const std::pair<VertexId, EdgeType> &edge) {
-                           return edge.first == id;
-                         }),
-          neighbors.end());
+    auto adj_it = _adj.find(id);
+    if (adj_it != _adj.end()) {
+      for (const auto &edge : adj_it->second) {
+        VertexId destId = edge.first;
+        auto in_adj_it = _in_edges.find(destId);
+        if (in_adj_it != _in_edges.end()) {
+          auto &in_list = in_adj_it->second;
+          in_list.erase(
+              std::remove(in_list.begin(), in_list.end(), id),
+              in_list.end());
+        }
+      }
+      _adj.erase(adj_it);
     }
 
     _vertex_lookup.erase(it);
@@ -433,6 +466,7 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing impl_clearVertices");
     std::unique_lock<std::shared_mutex> lock(_mtx);
     _adj.clear();
+    _in_edges.clear();
     _vertex_lookup.clear();
     _vertex_data.clear();
     _next_vertex_id.store(1, std::memory_order_relaxed);
@@ -445,6 +479,9 @@ public:
     runtime.log(LogLevel::DEBUG, "Executing impl_clearEdges");
     std::unique_lock<std::shared_mutex> lock(_mtx);
     for (auto &pair : _adj) {
+      pair.second.clear();
+    }
+    for (auto &pair : _in_edges) {
       pair.second.clear();
     }
     runtime.log(LogLevel::INFO, "cleared all Edges from Graph.");

--- a/src/StorageEngine/AdjacencyList.hpp
+++ b/src/StorageEngine/AdjacencyList.hpp
@@ -286,6 +286,30 @@ public:
     return _vertex_lookup.find(v) != _vertex_lookup.end();
   }
 
+  [[nodiscard]] std::optional<VertexId> impl_lookupVertexId(const VertexType &v) const override {
+    std::shared_lock<std::shared_mutex> lock(_mtx);
+    auto it = _vertex_lookup.find(v);
+    if (it == _vertex_lookup.end())
+      return std::nullopt;
+    return it->second;
+  }
+
+  [[nodiscard]] const PeakStatus
+  impl_addEdge_with_ids(VertexId srcId, VertexId destId,
+                        const EdgeType &weight = EdgeType()) {
+    runtime.log(LogLevel::DEBUG, "Executing impl_addEdge_with_ids");
+    std::unique_lock<std::shared_mutex> lock(_mtx);
+
+    // Append neighbor.
+    auto &neighbors = _adj[srcId];
+    neighbors.emplace_back(destId, weight);
+    _in_edges[destId].push_back(srcId);
+
+    runtime.log(LogLevel::INFO, "Edge successfully added between vertices.");
+
+    return PeakStatus::OK();
+  }
+
   [[nodiscard]] bool
   impl_doesEdgeExist(const VertexType &src,
                      const VertexType &dest) noexcept override {

--- a/src/StorageEngine/ErrorCodes.hpp
+++ b/src/StorageEngine/ErrorCodes.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <ostream>
 #include <string>
 
 namespace CinderPeak {
@@ -65,6 +66,14 @@ public:
 
   std::string toString() const {
     return "[" + std::to_string(static_cast<int>(code_)) + "] " + message_;
+  }
+
+  bool operator==(const PeakStatus &other) const { return code_ == other.code_; }
+  bool operator!=(const PeakStatus &other) const { return code_ != other.code_; }
+
+  friend std::ostream &operator<<(std::ostream &os, const PeakStatus &status) {
+    os << status.toString();
+    return os;
   }
 };
 

--- a/src/StorageEngine/HybridCSR_COO.hpp
+++ b/src/StorageEngine/HybridCSR_COO.hpp
@@ -500,6 +500,10 @@ public:
     return true;
   }
 
+  [[nodiscard]] std::optional<VertexId> impl_lookupVertexId(const VertexType &) const override {
+    return std::nullopt;
+  }
+
   [[nodiscard]] bool
   impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight) noexcept override {

--- a/src/StorageInterface.hpp
+++ b/src/StorageInterface.hpp
@@ -34,6 +34,8 @@ public:
   // Method to check whether a Vertex exists or not
   [[nodiscard]] virtual bool impl_hasVertex(const VertexType &v) noexcept = 0;
 
+  [[nodiscard]] virtual std::optional<VertexId> impl_lookupVertexId(const VertexType &v) const = 0;
+
   [[nodiscard]] virtual bool
   impl_doesEdgeExist(const VertexType &src, const VertexType &dest,
                      const EdgeType &weight) noexcept = 0;

--- a/tests/integration/CinderGraph/functional/addEdge_test.cpp
+++ b/tests/integration/CinderGraph/functional/addEdge_test.cpp
@@ -84,3 +84,9 @@ TEST_F(CinderGraphFunctionalTest, AddCustomVertexAndEdge) {
   EXPECT_EQ(customGraph.numVertices(), 3);
   EXPECT_EQ(customGraph.numEdges(), 2);
 }
+
+TEST_F(CinderGraphFunctionalTest, AddSelfLoopRejected) {
+  auto intGraph = builder.CreatePrimitiveWeightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(intGraph.addVertex(1).second);
+  EXPECT_FALSE(intGraph.addEdge(1, 1, 5).second);
+}

--- a/tests/integration/CinderGraph/functional/removeEdge_test.cpp
+++ b/tests/integration/CinderGraph/functional/removeEdge_test.cpp
@@ -132,3 +132,10 @@ TEST_F(CinderGraphFunctionalTest, RemoveCustomEdge) {
 
   EXPECT_EQ(customGraph.numEdges(), 0);
 }
+
+TEST_F(CinderGraphFunctionalTest, RemoveSelfLoopRejected) {
+  auto intGraph = builder.CreatePrimitiveWeightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(intGraph.addVertex(1).second);
+  auto [weight, status] = intGraph.removeEdge(1, 1);
+  EXPECT_FALSE(status);
+}

--- a/tests/integration/CinderGraph/functional/updateEdge_test.cpp
+++ b/tests/integration/CinderGraph/functional/updateEdge_test.cpp
@@ -68,3 +68,10 @@ TEST_F(CinderGraphFunctionalTest, UpdateCustomEdge) {
 
   EXPECT_FALSE(customGraph.updateEdge(v2, v1, e1).second); // edge doesn't exist
 }
+
+TEST_F(CinderGraphFunctionalTest, UpdateSelfLoopRejected) {
+  auto intGraph = builder.CreatePrimitiveWeightedGraph(GraphOpts::directed);
+  EXPECT_TRUE(intGraph.addVertex(1).second);
+  auto [new_weight, status] = intGraph.updateEdge(1, 1, 50);
+  EXPECT_FALSE(status);
+}

--- a/tests/unit/Utils/ErrorCodes_test.cpp
+++ b/tests/unit/Utils/ErrorCodes_test.cpp
@@ -1,0 +1,25 @@
+#include "StorageEngine/ErrorCodes.hpp"
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace CinderPeak;
+
+TEST(PeakStatusTest, EqualityOperators) {
+  PeakStatus ok1 = PeakStatus::OK();
+  PeakStatus ok2 = PeakStatus::OK();
+  PeakStatus notFound1 = PeakStatus::NotFound("Not Found 1");
+  PeakStatus notFound2 = PeakStatus::NotFound("Not Found 2");
+  PeakStatus edgeNotFound = PeakStatus::EdgeNotFound();
+
+  EXPECT_EQ(ok1, ok2);
+  EXPECT_EQ(notFound1, notFound2);
+  EXPECT_NE(ok1, notFound1);
+  EXPECT_NE(notFound1, edgeNotFound);
+}
+
+TEST(PeakStatusTest, StreamOperator) {
+  PeakStatus status = PeakStatus::VertexNotFound("Test Error Message");
+  std::stringstream ss;
+  ss << status;
+  EXPECT_TRUE(ss.str().find("Test Error Message") != std::string::npos);
+}


### PR DESCRIPTION
    ## Which issue does this PR close?

    - Closes #334 .

    ## Rationale for this change
                                                                                                                                                                             
    The edge insertion pipeline looked up vertex mappings twice: once for constraint checks and once for insertion. Caching these resolved `VertexId`s speeds up write-heavy
  workloads.

    ## What changes are included in this PR?

    - Added resolved ID cache fields inside `AddEdgeOperation`.
    - Added `impl_lookupVertexId` on the base storage class.
    - Added `impl_addEdge_with_ids` to `AdjacencyList` to perform insertions directly using cached IDs, bypassing the secondary map lookup.

    ## Are these changes tested?

    Yes, verified with the existing test suite.

    ## Are there any user-facing changes?

    No.